### PR TITLE
recover directly assign hex string logic

### DIFF
--- a/src/main/java/org/tron/common/utils/AbiUtil.java
+++ b/src/main/java/org/tron/common/utils/AbiUtil.java
@@ -266,12 +266,16 @@ public class AbiUtil {
   }
 
 
-  public static String parseMethod(String methodSign, String params) {
+  public static String parseMethod(String methodSign, String params, boolean isHex) {
     byte[] selector = new byte[4];
     System.arraycopy(Hash.sha3(methodSign.getBytes()), 0, selector,0, 4);
     System.out.println(methodSign + ":" + Hex.toHexString(selector));
     if (params.length() == 0) {
       return Hex.toHexString(selector);
+    }
+    if (isHex){
+      String result =Hex.toHexString(selector) + params;
+      return result;
     }
     String[] values = params.split(",");
     List<Coder> coders = new ArrayList<>();
@@ -290,7 +294,7 @@ public class AbiUtil {
     String method = "test(string,int2,string)";
     String params = "asdf,3123,adf";
 
-    System.out.println(parseMethod(method, params));
+//    System.out.println(parseMethod(method, params));
 //    parseMethod(method, params);
 
 //    String[] vs = params.split(",");

--- a/src/main/java/org/tron/walletcli/TestClient.java
+++ b/src/main/java/org/tron/walletcli/TestClient.java
@@ -1109,9 +1109,9 @@ public class TestClient {
   private void triggerContract(String[] parameters)
       throws IOException, CipherException, CancelException {
     if (parameters == null ||
-        parameters.length < 5) {
-      System.out.println("TriggerContract needs 5 parameters like following: ");
-      System.out.println("TriggerContract password contractAddress method args value");
+        parameters.length < 6) {
+      System.out.println("TriggerContract needs 6 parameters like following: ");
+      System.out.println("TriggerContract password contractAddress method args isHex value");
 //      System.out.println("example:\nTriggerContract password contractAddress method args value");
       return;
     }
@@ -1120,11 +1120,12 @@ public class TestClient {
     String contractAddrStr = parameters[1];
     String methodStr = parameters[2];
     String argsStr = parameters[3];
-    String valueStr = parameters[4];
+    boolean isHex = Boolean.valueOf(parameters[4]);
+    String valueStr = parameters[5];
     if (argsStr.equalsIgnoreCase("#")) {
       argsStr = "";
     }
-    byte[] input =  Hex.decode(AbiUtil.parseMethod(methodStr, argsStr));
+    byte[] input =  Hex.decode(AbiUtil.parseMethod(methodStr, argsStr, isHex));
     byte[] contractAddress = WalletClient.decodeFromBase58Check(contractAddrStr);
     byte[] callValue = Hex.decode(valueStr);
 


### PR DESCRIPTION
I suppose to assign bytes32[] as trigger contract param
use below command: 

    triggerContract Taihao00 TUnhvtP8ecrGHfjMXXFaHHNwh61JTmNQjA createProposal(bytes32[]) 000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000005 true 0000000000000000000000000000000000000000000000000000000000000000

0000000000000000000000000000000000000000000000000000000000000020 is the pointer
00000000000000000000000000000000000000000000000000000000000000004 is the array size
others are real array data