### PR TITLE
Fix: getCause throws NPE

### DIFF
--- a/src/main/java/org/tron/walletcli/Client.java
+++ b/src/main/java/org/tron/walletcli/Client.java
@@ -3403,13 +3403,12 @@ public class Client {
         } catch (EndOfFileException e) {
           System.out.println("\nBye.");
           return;
-        } catch (RuntimeException e) {
-          System.out.println(cmd + " failed!");
-          System.out.println(e.getMessage());
         } catch (Exception e) {
           System.out.println(cmd + " failed!");
           System.out.println(e.getMessage());
-          System.out.println(e.getCause().getMessage());
+          if (e.getCause() != null) {
+            System.out.println(e.getCause().getMessage());
+          }
 //          e.printStackTrace();
         }
       }

--- a/src/main/java/org/tron/walletcli/Client.java
+++ b/src/main/java/org/tron/walletcli/Client.java
@@ -3403,6 +3403,9 @@ public class Client {
         } catch (EndOfFileException e) {
           System.out.println("\nBye.");
           return;
+        } catch (RuntimeException e) {
+          System.out.println(cmd + " failed!");
+          System.out.println(e.getMessage());
         } catch (Exception e) {
           System.out.println(cmd + " failed!");
           System.out.println(e.getMessage());


### PR DESCRIPTION
# What does this PR do?

For now, when runtime exception occurs, the thread will exit, but for wallet-cli, sometimes it is maybe because of some APIs not working, but others can work well, so when met runtime exception, just print the error message and leave the choice to the user that whether they want to quit or continue.

# Why are these changes required?

Lite fullnode will shield some APIs when the node is a lite fullnode, so this change is required.

# This PR has been tested by:

Manual Testing
