### PR TITLE
typo: remove unused param for dex

### DIFF
--- a/src/main/protos/core/contract/market_contract.proto
+++ b/src/main/protos/core/contract/market_contract.proto
@@ -11,7 +11,6 @@ message MarketSellAssetContract {
   int64 sell_token_quantity = 3;
   bytes buy_token_id = 4;
   int64 buy_token_quantity = 5; // min to receive
-  bytes pre_price_key = 6; // order price position
 }
 
 message MarketCancelOrderContract {


### PR DESCRIPTION
typo: remove unused param for dex