### PR TITLE
fix the format of arguments of the constructor in the deploycontract command

### DIFF
--- a/src/main/java/org/tron/walletcli/Client.java
+++ b/src/main/java/org/tron/walletcli/Client.java
@@ -2108,11 +2108,11 @@ public class Client {
       System.out.println("origin_energy_limit must > 0");
       return;
     }
-    if (!constructorStr.equals("#")) {
+    if (!(constructorStr.equals("#") || argsStr.equals("#"))) {
       if (isHex) {
         codeStr += argsStr;
       } else {
-        codeStr += AbiUtil.parseMethod(constructorStr, argsStr);
+        codeStr += Hex.toHexString(AbiUtil.encodeInput(constructorStr, argsStr));
       }
     }
     long value = 0;
@@ -3682,7 +3682,7 @@ public class Client {
         || cmdLine.toLowerCase().startsWith("triggercontract")
         || cmdLine.toLowerCase().startsWith("triggerconstantcontract")
         || cmdLine.toLowerCase().startsWith("updateaccountpermission")) {
-      return cmdLine.split(" ", -1);
+      return cmdLine.split("\\s+", -1);
     }
     String[] strArray = cmdLine.split("\"");
     int num = strArray.length;


### PR DESCRIPTION
What does this PR do?
This PR is meant to fix fix the format of constructor and its arguments in the deploycontract command.

Why are these changes required?
Optimize user experience

This PR has been tested by:
Unit Tests
Manual Testing

Follow up

Extra details
1. If there is no constructor, please fill the field with "#".
2. if there is no arguments, please fill the field with "#".