### PR TITLE
optimize the logic of scanning blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ soliditynode = {
     "solidity ip : port"
   ]
 } // NOTE: solidity node is optional
+
+blockNumberStartToScan = 22690588 // NOTE: this field is optional
 ```
 
 ### Run a web wallet
@@ -1514,7 +1516,14 @@ d  :2fd028965d3b455579ab28
 
 ## How to transfer shielded TRC20 token
 
-when you begin to transfer TRC20 token to shielded address, you must have a shielded address. The
+If you want to try to transfer shielded TRC20 token, you'd better set the `blockNumberStartToScan` field in `config.conf` file.
+This field is used to set the starting block that the wallet needs to scan. If you ignore this field, or set it to 0, 
+the notes you receive will probably take a long time to show up in the wallet. It is recommended that this field is 
+set to the block number in which the earliest relevant shielded contract was created. If the exact number is not known, 
+this field can be set as follows. If used in mainnet, please set 22690588. If used in Nile testnet, please set 6380000. 
+Otherwise, please set 0.
+
+When you begin to transfer TRC20 token to shielded address, you must have a shielded address. The
  following commands help to generate shielded account.
 
 ### GetSpendingKey
@@ -1847,6 +1856,8 @@ type
 > Shows the type of note. If the variable is omitted or set to 0, it shows all unspent notes; For other values, it shows all the notes, including spent notes and unspent notes.
 
 List the note scanned by the local cache address, and the `Scaling Factor`.
+
+**NOTE** When you load shielded wallet, the wallet will scan blocks to find the notes others send to you in the backend. This will take a long time, so when you run `ListShieldedTRC20Note`, your notes will not be displayed immediately.
 
 Example:
 

--- a/src/main/resources/config.conf
+++ b/src/main/resources/config.conf
@@ -15,3 +15,9 @@ fullnode = {
 #}
 
 RPC_version = 2
+
+# This field used in shielded transaction. It is recommended that this field is set to the block
+# number in which the earliest relevant shielded contract was created. If the exact number is not
+# known, this field can be set as follows. If used in mainnet, please set 22690588. If used in Nile
+# testnet, please set 6380000. Otherwise, please set 0.
+blockNumberStartToScan = 22690588


### PR DESCRIPTION
What does this PR do?
Optimize the logic of scanning blocks. 
1. Add a configuration item to set the starting block that the wallet to scan. 
2. Reduce the number of blocks to request to fullnode, from 1000 to 200 at a time.
 
Why are these changes required?
Speed up synchronization time of shielded TRC20 transaction.

This PR has been tested by:

Manual Testing
Follow up

Extra details