### PR TITLE
Event subscribe support

### DIFF
--- a/src/main/java/org/tron/walletcli/Client.java
+++ b/src/main/java/org/tron/walletcli/Client.java
@@ -20,6 +20,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.bouncycastle.util.encoders.Hex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.tron.api.GrpcAPI;
 import org.tron.api.GrpcAPI.AccountNetMessage;
 import org.tron.api.GrpcAPI.AccountResourceMessage;
 import org.tron.api.GrpcAPI.AddressPrKeyPairMessage;
@@ -1811,6 +1812,8 @@ public class Client {
     System.out.println("UpdateWitness");
     System.out.println("VoteWitness");
     System.out.println("WithdrawBalance");
+    System.out.println("SetEventFilter");
+    System.out.println("SetEventPluginConfig");
 //    System.out.println("buyStorage");
 //    System.out.println("buyStorageBytes");
 //    System.out.println("sellStorage");
@@ -2205,6 +2208,16 @@ public class Client {
             generateAddress();
             break;
           }
+          case "seteventfilter" :{
+            setEventFilter(parameters);
+            break;
+          }
+
+          case "seteventpluginconfig" :{
+            setEventPluginConfig(parameters);
+            break;
+          }
+
           case "exit":
           case "quit": {
             System.out.println("Exit !!!");
@@ -2240,6 +2253,36 @@ public class Client {
     } else {
       logger.info("List witnesses " + " failed !!");
     }
+  }
+
+  private void setEventFilter(String[] parameters){
+    if (parameters == null || parameters.length != 4) {
+      System.out.println("setEventFilter needs 4 parameter, seteventfilter fromBlock toBlock address1|address2, topic1|topic2");
+      return;
+    }
+
+    String fromBlock = parameters[0];
+    String toBlock = parameters[1];
+    List<String> addressList = Arrays.asList(parameters[2].split("\\|"));
+    List<String> topicList = Arrays.asList(parameters[3].split("\\|"));
+
+    WalletApi.setEventFilter(fromBlock, toBlock, addressList, topicList);
+  }
+
+  private void setEventPluginConfig(String[] parameters){
+
+    if (parameters == null) {
+      System.out.println("setEventPluginConfig needs more than 1 parameter, setEventPluginConfig block|false transaction|false contractevent|true contractlog|true");
+      return;
+    }
+
+    List<String> pluginInfoList = new ArrayList<>();
+
+    for (int index = 0; index < parameters.length; ++index){
+      pluginInfoList.add(parameters[index]);
+    }
+
+    WalletApi.setEventPluginConfig(pluginInfoList);
   }
 
   public static void main(String[] args) {

--- a/src/main/java/org/tron/walletcli/Client.java
+++ b/src/main/java/org/tron/walletcli/Client.java
@@ -2264,8 +2264,30 @@ public class Client {
     String fromBlock = parameters[0];
     String toBlock = parameters[1];
 
+    if (!fromBlock.isEmpty() && fromBlock.equalsIgnoreCase("*")){
+      fromBlock = "";
+    }
+
+    if (!toBlock.isEmpty() && toBlock.equalsIgnoreCase("*")){
+      toBlock = "";
+    }
+
     List<String> addressList = Arrays.asList(parameters[2].split("\\|"));
     List<String> topicList = Arrays.asList(parameters[3].split("\\|"));
+
+    for (int index = 0; index < addressList.size(); ++index){
+      String address = addressList.get(index);
+      if (!address.isEmpty() && address.equals("*")){
+        addressList.set(index, "");
+      }
+    }
+
+    for (int index = 0; index < topicList.size(); ++index){
+      String topic = topicList.get(index);
+      if (!topic.isEmpty() && topic.equals("*")){
+        topicList.set(index, "");
+      }
+    }
 
     if (WalletApi.setEventFilter(fromBlock, toBlock, addressList, topicList)){
       System.out.println("setEventFilter successfully");

--- a/src/main/java/org/tron/walletcli/Client.java
+++ b/src/main/java/org/tron/walletcli/Client.java
@@ -20,7 +20,6 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.bouncycastle.util.encoders.Hex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.tron.api.GrpcAPI;
 import org.tron.api.GrpcAPI.AccountNetMessage;
 import org.tron.api.GrpcAPI.AccountResourceMessage;
 import org.tron.api.GrpcAPI.AddressPrKeyPairMessage;
@@ -2257,7 +2256,7 @@ public class Client {
 
   private void setEventFilter(String[] parameters){
     if (parameters == null || parameters.length != 4) {
-      System.out.println("setEventFilter needs 4 parameter, seteventfilter fromBlock toBlock address1|address2, topic1|topic2");
+      logger.error("setEventFilter needs 4 parameter, seteventfilter fromBlock toBlock address1|address2, topic1|topic2");
       return;
     }
 
@@ -2290,17 +2289,17 @@ public class Client {
     }
 
     if (WalletApi.setEventFilter(fromBlock, toBlock, addressList, topicList)){
-      System.out.println("setEventFilter successfully");
+      logger.info("setEventFilter successfully");
     }
     else {
-      System.out.println("setEventFilter failed");
+      logger.error("setEventFilter failed");
     }
   }
 
   private void setEventPluginConfig(String[] parameters){
 
     if (parameters == null) {
-      System.out.println("setEventPluginConfig needs more than 1 parameter, setEventPluginConfig block|false transaction|false contractevent|true contractlog|true");
+      logger.error("setEventPluginConfig needs more than 1 parameter, setEventPluginConfig block|false transaction|false contractevent|true contractlog|true");
       return;
     }
 
@@ -2311,10 +2310,10 @@ public class Client {
     }
 
     if (WalletApi.setEventPluginConfig(pluginInfoList)){
-      System.out.println("setEventPluginConfig successfully");
+      logger.info("setEventPluginConfig successfully");
     }
     else {
-      System.out.println("setEventPluginConfig failed");
+      logger.error("setEventPluginConfig failed");
     }
   }
 

--- a/src/main/java/org/tron/walletcli/Client.java
+++ b/src/main/java/org/tron/walletcli/Client.java
@@ -2263,10 +2263,16 @@ public class Client {
 
     String fromBlock = parameters[0];
     String toBlock = parameters[1];
+
     List<String> addressList = Arrays.asList(parameters[2].split("\\|"));
     List<String> topicList = Arrays.asList(parameters[3].split("\\|"));
 
-    WalletApi.setEventFilter(fromBlock, toBlock, addressList, topicList);
+    if (WalletApi.setEventFilter(fromBlock, toBlock, addressList, topicList)){
+      System.out.println("setEventFilter successfully");
+    }
+    else {
+      System.out.println("setEventFilter failed");
+    }
   }
 
   private void setEventPluginConfig(String[] parameters){
@@ -2282,7 +2288,12 @@ public class Client {
       pluginInfoList.add(parameters[index]);
     }
 
-    WalletApi.setEventPluginConfig(pluginInfoList);
+    if (WalletApi.setEventPluginConfig(pluginInfoList)){
+      System.out.println("setEventPluginConfig successfully");
+    }
+    else {
+      System.out.println("setEventPluginConfig failed");
+    }
   }
 
   public static void main(String[] args) {

--- a/src/main/java/org/tron/walletserver/GrpcClient.java
+++ b/src/main/java/org/tron/walletserver/GrpcClient.java
@@ -755,4 +755,12 @@ public class GrpcClient {
     BytesMessage bytesMessage = BytesMessage.newBuilder().setValue(byteString).build();
     return blockingStubFull.getContract(bytesMessage);
   }
+
+  public GrpcAPI.Return setEventFilter(GrpcAPI.EventFilter request){
+    return blockingStubFull.setEventFilter(request);
+  }
+
+  public GrpcAPI.Return setPluginConfig(GrpcAPI.EventPluginInfo request){
+    return blockingStubFull.setEventPluginConfig(request);
+  }
 }

--- a/src/main/java/org/tron/walletserver/WalletApi.java
+++ b/src/main/java/org/tron/walletserver/WalletApi.java
@@ -1021,14 +1021,14 @@ public class WalletApi {
   }
 
   private FreezeBalanceContract createFreezeBalanceContract(long frozen_balance,
-      long frozen_duration, int resourceCode,String receiverAddress) {
+      long frozen_duration, int resourceCode, String receiverAddress) {
     byte[] address = getAddress();
     Contract.FreezeBalanceContract.Builder builder = Contract.FreezeBalanceContract.newBuilder();
     ByteString byteAddress = ByteString.copyFrom(address);
     builder.setOwnerAddress(byteAddress).setFrozenBalance(frozen_balance)
         .setFrozenDuration(frozen_duration).setResourceValue(resourceCode);
 
-    if(receiverAddress != null && !receiverAddress.equals("")){
+    if (receiverAddress != null && !receiverAddress.equals("")) {
       ByteString receiverAddressBytes = ByteString.copyFrom(
           Objects.requireNonNull(WalletApi.decodeFromBase58Check(receiverAddress)));
       builder.setReceiverAddress(receiverAddressBytes);
@@ -1064,9 +1064,10 @@ public class WalletApi {
     return builder.build();
   }
 
-  public boolean unfreezeBalance(int resourceCode,String receiverAddress)
+  public boolean unfreezeBalance(int resourceCode, String receiverAddress)
       throws CipherException, IOException, CancelException {
-    Contract.UnfreezeBalanceContract contract = createUnfreezeBalanceContract(resourceCode,receiverAddress);
+    Contract.UnfreezeBalanceContract contract = createUnfreezeBalanceContract(resourceCode,
+        receiverAddress);
     if (rpcVersion == 2) {
       TransactionExtention transactionExtention = rpcCli.createTransaction2(contract);
       return processTransactionExtention(transactionExtention);
@@ -1077,16 +1078,15 @@ public class WalletApi {
   }
 
 
-
-
-  private UnfreezeBalanceContract createUnfreezeBalanceContract(int resourceCode,String receiverAddress) {
+  private UnfreezeBalanceContract createUnfreezeBalanceContract(int resourceCode,
+      String receiverAddress) {
     byte[] address = getAddress();
     Contract.UnfreezeBalanceContract.Builder builder = Contract.UnfreezeBalanceContract
         .newBuilder();
     ByteString byteAddreess = ByteString.copyFrom(address);
     builder.setOwnerAddress(byteAddreess).setResourceValue(resourceCode);
 
-    if(receiverAddress != null && !receiverAddress.equals("")){
+    if (receiverAddress != null && !receiverAddress.equals("")) {
       ByteString receiverAddressBytes = ByteString.copyFrom(
           Objects.requireNonNull(WalletApi.decodeFromBase58Check(receiverAddress)));
       builder.setReceiverAddress(receiverAddressBytes);
@@ -1177,9 +1177,11 @@ public class WalletApi {
     return rpcCli.getDelegatedResource(fromAddress, toAddress);
   }
 
-  public static Optional<DelegatedResourceAccountIndex> getDelegatedResourceAccountIndex(String address) {
-    return rpcCli.getDelegatedResourceAccountIndex(address );
+  public static Optional<DelegatedResourceAccountIndex> getDelegatedResourceAccountIndex(
+      String address) {
+    return rpcCli.getDelegatedResourceAccountIndex(address);
   }
+
   public static Optional<ExchangeList> listExchanges() {
     return rpcCli.listExchanges();
   }
@@ -1483,7 +1485,8 @@ public class WalletApi {
 
   public static CreateSmartContract createContractDeployContract(String contractName,
       byte[] address,
-      String ABI, String code, long value, long consumeUserResourcePercent, long originEnergyLimit, long tokenValue, String tokenId,
+      String ABI, String code, long value, long consumeUserResourcePercent, long originEnergyLimit,
+      long tokenValue, String tokenId,
       String libraryAddressPair) {
     SmartContract.ABI abi = jsonStr2ABI(ABI);
     if (abi == null) {
@@ -1510,11 +1513,11 @@ public class WalletApi {
     }
 
     builder.setBytecode(ByteString.copyFrom(byteCode));
-     CreateSmartContract.Builder createSmartContractBuilder = CreateSmartContract.newBuilder();
+    CreateSmartContract.Builder createSmartContractBuilder = CreateSmartContract.newBuilder();
     createSmartContractBuilder.setOwnerAddress(ByteString.copyFrom(address)).
         setNewContract(builder.build());
-     if (tokenId != null && !tokenId.equalsIgnoreCase("") && !tokenId.equalsIgnoreCase("#")){
-       createSmartContractBuilder.setCallTokenValue(tokenValue).setTokenId(Long.parseLong(tokenId));
+    if (tokenId != null && !tokenId.equalsIgnoreCase("") && !tokenId.equalsIgnoreCase("#")) {
+      createSmartContractBuilder.setCallTokenValue(tokenValue).setTokenId(Long.parseLong(tokenId));
     }
     return createSmartContractBuilder.build();
   }
@@ -1626,11 +1629,13 @@ public class WalletApi {
   }
 
   public boolean deployContract(String contractName, String ABI, String code,
-      long feeLimit, long value, long consumeUserResourcePercent, long originEnergyLimit, long tokenValue, String tokenId, String libraryAddressPair)
+      long feeLimit, long value, long consumeUserResourcePercent, long originEnergyLimit,
+      long tokenValue, String tokenId, String libraryAddressPair)
       throws IOException, CipherException, CancelException {
     byte[] owner = getAddress();
     CreateSmartContract contractDeployContract = createContractDeployContract(contractName, owner,
-        ABI, code, value, consumeUserResourcePercent, originEnergyLimit, tokenValue, tokenId, libraryAddressPair);
+        ABI, code, value, consumeUserResourcePercent, originEnergyLimit, tokenValue, tokenId,
+        libraryAddressPair);
 
     TransactionExtention transactionExtention = rpcCli.deployContract(contractDeployContract);
     if (transactionExtention == null || !transactionExtention.getResult().getResult()) {
@@ -1669,7 +1674,8 @@ public class WalletApi {
 
   }
 
-  public boolean triggerContract(byte[] contractAddress, long callValue, byte[] data, long feeLimit, long tokenValue, String tokenId)
+  public boolean triggerContract(byte[] contractAddress, long callValue, byte[] data, long feeLimit,
+      long tokenValue, String tokenId)
       throws IOException, CipherException, CancelException {
     byte[] owner = getAddress();
     Contract.TriggerSmartContract triggerContract = triggerCallContract(owner, contractAddress,
@@ -1770,6 +1776,6 @@ public class WalletApi {
 
   public static void main(String[] args) {
     System.out
-            .println(ByteArray.toHexString(Hash.sha3(ByteArray.fromString("playerRollDice(uint256)"))));
+        .println(ByteArray.toHexString(Hash.sha3(ByteArray.fromString("playerRollDice(uint256)"))));
   }
 }

--- a/src/main/java/org/tron/walletserver/WalletApi.java
+++ b/src/main/java/org/tron/walletserver/WalletApi.java
@@ -1723,11 +1723,9 @@ public class WalletApi {
     Return ret = rpcCli.setEventFilter(request.build());
 
     if (ret.getResult()){
-      System.out.println("setEventFilter successfully");
       return true;
     }
     else {
-      System.out.println("setEventFilter failed");
       return false;
     }
   }
@@ -1753,11 +1751,9 @@ public class WalletApi {
 
     Return ret = rpcCli.setPluginConfig(request.build());
     if (ret.getResult()){
-      System.out.println("setEventPluginConfig successfully");
       return true;
     }
     else {
-      System.out.println("setEventPluginConfig failed");
       return false;
     }
   }

--- a/src/main/java/org/tron/walletserver/WalletApi.java
+++ b/src/main/java/org/tron/walletserver/WalletApi.java
@@ -1767,4 +1767,9 @@ public class WalletApi {
       return false;
     }
   }
+
+  public static void main(String[] args) {
+    System.out
+            .println(ByteArray.toHexString(Hash.sha3(ByteArray.fromString("playerRollDice(uint256)"))));
+  }
 }

--- a/src/main/java/org/tron/walletserver/WalletApi.java
+++ b/src/main/java/org/tron/walletserver/WalletApi.java
@@ -1710,4 +1710,55 @@ public class WalletApi {
   public static SmartContract getContract(byte[] address) {
     return rpcCli.getContract(address);
   }
+
+  public static boolean setEventFilter(String fromBlock, String toBlock, List<String> addressList, List<String> topicList){
+
+    GrpcAPI.EventFilter.Builder request = GrpcAPI.EventFilter.newBuilder();
+
+    request.setFromBlock(fromBlock);
+    request.setToBlock(toBlock);
+    request.addAllContractAddress(addressList);
+    request.addAllContractTopic(topicList);
+
+    Return ret = rpcCli.setEventFilter(request.build());
+
+    if (ret.getResult()){
+      System.out.println("setEventFilter successfully");
+      return true;
+    }
+    else {
+      System.out.println("setEventFilter failed");
+      return false;
+    }
+  }
+
+  public static boolean setEventPluginConfig(List<String> pluginInfoList){
+
+    GrpcAPI.EventPluginInfo.Builder request = GrpcAPI.EventPluginInfo.newBuilder();
+
+    for (String item: pluginInfoList){
+      String[] pluginInfoArray = item.split("\\|");
+      if (pluginInfoArray.length != 2){
+        System.out.println("setEventPluginConfig invalid command format");
+        return false;
+      }
+
+      GrpcAPI.TriggerInfo.Builder triggerInfo = GrpcAPI.TriggerInfo.newBuilder();
+      triggerInfo.setTriggerName(pluginInfoArray[0]);
+
+      boolean enable = Boolean.valueOf(pluginInfoArray[1]);
+      triggerInfo.setEnable(enable);
+      request.addTriggerInfo(triggerInfo);
+    }
+
+    Return ret = rpcCli.setPluginConfig(request.build());
+    if (ret.getResult()){
+      System.out.println("setEventPluginConfig successfully");
+      return true;
+    }
+    else {
+      System.out.println("setEventPluginConfig failed");
+      return false;
+    }
+  }
 }

--- a/src/main/protos/api/api.proto
+++ b/src/main/protos/api/api.proto
@@ -598,6 +598,26 @@ service Wallet {
   rpc GetNodeInfo (EmptyMessage) returns (NodeInfo) {
   };
 
+  rpc SetEventFilter (EventFilter) returns (Return) {
+          option (google.api.http) = {
+            post: "/wallet/seteventfilter"
+            body: "*"
+            additional_bindings {
+              get: "/wallet/seteventfilter"
+            }
+          };
+        }
+
+        rpc SetEventPluginConfig (EventPluginInfo) returns (Return) {
+              option (google.api.http) = {
+                post: "/wallet/setpluginconfig"
+                body: "*"
+                additional_bindings {
+                  get: "/wallet/setpluginconfig"
+                }
+              };
+        }
+
 };
 
 
@@ -955,4 +975,20 @@ message BlockListExtention {
 
 message TransactionListExtention {
   repeated TransactionExtention transaction = 1;
+}
+
+message EventFilter {
+    string fromBlock = 1;
+    string toBlock = 2;
+    repeated string contractAddress = 3;
+    repeated string contractTopic = 4;
+}
+
+message TriggerInfo{
+    string triggerName = 1;
+    bool enable = 2;
+    string topic = 3;
+}
+message EventPluginInfo{
+    repeated TriggerInfo triggerInfo = 1;
 }


### PR DESCRIPTION
What does this PR do?
to support event subscribe,  adding seteventfilter/seteventpluginconfig commands. 
Why are these changes required?
seteventfilter is used to change filter query immediately.  seteventpluginconfig is used to enable or disable specified trigger type.

This PR has been tested by:
test in local
Follow up
Extra details
usage:
seteventfilter 100 1000 address1|address2 topic1|topic2
if parameter is null, input *
for example: seteventfilter * * * *, which means any contract log or event will be subscribed.

command: setEventPluginConfig  block|true transaction|false
