### PR TITLE
feat(cli): allow known globals after command; query output + contract…

### DIFF
--- a/docs/standard-cli-contract-spec.md
+++ b/docs/standard-cli-contract-spec.md
@@ -50,7 +50,7 @@ The standard CLI has two distinct option layers:
 
 ### Global Options
 
-Global options affect the overall execution environment before the command is known.
+Global options affect the overall execution environment for the whole command run.
 
 Examples:
 
@@ -61,7 +61,8 @@ Examples:
 - quiet / verbose behavior
 - global help / version handling
 
-Global options are parsed by `GlobalOptions.parse(String[] args)`.
+Global options are parsed by `GlobalOptions.parse(String[] args)`. Known global options may appear either before or
+after the command token, except for command-help handling described below.
 
 ### Command-Local Options
 
@@ -79,26 +80,25 @@ Command-local options are parsed by `CommandDefinition.parseArgs(String[] args)`
 
 - global options configure how the CLI run is executed
 - command-local options configure what the chosen command does
-- global parsing happens first
+- global parsing happens first and extracts known global options from the full argument list
 - command-local parsing happens only after the command token is known
 - a token must not be interpreted as both a global option and a command-local option in the same pass
 
 ## Contract 1: Global Option Parsing
 
-`GlobalOptions.parse(String[] args)` is responsible only for parsing options that affect the whole run before
-the command is known.
+`GlobalOptions.parse(String[] args)` is responsible only for parsing known options that affect the whole run.
 
 ### Parsing Model
 
-Global option parsing is a left-to-right first-pass scan.
+Global option parsing is a left-to-right first-pass scan across the full argument list.
 
 The parser consumes tokens until one of these happens:
 
-1. it reaches the first command token
-2. it reaches the end of input
-3. it encounters a malformed global option and fails with a usage error
+1. it reaches the end of input
+2. it encounters a malformed known global option and fails with a usage error
 
-This pass is intentionally narrow. It must not inspect or reinterpret command-local options.
+This pass is intentionally narrow. It extracts only known global options and must not reinterpret unknown
+post-command options that belong to command-local parsing.
 
 ### Supported Syntax
 
@@ -126,11 +126,13 @@ For Contract 1, this applies to valued global options only.
 
 ### Boundary Rules
 
-- Global options are only recognized before the command token.
+- Known global options are recognized before and after the command token.
 - The first token before command resolution that does not begin with `-` is the command token.
 - The command token is normalized to lowercase for registry lookup.
-- After the command token is found, all remaining tokens are passed through unchanged as command arguments.
-- Tokens after the command token are never reinterpreted as global options, even if they look like global flags.
+- After the command token is found, known global options are extracted and all other tokens are passed through
+  unchanged as command arguments.
+- Unknown options after the command token are never reinterpreted as global options.
+- Post-command `--help` and `-h` are reserved for command help and are passed through as command arguments.
 
 Examples:
 
@@ -143,13 +145,21 @@ Examples:
   - command: `get-balance`
   - command args: `--address T...`
 - `wallet-cli get-balance --network nile`
+  - global options: `--network nile`
   - command: `get-balance`
-  - command args: `--network nile`
-  - `--network` is not treated as a global option because it appears after the command token
+  - command args: none
 - `wallet-cli get-balance --network=nile`
+  - global options: `--network=nile`
   - command: `get-balance`
-  - command args: `--network=nile`
-  - `--network=nile` is not treated as a global option because it appears after the command token
+  - command args: none
+- `wallet-cli get-balance --address T... --network nile`
+  - global options: `--network nile`
+  - command: `get-balance`
+  - command args: `--address T...`
+- `wallet-cli get-balance --help`
+  - command: `get-balance`
+  - command args: `--help`
+  - `--help` is not treated as global help because it appears after the command token
 
 ### No-Command Cases
 
@@ -196,7 +206,7 @@ The following are usage errors at the global parsing layer:
 - unknown global option before the command token
 - missing value for a valued global option
 - invalid value for a constrained global option
-- malformed global syntax before the command token
+- malformed syntax for a known global option
 
 Specific expectations:
 
@@ -216,6 +226,10 @@ Specific expectations:
   - usage error: missing or empty value for `--output`
 - `--quiet=true`
   - usage error: option `--quiet` does not take a value
+- `get-balance --network beta`
+  - usage error: invalid value for `--network`
+- `get-balance --unknown value`
+  - not a global parsing error; `--unknown value` remains command-local input
 
 Error classification for valued global options:
 

--- a/docs/standard-cli-contract-spec.md
+++ b/docs/standard-cli-contract-spec.md
@@ -61,8 +61,9 @@ Examples:
 - quiet / verbose behavior
 - global help / version handling
 
-Global options are parsed by `GlobalOptions.parse(String[] args)`. Known global options may appear either before or
-after the command token, except for command-help handling described below.
+Global options are parsed by `GlobalOptions.parse(String[] args)`. Execution modifiers may appear either before or
+after the command token. Top-level mode selectors are pre-command only, except for command-help handling described
+below.
 
 ### Command-Local Options
 
@@ -78,7 +79,8 @@ Command-local options are parsed by `CommandDefinition.parseArgs(String[] args)`
 
 ### Layer Boundary
 
-- global options configure how the CLI run is executed
+- global execution modifiers configure how the CLI run is executed
+- top-level mode selectors choose an alternate program mode before command execution
 - command-local options configure what the chosen command does
 - global parsing happens first and extracts known global options from the full argument list
 - command-local parsing happens only after the command token is known
@@ -126,13 +128,15 @@ For Contract 1, this applies to valued global options only.
 
 ### Boundary Rules
 
-- Known global options are recognized before and after the command token.
+- Execution modifier global options are recognized before and after the command token.
+- Top-level mode selectors `--version` and `--interactive` are recognized only before the command token.
 - The first token before command resolution that does not begin with `-` is the command token.
 - The command token is normalized to lowercase for registry lookup.
-- After the command token is found, known global options are extracted and all other tokens are passed through
-  unchanged as command arguments.
+- After the command token is found, execution modifier global options are extracted and all other tokens are passed
+  through unchanged as command arguments.
 - Unknown options after the command token are never reinterpreted as global options.
 - Post-command `--help` and `-h` are reserved for command help and are passed through as command arguments.
+- Post-command `--version` and `--interactive` are command-local tokens and are passed through as command arguments.
 
 Examples:
 
@@ -160,6 +164,14 @@ Examples:
   - command: `get-balance`
   - command args: `--help`
   - `--help` is not treated as global help because it appears after the command token
+- `wallet-cli get-balance --version`
+  - command: `get-balance`
+  - command args: `--version`
+  - `--version` is not treated as global version because it appears after the command token
+- `wallet-cli get-balance --interactive`
+  - command: `get-balance`
+  - command args: `--interactive`
+  - `--interactive` is not treated as global interactive mode because it appears after the command token
 
 ### No-Command Cases
 

--- a/qa/contracts.tsv
+++ b/qa/contracts.tsv
@@ -12,7 +12,8 @@ contract__global_invalid_network_value_json|empty|none|default|json|usage|["--ou
 contract__global_flag_with_value_json|empty|none|default|json|usage|["--output","json","--quiet=true","current-network"]|||usage_error|||
 contract__global_repeated_network_json|empty|none|default|json|usage|["--output","json","--network","nile","--network","main","current-network"]|||usage_error|||
 contract__global_quiet_verbose_conflict_json|empty|none|default|json|usage|["--output","json","--quiet","--verbose","current-network"]|||usage_error|||
-contract__post_command_global_like_token_text|empty|none|default|text|usage|["current-network","--network","nile"]||||Unknown option: --network||
+contract__post_command_global_network_text|empty|none|default|text|success|["current-network","--network","nile"]||||Current network:||
+contract__post_command_unknown_option_text|empty|none|default|text|usage|["current-network","--unknown","value"]||||Unknown option: --unknown||
 contract__command_missing_required_value_text|empty|none|default|text|usage|["get-block-by-latest-num","--count"]||||Missing value for --count||
 contract__command_empty_required_value_json|empty|none|default|json|usage|["--output","json","get-block-by-latest-num","--count="]|||usage_error|||
 contract__command_boolean_flag_exec|empty|none|default|text|execution|["freeze-balance-v2","--amount","1","--multi"]|||execution_error|Error:||

--- a/qa/contracts.tsv
+++ b/qa/contracts.tsv
@@ -14,6 +14,8 @@ contract__global_repeated_network_json|empty|none|default|json|usage|["--output"
 contract__global_quiet_verbose_conflict_json|empty|none|default|json|usage|["--output","json","--quiet","--verbose","current-network"]|||usage_error|||
 contract__post_command_global_network_text|empty|none|default|text|success|["current-network","--network","nile"]||||Current network:||
 contract__post_command_unknown_option_text|empty|none|default|text|usage|["current-network","--unknown","value"]||||Unknown option: --unknown||
+contract__post_command_version_text|empty|none|default|text|usage|["current-network","--version"]||||Unknown option: --version||
+contract__post_command_interactive_text|empty|none|default|text|usage|["current-network","--interactive"]||||Unknown option: --interactive||
 contract__command_missing_required_value_text|empty|none|default|text|usage|["get-block-by-latest-num","--count"]||||Missing value for --count||
 contract__command_empty_required_value_json|empty|none|default|json|usage|["--output","json","get-block-by-latest-num","--count="]|||usage_error|||
 contract__command_boolean_flag_exec|empty|none|default|text|execution|["freeze-balance-v2","--amount","1","--multi"]|||execution_error|Error:||

--- a/src/main/java/org/tron/walletcli/Client.java
+++ b/src/main/java/org/tron/walletcli/Client.java
@@ -4798,6 +4798,7 @@ public class Client {
   }
 
   private static boolean requestsJsonOutput(String[] args) {
+    // Fallback scan for parse errors assumes --output is a standard-CLI global-only option.
     for (int i = 0; i < args.length; i++) {
       String token = args[i];
       if ("--output".equals(token)) {

--- a/src/main/java/org/tron/walletcli/Client.java
+++ b/src/main/java/org/tron/walletcli/Client.java
@@ -4800,9 +4800,6 @@ public class Client {
   private static boolean requestsJsonOutput(String[] args) {
     for (int i = 0; i < args.length; i++) {
       String token = args[i];
-      if (!token.startsWith("-")) {
-        return false;
-      }
       if ("--output".equals(token)) {
         return i + 1 < args.length && "json".equalsIgnoreCase(args[i + 1]);
       }

--- a/src/main/java/org/tron/walletcli/cli/GlobalOptions.java
+++ b/src/main/java/org/tron/walletcli/cli/GlobalOptions.java
@@ -1,6 +1,7 @@
 package org.tron.walletcli.cli;
 
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 public class GlobalOptions {
@@ -41,26 +42,36 @@ public class GlobalOptions {
         boolean networkSeen = false;
         boolean walletSeen = false;
         boolean grpcEndpointSeen = false;
+        List<String> commandArgs = new ArrayList<String>();
         for (int i = 0; i < args.length; i++) {
             String token = args[i];
+            boolean commandSeen = opts.command != null;
 
-            if (!token.startsWith("-")) {
+            if (!commandSeen && !token.startsWith("-")) {
                 opts.command = token.toLowerCase(Locale.ROOT);
-                opts.commandArgs = Arrays.copyOfRange(args, i + 1, args.length);
-                return opts;
-            }
-
-            if ("-h".equals(token)) {
-                opts.help = true;
                 continue;
             }
 
-            if (token.startsWith("-h=")) {
+            if ("-h".equals(token)) {
+                if (commandSeen) {
+                    commandArgs.add(token);
+                } else {
+                    opts.help = true;
+                }
+                continue;
+            }
+
+            if (!commandSeen && token.startsWith("-h=")) {
                 throw new CliUsageException("Option -h does not take a value");
             }
 
             if (!token.startsWith("--")) {
-                throw new CliUsageException("Unknown global option: " + token);
+                if (commandSeen) {
+                    commandArgs.add(token);
+                } else {
+                    throw new CliUsageException("Unknown global option: " + token);
+                }
+                continue;
             }
 
             ParsedLongOption parsed = parseLongOptionToken(token);
@@ -70,6 +81,10 @@ public class GlobalOptions {
                     opts.interactive = true;
                     break;
                 case "help":
+                    if (commandSeen) {
+                        commandArgs.add(token);
+                        break;
+                    }
                     ensureNoInlineValue(parsed, "--help");
                     opts.help = true;
                     break;
@@ -124,9 +139,14 @@ public class GlobalOptions {
                     }
                     break;
                 default:
-                    throw new CliUsageException("Unknown global option: --" + parsed.name);
+                    if (commandSeen) {
+                        commandArgs.add(token);
+                    } else {
+                        throw new CliUsageException("Unknown global option: --" + parsed.name);
+                    }
             }
         }
+        opts.commandArgs = commandArgs.toArray(new String[0]);
         return opts;
     }
 

--- a/src/main/java/org/tron/walletcli/cli/GlobalOptions.java
+++ b/src/main/java/org/tron/walletcli/cli/GlobalOptions.java
@@ -77,6 +77,10 @@ public class GlobalOptions {
             ParsedLongOption parsed = parseLongOptionToken(token);
             switch (parsed.name) {
                 case "interactive":
+                    if (commandSeen) {
+                        commandArgs.add(token);
+                        break;
+                    }
                     ensureNoInlineValue(parsed, "--interactive");
                     opts.interactive = true;
                     break;
@@ -89,6 +93,10 @@ public class GlobalOptions {
                     opts.help = true;
                     break;
                 case "version":
+                    if (commandSeen) {
+                        commandArgs.add(token);
+                        break;
+                    }
                     ensureNoInlineValue(parsed, "--version");
                     opts.version = true;
                     break;
@@ -174,6 +182,7 @@ public class GlobalOptions {
         if (valueIndex >= args.length || args[valueIndex].startsWith("-")) {
             throw new CliUsageException("Missing value for " + optionName);
         }
+        // Valued globals intentionally consume the next non-flag token greedily; command names are not special here.
         return args[valueIndex];
     }
 

--- a/src/main/java/org/tron/walletcli/cli/OutputFormatter.java
+++ b/src/main/java/org/tron/walletcli/cli/OutputFormatter.java
@@ -16,6 +16,8 @@ public class OutputFormatter {
 
     public enum OutputMode { TEXT, JSON }
     private static final String MULTIPLE_OUTCOMES_MESSAGE = "Multiple terminal outcomes emitted";
+    private static final int MAX_METADATA_KEYS = 12;
+    private static final int MAX_METADATA_VALUE_LENGTH = 200;
 
     private final OutputMode mode;
     private final boolean quiet;
@@ -99,11 +101,15 @@ public class OutputFormatter {
     }
 
     private void recordSuccess(String textMessage, Object jsonData) {
+        recordSuccess(textMessage, jsonData, false);
+    }
+
+    private void recordSuccess(String textMessage, Object jsonData, boolean queryResult) {
         if (outcome != null) {
             recordMultipleOutcomeViolation();
             throw new CliAbortException(CliAbortException.Kind.EXECUTION);
         }
-        outcome = Outcome.success(textMessage, normalizeJsonData(jsonData));
+        outcome = Outcome.success(textMessage, normalizeJsonData(jsonData), queryResult);
     }
 
     private void recordError(String code, String message, CliAbortException.Kind abortKind, String usageHelp) {
@@ -135,31 +141,10 @@ public class OutputFormatter {
                 emitJsonSuccess(current.jsonData);
             } else {
                 out.println(current.textMessage);
-                Map<?, ?> kvPairs = null;
-                if (current.jsonData instanceof Map) {
-                    kvPairs = (Map<?, ?>) current.jsonData;
-                } else if (current.jsonData instanceof JsonElement
-                        && ((JsonElement) current.jsonData).isJsonObject()) {
-                    kvPairs = ((JsonElement) current.jsonData).getAsJsonObject().asMap();
-                }
-                // Intentional: text mode surfaces structured data as an aligned metadata table,
-                // giving human users richer context without requiring --output json.
-                if (kvPairs != null) {
-                    List<Map.Entry<?, ?>> details = new ArrayList<>();
-                    int maxKeyLen = 0;
-                    for (Map.Entry<?, ?> e : kvPairs.entrySet()) {
-                        if ("message".equals(e.getKey())) continue;
-                        details.add(e);
-                        maxKeyLen = Math.max(maxKeyLen, String.valueOf(e.getKey()).length());
-                    }
-                    if (!details.isEmpty()) {
-                        out.println();
-                        out.println("  Metadata:");
-                        String fmt = "    %-" + maxKeyLen + "s : %s%n";
-                        for (Map.Entry<?, ?> e : details) {
-                            out.printf(fmt, e.getKey(), e.getValue());
-                        }
-                    }
+                if (current.queryResult) {
+                    renderQueryResult(current.jsonData);
+                } else {
+                    renderMetadata(current.jsonData);
                 }
             }
             return;
@@ -179,6 +164,11 @@ public class OutputFormatter {
     /** Print a successful result with a text message and optional JSON data. */
     public void success(String textMessage, Object jsonData) {
         recordSuccess(textMessage, jsonData);
+    }
+
+    /** Print a query result with a success message and formatter-selected text details. */
+    public void queryResult(String textMessage, Object resultData) {
+        recordSuccess(textMessage, resultData, true);
     }
 
     /** Print a success message in text mode and expose it under data.message in JSON mode. */
@@ -210,7 +200,7 @@ public class OutputFormatter {
             return;
         }
         String formatted = org.tron.common.utils.Utils.formatMessageString(message);
-        recordSuccess(formatted, formatted);
+        recordSuccess(formatted, mode == OutputMode.TEXT ? wrapMessage(formatted) : formatted);
     }
 
     /** Print a message object (trident Response types or pre-formatted strings). */
@@ -219,7 +209,8 @@ public class OutputFormatter {
             error("not_found", failMsg);
             return;
         }
-        recordSuccess(String.valueOf(message), message);
+        String text = String.valueOf(message);
+        recordSuccess(text, mode == OutputMode.TEXT ? wrapMessage(text) : message);
     }
 
     /** Print raw text. */
@@ -232,6 +223,87 @@ public class OutputFormatter {
         Map<String, Object> data = new LinkedHashMap<String, Object>();
         data.put(key, value);
         recordSuccess(key + " = " + value, data);
+    }
+
+    private void renderQueryResult(Object jsonData) {
+        if (shouldRenderAsMetadata(jsonData)) {
+            renderMetadata(jsonData);
+            return;
+        }
+        out.println();
+        out.println("  Result:");
+        out.println(indentResult(gson.toJson(jsonData)));
+    }
+
+    private String indentResult(String text) {
+        return "  " + text.replace(System.lineSeparator(), System.lineSeparator() + "  ");
+    }
+
+    private void renderMetadata(Object jsonData) {
+        Map<?, ?> kvPairs = objectEntries(jsonData);
+        // Intentional: text mode surfaces structured data as an aligned metadata table,
+        // giving human users richer context without requiring --output json.
+        if (kvPairs != null) {
+            List<Map.Entry<?, ?>> details = new ArrayList<>();
+            int maxKeyLen = 0;
+            for (Map.Entry<?, ?> e : kvPairs.entrySet()) {
+                if ("message".equals(e.getKey())) continue;
+                details.add(e);
+                maxKeyLen = Math.max(maxKeyLen, String.valueOf(e.getKey()).length());
+            }
+            if (!details.isEmpty()) {
+                out.println();
+                out.println("  Metadata:");
+                String fmt = "    %-" + maxKeyLen + "s : %s%n";
+                for (Map.Entry<?, ?> e : details) {
+                    out.printf(fmt, e.getKey(), e.getValue());
+                }
+            }
+        }
+    }
+
+    private Map<?, ?> objectEntries(Object jsonData) {
+        if (jsonData instanceof Map) {
+            return (Map<?, ?>) jsonData;
+        }
+        if (jsonData instanceof JsonElement && ((JsonElement) jsonData).isJsonObject()) {
+            return ((JsonElement) jsonData).getAsJsonObject().asMap();
+        }
+        return null;
+    }
+
+    private boolean shouldRenderAsMetadata(Object jsonData) {
+        Map<?, ?> kvPairs = objectEntries(jsonData);
+        if (kvPairs == null || kvPairs.size() > MAX_METADATA_KEYS) {
+            return false;
+        }
+        for (Map.Entry<?, ?> e : kvPairs.entrySet()) {
+            if ("message".equals(e.getKey())) {
+                continue;
+            }
+            if (!isMetadataValue(e.getValue())) {
+                return false;
+            }
+            if (String.valueOf(e.getValue()).length() > MAX_METADATA_VALUE_LENGTH) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean isMetadataValue(Object value) {
+        if (value == null) {
+            return true;
+        }
+        if (value instanceof String || value instanceof Number || value instanceof Boolean
+                || value instanceof Character) {
+            return true;
+        }
+        if (value instanceof JsonElement) {
+            JsonElement element = (JsonElement) value;
+            return element.isJsonNull() || element.isJsonPrimitive();
+        }
+        return false;
     }
 
     /** Print an error and signal exit code 1. */
@@ -256,26 +328,28 @@ public class OutputFormatter {
         private final boolean success;
         private final String textMessage;
         private final Object jsonData;
+        private final boolean queryResult;
         private final String errorCode;
         private final String errorMessage;
         private final String usageHelp;
 
-        private Outcome(boolean success, String textMessage, Object jsonData,
+        private Outcome(boolean success, String textMessage, Object jsonData, boolean queryResult,
                         String errorCode, String errorMessage, String usageHelp) {
             this.success = success;
             this.textMessage = textMessage;
             this.jsonData = jsonData;
+            this.queryResult = queryResult;
             this.errorCode = errorCode;
             this.errorMessage = errorMessage;
             this.usageHelp = usageHelp;
         }
 
-        private static Outcome success(String textMessage, Object jsonData) {
-            return new Outcome(true, textMessage, jsonData, null, null, null);
+        private static Outcome success(String textMessage, Object jsonData, boolean queryResult) {
+            return new Outcome(true, textMessage, jsonData, queryResult, null, null, null);
         }
 
         private static Outcome error(String errorCode, String errorMessage, String usageHelp) {
-            return new Outcome(false, null, null, errorCode, errorMessage, usageHelp);
+            return new Outcome(false, null, null, false, errorCode, errorMessage, usageHelp);
         }
     }
 }

--- a/src/main/java/org/tron/walletcli/cli/OutputFormatter.java
+++ b/src/main/java/org/tron/walletcli/cli/OutputFormatter.java
@@ -236,7 +236,7 @@ public class OutputFormatter {
     }
 
     private String indentResult(String text) {
-        return "  " + text.replace(System.lineSeparator(), System.lineSeparator() + "  ");
+        return "  " + text.replace("\n", "\n  ");
     }
 
     private void renderMetadata(Object jsonData) {
@@ -277,6 +277,7 @@ public class OutputFormatter {
         if (kvPairs == null || kvPairs.size() > MAX_METADATA_KEYS) {
             return false;
         }
+        boolean hasPrintableMetadata = false;
         for (Map.Entry<?, ?> e : kvPairs.entrySet()) {
             if ("message".equals(e.getKey())) {
                 continue;
@@ -287,8 +288,9 @@ public class OutputFormatter {
             if (String.valueOf(e.getValue()).length() > MAX_METADATA_VALUE_LENGTH) {
                 return false;
             }
+            hasPrintableMetadata = true;
         }
-        return true;
+        return hasPrintableMetadata;
     }
 
     private boolean isMetadataValue(Object value) {

--- a/src/main/java/org/tron/walletcli/cli/commands/ContractCommands.java
+++ b/src/main/java/org/tron/walletcli/cli/commands/ContractCommands.java
@@ -232,8 +232,7 @@ public class ContractCommands {
                         out.error("query_failed", constantContractMessage(result, "TriggerConstantContract failed"));
                         return;
                     }
-                    String formatted = Utils.formatMessageString(result);
-                    out.success("Execution result = " + formatted, formatted);
+                    out.queryResult("TriggerConstantContract successful !!", Utils.formatMessageString(result));
                 })
                 .build());
     }
@@ -304,8 +303,7 @@ public class ContractCommands {
                         out.error("query_failed", estimateEnergyMessage(result, "EstimateEnergy failed"));
                         return;
                     }
-                    String formatted = Utils.formatMessageString(result);
-                    out.success("Estimate energy result = " + formatted, formatted);
+                    out.queryResult("EstimateEnergy successful !!", Utils.formatMessageString(result));
                 })
                 .build());
     }

--- a/src/main/java/org/tron/walletcli/cli/commands/QueryCommands.java
+++ b/src/main/java/org/tron/walletcli/cli/commands/QueryCommands.java
@@ -142,7 +142,7 @@ public class QueryCommands {
                     if (account == null) {
                         out.error("query_failed", "GetAccount failed");
                     } else {
-                        out.printMessage(Utils.formatMessageString(account), "GetAccount failed");
+                        out.queryResult("GetAccount successful !!", Utils.formatMessageString(account));
                     }
                 })
                 .build());
@@ -159,7 +159,7 @@ public class QueryCommands {
                     if (account == null) {
                         out.error("query_failed", "GetAccountById failed");
                     } else {
-                        out.printMessage(Utils.formatMessageString(account), "GetAccountById failed");
+                        out.queryResult("GetAccountById successful !!", Utils.formatMessageString(account));
                     }
                 })
                 .build());
@@ -174,7 +174,7 @@ public class QueryCommands {
                 .handler((ctx, opts, wrapper, out) -> {
                     byte[] addressBytes = opts.getAddress("address");
                     Response.AccountNetMessage accountNet = wrapper.getAccountNetForCli(addressBytes);
-                    out.printMessage(Utils.formatMessageString(accountNet), "GetAccountNet failed");
+                    out.queryResult("GetAccountNet successful !!", Utils.formatMessageString(accountNet));
                 })
                 .build());
     }
@@ -188,7 +188,7 @@ public class QueryCommands {
                 .handler((ctx, opts, wrapper, out) -> {
                     byte[] addressBytes = opts.getAddress("address");
                     Response.AccountResourceMessage accountResource = wrapper.getAccountResourceForCli(addressBytes);
-                    out.printMessage(Utils.formatMessageString(accountResource), "GetAccountResource failed");
+                    out.queryResult("GetAccountResource successful !!", Utils.formatMessageString(accountResource));
                 })
                 .build());
     }
@@ -244,7 +244,7 @@ public class QueryCommands {
                     if (block == null) {
                         out.error("query_failed", "GetBlock failed");
                     } else {
-                        out.printMessage(Utils.printBlock(block), "GetBlock failed");
+                        out.queryResult("GetBlock successful !!", Utils.printBlock(block));
                     }
                 })
                 .build());
@@ -263,7 +263,7 @@ public class QueryCommands {
                     if (block == null) {
                         out.error("query_failed", "GetBlockById failed");
                     } else {
-                        out.printMessage(Utils.printBlock(block), "GetBlockById failed");
+                        out.queryResult("GetBlockById successful !!", Utils.printBlock(block));
                     }
                 })
                 .build());
@@ -284,14 +284,14 @@ public class QueryCommands {
                         if (block == null) {
                             out.error("query_failed", "GetBlock failed");
                         } else {
-                            out.printMessage(Utils.printBlock(block), "GetBlock failed");
+                            out.queryResult("GetBlockByIdOrNum successful !!", Utils.printBlock(block));
                         }
                     } catch (NumberFormatException e) {
                         Chain.Block block = WalletApi.getBlockById(value);
                         if (block == null) {
                             out.error("query_failed", "GetBlockById failed");
                         } else {
-                            out.printMessage(Utils.printBlock(block), "GetBlockById failed");
+                            out.queryResult("GetBlockByIdOrNum successful !!", Utils.printBlock(block));
                         }
                     }
                 })
@@ -311,7 +311,7 @@ public class QueryCommands {
                     if (blocks == null) {
                         out.error("query_failed", "GetBlockByLatestNum failed");
                     } else {
-                        out.printMessage(Utils.formatMessageString(blocks), "GetBlockByLatestNum failed");
+                        out.queryResult("GetBlockByLatestNum successful !!", Utils.formatMessageString(blocks));
                     }
                 })
                 .build());
@@ -337,7 +337,7 @@ public class QueryCommands {
                     if (blocks == null) {
                         out.error("query_failed", "GetBlockByLimitNext failed");
                     } else {
-                        out.printMessage(Utils.formatMessageString(blocks), "GetBlockByLimitNext failed");
+                        out.queryResult("GetBlockByLimitNext successful !!", Utils.formatMessageString(blocks));
                     }
                 })
                 .build());
@@ -353,7 +353,7 @@ public class QueryCommands {
                     String id = opts.getString("id");
                     CommandSupport.requireHexHash(out, "id", id);
                     Chain.Transaction tx = wrapper.getTransactionByIdForCli(id);
-                    out.printMessage(Utils.formatMessageString(tx), "GetTransactionById failed");
+                    out.queryResult("GetTransactionById successful !!", Utils.formatMessageString(tx));
                 })
                 .build());
     }
@@ -368,7 +368,7 @@ public class QueryCommands {
                     String id = opts.getString("id");
                     CommandSupport.requireHexHash(out, "id", id);
                     Response.TransactionInfo txInfo = wrapper.getTransactionInfoByIdForCli(id);
-                    out.printMessage(Utils.formatMessageString(txInfo), "GetTransactionInfoById failed");
+                    out.queryResult("GetTransactionInfoById successful !!", Utils.formatMessageString(txInfo));
                 })
                 .build());
     }
@@ -401,7 +401,7 @@ public class QueryCommands {
                     if (result == null) {
                         out.error("query_failed", "GetAssetIssueByAccount failed");
                     } else {
-                        out.printMessage(Utils.formatMessageString(result), "GetAssetIssueByAccount failed");
+                        out.queryResult("GetAssetIssueByAccount successful !!", Utils.formatMessageString(result));
                     }
                 })
                 .build());
@@ -415,7 +415,11 @@ public class QueryCommands {
                 .option("id", "Asset ID", true)
                 .handler((ctx, opts, wrapper, out) -> {
                     Contract.AssetIssueContract result = WalletApi.getAssetIssueById(opts.getString("id"));
-                    out.protobuf(result, "GetAssetIssueById failed");
+                    if (result == null) {
+                        out.error("not_found", "GetAssetIssueById failed");
+                    } else {
+                        out.queryResult("GetAssetIssueById successful !!", Utils.formatMessageString(result));
+                    }
                 })
                 .build());
     }
@@ -428,7 +432,11 @@ public class QueryCommands {
                 .option("name", "Asset name", true)
                 .handler((ctx, opts, wrapper, out) -> {
                     Contract.AssetIssueContract result = WalletApi.getAssetIssueByName(opts.getString("name"));
-                    out.protobuf(result, "GetAssetIssueByName failed");
+                    if (result == null) {
+                        out.error("not_found", "GetAssetIssueByName failed");
+                    } else {
+                        out.queryResult("GetAssetIssueByName successful !!", Utils.formatMessageString(result));
+                    }
                 })
                 .build());
     }
@@ -444,7 +452,7 @@ public class QueryCommands {
                     if (result == null) {
                         out.error("query_failed", "GetAssetIssueListByName failed");
                     } else {
-                        out.printMessage(Utils.formatMessageString(result), "GetAssetIssueListByName failed");
+                        out.queryResult("GetAssetIssueListByName successful !!", Utils.formatMessageString(result));
                     }
                 })
                 .build());
@@ -457,7 +465,7 @@ public class QueryCommands {
                 .description("Get chain parameters")
                 .handler((ctx, opts, wrapper, out) -> {
                     Response.ChainParameters result = wrapper.getChainParametersForCli();
-                    out.printMessage(Utils.formatMessageString(result), "GetChainParameters failed");
+                    out.queryResult("GetChainParameters successful !!", Utils.formatMessageString(result));
                 })
                 .build());
     }
@@ -469,7 +477,11 @@ public class QueryCommands {
                 .description("Get bandwidth prices history")
                 .handler((ctx, opts, wrapper, out) -> {
                     Response.PricesResponseMessage result = WalletApi.getBandwidthPrices();
-                    out.protobuf(result, "GetBandwidthPrices failed");
+                    if (result == null) {
+                        out.error("not_found", "GetBandwidthPrices failed");
+                    } else {
+                        out.queryResult("GetBandwidthPrices successful !!", Utils.formatMessageString(result));
+                    }
                 })
                 .build());
     }
@@ -481,7 +493,11 @@ public class QueryCommands {
                 .description("Get energy prices history")
                 .handler((ctx, opts, wrapper, out) -> {
                     Response.PricesResponseMessage result = WalletApi.getEnergyPrices();
-                    out.protobuf(result, "GetEnergyPrices failed");
+                    if (result == null) {
+                        out.error("not_found", "GetEnergyPrices failed");
+                    } else {
+                        out.queryResult("GetEnergyPrices successful !!", Utils.formatMessageString(result));
+                    }
                 })
                 .build());
     }
@@ -493,7 +509,11 @@ public class QueryCommands {
                 .description("Get memo fee")
                 .handler((ctx, opts, wrapper, out) -> {
                     Response.PricesResponseMessage result = WalletApi.getMemoFee();
-                    out.protobuf(result, "GetMemoFee failed");
+                    if (result == null) {
+                        out.error("not_found", "GetMemoFee failed");
+                    } else {
+                        out.queryResult("GetMemoFee successful !!", Utils.formatMessageString(result));
+                    }
                 })
                 .build());
     }
@@ -523,7 +543,7 @@ public class QueryCommands {
                     if (contract == null) {
                         out.error("query_failed", "GetContract failed");
                     } else {
-                        out.printMessage(Utils.formatMessageString(contract), "GetContract failed");
+                        out.queryResult("GetContract successful !!", Utils.formatMessageString(contract));
                     }
                 })
                 .build());
@@ -540,7 +560,7 @@ public class QueryCommands {
                     if (contractInfo == null) {
                         out.error("query_failed", "GetContractInfo failed");
                     } else {
-                        out.printMessage(Utils.formatMessageString(contractInfo), "GetContractInfo failed");
+                        out.queryResult("GetContractInfo successful !!", Utils.formatMessageString(contractInfo));
                     }
                 })
                 .build());
@@ -560,7 +580,7 @@ public class QueryCommands {
                     if (result == null) {
                         out.error("query_failed", "GetDelegatedResource failed");
                     } else {
-                        out.printMessage(Utils.formatMessageString(result), "GetDelegatedResource failed");
+                        out.queryResult("GetDelegatedResource successful !!", Utils.formatMessageString(result));
                     }
                 })
                 .build());
@@ -580,7 +600,7 @@ public class QueryCommands {
                     if (result == null) {
                         out.error("query_failed", "GetDelegatedResourceV2 failed");
                     } else {
-                        out.printMessage(Utils.formatMessageString(result), "GetDelegatedResourceV2 failed");
+                        out.queryResult("GetDelegatedResourceV2 successful !!", Utils.formatMessageString(result));
                     }
                 })
                 .build());
@@ -599,8 +619,8 @@ public class QueryCommands {
                     if (result == null) {
                         out.error("query_failed", "GetDelegatedResourceAccountIndex failed");
                     } else {
-                        out.printMessage(Utils.formatMessageString(result),
-                                "GetDelegatedResourceAccountIndex failed");
+                        out.queryResult("GetDelegatedResourceAccountIndex successful !!",
+                                Utils.formatMessageString(result));
                     }
                 })
                 .build());
@@ -619,8 +639,8 @@ public class QueryCommands {
                     if (result == null) {
                         out.error("query_failed", "GetDelegatedResourceAccountIndexV2 failed");
                     } else {
-                        out.printMessage(Utils.formatMessageString(result),
-                                "GetDelegatedResourceAccountIndexV2 failed");
+                        out.queryResult("GetDelegatedResourceAccountIndexV2 successful !!",
+                                Utils.formatMessageString(result));
                     }
                 })
                 .build());
@@ -723,7 +743,7 @@ public class QueryCommands {
                     if (nodeList == null) {
                         out.error("query_failed", "ListNodes failed");
                     } else {
-                        out.printMessage(Utils.formatMessageString(nodeList), "ListNodes failed");
+                        out.queryResult("ListNodes successful !!", Utils.formatMessageString(nodeList));
                     }
                 })
                 .build());
@@ -736,7 +756,7 @@ public class QueryCommands {
                 .description("List all witnesses")
                 .handler((ctx, opts, wrapper, out) -> {
                     Response.WitnessList witnessList = wrapper.listWitnessesForCli();
-                    out.printMessage(Utils.formatMessageString(witnessList), "ListWitnesses failed");
+                    out.queryResult("ListWitnesses successful !!", Utils.formatMessageString(witnessList));
                 })
                 .build());
     }
@@ -748,7 +768,11 @@ public class QueryCommands {
                 .description("List all asset issues")
                 .handler((ctx, opts, wrapper, out) -> {
                     Response.AssetIssueList result = WalletApi.getAssetIssueList();
-                    out.protobuf(result, "ListAssetIssue failed");
+                    if (result == null) {
+                        out.error("not_found", "ListAssetIssue failed");
+                    } else {
+                        out.queryResult("ListAssetIssue successful !!", Utils.formatMessageString(result));
+                    }
                 })
                 .build());
     }
@@ -769,7 +793,7 @@ public class QueryCommands {
                     if (result == null) {
                         out.error("query_failed", "ListAssetIssuePaginated failed");
                     } else {
-                        out.printMessage(Utils.formatMessageString(result), "ListAssetIssuePaginated failed");
+                        out.queryResult("ListAssetIssuePaginated successful !!", Utils.formatMessageString(result));
                     }
                 })
                 .build());
@@ -785,7 +809,7 @@ public class QueryCommands {
                     if (result == null) {
                         out.error("query_failed", "ListProposals failed");
                     } else {
-                        out.printMessage(Utils.formatMessageString(result), "ListProposals failed");
+                        out.queryResult("ListProposals successful !!", Utils.formatMessageString(result));
                     }
                 })
                 .build());
@@ -807,7 +831,7 @@ public class QueryCommands {
                     if (result == null) {
                         out.error("query_failed", "ListProposalsPaginated failed");
                     } else {
-                        out.printMessage(Utils.formatMessageString(result), "ListProposalsPaginated failed");
+                        out.queryResult("ListProposalsPaginated successful !!", Utils.formatMessageString(result));
                     }
                 })
                 .build());
@@ -825,7 +849,7 @@ public class QueryCommands {
                     if (result == null) {
                         out.error("query_failed", "GetProposal failed");
                     } else {
-                        out.printMessage(Utils.formatMessageString(result), "GetProposal failed");
+                        out.queryResult("GetProposal successful !!", Utils.formatMessageString(result));
                     }
                 })
                 .build());
@@ -841,7 +865,7 @@ public class QueryCommands {
                     if (result == null) {
                         out.error("query_failed", "ListExchanges failed");
                     } else {
-                        out.printMessage(Utils.formatMessageString(result), "ListExchanges failed");
+                        out.queryResult("ListExchanges successful !!", Utils.formatMessageString(result));
                     }
                 })
                 .build());
@@ -863,7 +887,7 @@ public class QueryCommands {
                     if (result == null) {
                         out.error("query_failed", "ListExchangesPaginated failed");
                     } else {
-                        out.printMessage(Utils.formatMessageString(result), "ListExchangesPaginated failed");
+                        out.queryResult("ListExchangesPaginated successful !!", Utils.formatMessageString(result));
                     }
                 })
                 .build());
@@ -880,7 +904,7 @@ public class QueryCommands {
                     if (result == null) {
                         out.error("query_failed", "GetExchange failed");
                     } else {
-                        out.printMessage(Utils.formatMessageString(result), "GetExchange failed");
+                        out.queryResult("GetExchange successful !!", Utils.formatMessageString(result));
                     }
                 })
                 .build());
@@ -897,7 +921,7 @@ public class QueryCommands {
                     if (result == null) {
                         out.error("query_failed", "GetMarketOrderByAccount failed");
                     } else {
-                        out.printMessage(Utils.formatMessageString(result), "GetMarketOrderByAccount failed");
+                        out.queryResult("GetMarketOrderByAccount successful !!", Utils.formatMessageString(result));
                     }
                 })
                 .build());
@@ -922,7 +946,7 @@ public class QueryCommands {
                     if (result == null) {
                         out.error("query_failed", "GetMarketOrderById failed");
                     } else {
-                        out.printMessage(Utils.formatMessageString(result), "GetMarketOrderById failed");
+                        out.queryResult("GetMarketOrderById successful !!", Utils.formatMessageString(result));
                     }
                 })
                 .build());
@@ -942,7 +966,8 @@ public class QueryCommands {
                     if (result == null) {
                         out.error("query_failed", "GetMarketOrderListByPair failed");
                     } else {
-                        out.printMessage(Utils.formatMessageString(result), "GetMarketOrderListByPair failed");
+                        out.queryResult("GetMarketOrderListByPair successful !!",
+                                Utils.formatMessageString(result));
                     }
                 })
                 .build());
@@ -955,7 +980,7 @@ public class QueryCommands {
                 .description("Get all market trading pairs")
                 .handler((ctx, opts, wrapper, out) -> {
                     Response.MarketOrderPairList result = wrapper.getMarketPairListForCli();
-                    out.printMessage(Utils.formatMessageString(result), "GetMarketPairList failed");
+                    out.queryResult("GetMarketPairList successful !!", Utils.formatMessageString(result));
                 })
                 .build());
     }
@@ -974,7 +999,7 @@ public class QueryCommands {
                     if (result == null) {
                         out.error("query_failed", "GetMarketPriceByPair failed");
                     } else {
-                        out.printMessage(Utils.formatMessageString(result), "GetMarketPriceByPair failed");
+                        out.queryResult("GetMarketPriceByPair successful !!", Utils.formatMessageString(result));
                     }
                 })
                 .build());
@@ -993,7 +1018,7 @@ public class QueryCommands {
                     String address = opts.has("address")
                             ? WalletApi.encode58Check(opts.getAddress("address")) : null;
                     String rendered = JSON.toJSONString(wrapper.getGasFreeInfoDataForCli(address), true);
-                    out.printMessage(rendered, "GetGasFreeInfo failed");
+                    out.queryResult("GetGasFreeInfo successful !!", rendered);
                 })
                 .build());
     }
@@ -1006,7 +1031,7 @@ public class QueryCommands {
                 .option("id", "Transaction ID", true)
                 .handler((ctx, opts, wrapper, out) -> {
                     String rendered = JSON.toJSONString(wrapper.gasFreeTraceData(opts.getString("id")), true);
-                    out.printMessage(rendered, "GasFreeTrace failed");
+                    out.queryResult("GasFreeTrace successful !!", rendered);
                 })
                 .build());
     }

--- a/src/test/java/org/tron/walletcli/ClientMainTest.java
+++ b/src/test/java/org/tron/walletcli/ClientMainTest.java
@@ -125,4 +125,24 @@ public class ClientMainTest {
       System.setOut(originalOut);
     }
   }
+
+  @Test
+  public void runMainEmitsJsonForPostCommandGlobalParseFailureWhenJsonWasRequested() throws Exception {
+    ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+    PrintStream originalOut = System.out;
+    System.setOut(new PrintStream(stdout));
+    try {
+      int exitCode = Client.runMain(new String[]{
+          "get-balance", "--output", "json", "--network", "beta"
+      });
+
+      Assert.assertEquals(2, exitCode);
+      String output = stdout.toString(StandardCharsets.UTF_8.name());
+      Assert.assertTrue(output.contains("\"success\": false"));
+      Assert.assertTrue(output.contains("\"error\": \"usage_error\""));
+      Assert.assertTrue(output.contains("Invalid value for --network: beta"));
+    } finally {
+      System.setOut(originalOut);
+    }
+  }
 }

--- a/src/test/java/org/tron/walletcli/cli/GlobalOptionsTest.java
+++ b/src/test/java/org/tron/walletcli/cli/GlobalOptionsTest.java
@@ -60,7 +60,7 @@ public class GlobalOptionsTest {
   }
 
   @Test
-  public void parseNormalizesCommandAndPreservesPostCommandTokens() {
+  public void parseNormalizesCommandAndExtractsPostCommandGlobalOptions() {
     GlobalOptions opts = GlobalOptions.parse(new String[]{
         "--output", "json",
         "Get-Balance",
@@ -70,7 +70,121 @@ public class GlobalOptionsTest {
     });
 
     Assert.assertEquals("get-balance", opts.getCommand());
-    Assert.assertArrayEquals(new String[]{"--network=nile", "-h", "value"}, opts.getCommandArgs());
+    Assert.assertEquals("nile", opts.getNetwork());
+    Assert.assertArrayEquals(new String[]{"-h", "value"}, opts.getCommandArgs());
+  }
+
+  @Test
+  public void parseAllowsNetworkAfterCommand() {
+    GlobalOptions opts = GlobalOptions.parse(new String[]{
+        "gas-free-info",
+        "--network", "nile",
+        "--address", "TXYZ"
+    });
+
+    Assert.assertEquals("nile", opts.getNetwork());
+    Assert.assertEquals("gas-free-info", opts.getCommand());
+    Assert.assertArrayEquals(new String[]{"--address", "TXYZ"}, opts.getCommandArgs());
+  }
+
+  @Test
+  public void parseAllowsNetworkInlineAfterCommand() {
+    GlobalOptions opts = GlobalOptions.parse(new String[]{
+        "gas-free-info",
+        "--network=nile",
+        "--address", "TXYZ"
+    });
+
+    Assert.assertEquals("nile", opts.getNetwork());
+    Assert.assertEquals("gas-free-info", opts.getCommand());
+    Assert.assertArrayEquals(new String[]{"--address", "TXYZ"}, opts.getCommandArgs());
+  }
+
+  @Test
+  public void parseAllowsOutputAfterCommand() {
+    GlobalOptions opts = GlobalOptions.parse(new String[]{
+        "get-balance",
+        "--output", "json",
+        "--address", "TXYZ"
+    });
+
+    Assert.assertEquals("json", opts.getOutput());
+    Assert.assertEquals("get-balance", opts.getCommand());
+    Assert.assertArrayEquals(new String[]{"--address", "TXYZ"}, opts.getCommandArgs());
+  }
+
+  @Test
+  public void parseAllowsWalletAfterCommand() {
+    GlobalOptions opts = GlobalOptions.parse(new String[]{
+        "get-address",
+        "--wallet", "alpha"
+    });
+
+    Assert.assertEquals("alpha", opts.getWallet());
+    Assert.assertEquals("get-address", opts.getCommand());
+    Assert.assertArrayEquals(new String[0], opts.getCommandArgs());
+  }
+
+  @Test
+  public void parseAllowsGrpcEndpointAfterCommand() {
+    GlobalOptions opts = GlobalOptions.parse(new String[]{
+        "current-network",
+        "--grpc-endpoint", "127.0.0.1:50051"
+    });
+
+    Assert.assertEquals("127.0.0.1:50051", opts.getGrpcEndpoint());
+    Assert.assertEquals("current-network", opts.getCommand());
+    Assert.assertArrayEquals(new String[0], opts.getCommandArgs());
+  }
+
+  @Test
+  public void parseAllowsMixedGlobalOptionsBeforeAndAfterCommand() {
+    GlobalOptions opts = GlobalOptions.parse(new String[]{
+        "--output", "json",
+        "gas-free-info",
+        "--network", "nile",
+        "--address", "TXYZ",
+        "--wallet=alpha",
+        "--grpc-endpoint=127.0.0.1:50051",
+        "--verbose"
+    });
+
+    Assert.assertEquals("json", opts.getOutput());
+    Assert.assertEquals("nile", opts.getNetwork());
+    Assert.assertEquals("alpha", opts.getWallet());
+    Assert.assertEquals("127.0.0.1:50051", opts.getGrpcEndpoint());
+    Assert.assertTrue(opts.isVerbose());
+    Assert.assertEquals("gas-free-info", opts.getCommand());
+    Assert.assertArrayEquals(new String[]{"--address", "TXYZ"}, opts.getCommandArgs());
+  }
+
+  @Test
+  public void parseKeepsPostCommandHelpAsCommandArg() {
+    GlobalOptions opts = GlobalOptions.parse(new String[]{
+        "gas-free-info",
+        "--help"
+    });
+
+    Assert.assertFalse(opts.isHelp());
+    Assert.assertEquals("gas-free-info", opts.getCommand());
+    Assert.assertArrayEquals(new String[]{"--help"}, opts.getCommandArgs());
+  }
+
+  @Test
+  public void parseRejectsRepeatedGlobalOptionAcrossCommandBoundary() {
+    assertUsageError(new String[]{"--network", "nile", "get-balance", "--network", "main"},
+        "Repeated global option: --network");
+  }
+
+  @Test
+  public void parseLeavesUnknownPostCommandOptionForCommandParser() {
+    GlobalOptions opts = GlobalOptions.parse(new String[]{
+        "gas-free-info",
+        "--unknown", "value"
+    });
+
+    Assert.assertEquals("gas-free-info", opts.getCommand());
+    Assert.assertArrayEquals(new String[]{"--unknown", "value"}, opts.getCommandArgs());
   }
 
   @Test

--- a/src/test/java/org/tron/walletcli/cli/GlobalOptionsTest.java
+++ b/src/test/java/org/tron/walletcli/cli/GlobalOptionsTest.java
@@ -171,6 +171,44 @@ public class GlobalOptionsTest {
   }
 
   @Test
+  public void parseKeepsPostCommandVersionAsCommandArg() {
+    GlobalOptions opts = GlobalOptions.parse(new String[]{
+        "get-balance",
+        "--version"
+    });
+
+    Assert.assertFalse(opts.isVersion());
+    Assert.assertEquals("get-balance", opts.getCommand());
+    Assert.assertArrayEquals(new String[]{"--version"}, opts.getCommandArgs());
+  }
+
+  @Test
+  public void parseKeepsPostCommandInteractiveAsCommandArg() {
+    GlobalOptions opts = GlobalOptions.parse(new String[]{
+        "get-balance",
+        "--interactive"
+    });
+
+    Assert.assertFalse(opts.isInteractive());
+    Assert.assertEquals("get-balance", opts.getCommand());
+    Assert.assertArrayEquals(new String[]{"--interactive"}, opts.getCommandArgs());
+  }
+
+  @Test
+  public void parseTreatsPreCommandVersionAndInteractiveAsGlobalModes() {
+    GlobalOptions opts = GlobalOptions.parse(new String[]{
+        "--version",
+        "--interactive",
+        "get-balance"
+    });
+
+    Assert.assertTrue(opts.isVersion());
+    Assert.assertTrue(opts.isInteractive());
+    Assert.assertEquals("get-balance", opts.getCommand());
+    Assert.assertArrayEquals(new String[0], opts.getCommandArgs());
+  }
+
+  @Test
   public void parseRejectsRepeatedGlobalOptionAcrossCommandBoundary() {
     assertUsageError(new String[]{"--network", "nile", "get-balance", "--network", "main"},
         "Repeated global option: --network");

--- a/src/test/java/org/tron/walletcli/cli/OutputFormatterTest.java
+++ b/src/test/java/org/tron/walletcli/cli/OutputFormatterTest.java
@@ -147,6 +147,51 @@ public class OutputFormatterTest {
   }
 
   @Test
+  public void textModeQueryResultMessageOnlyRendersResult() throws Exception {
+    ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+    OutputFormatter formatter = new OutputFormatter(
+        OutputFormatter.OutputMode.TEXT, false, new PrintStream(stdout), System.err);
+    formatter.queryResult("Query successful !!", "plain text");
+    formatter.flush();
+
+    String output = stdout.toString(StandardCharsets.UTF_8.name());
+    Assert.assertTrue(output.contains("Query successful !!"));
+    Assert.assertTrue(output.contains("Result:"));
+    Assert.assertTrue(output.contains("\"message\""));
+    Assert.assertTrue(output.contains("plain text"));
+    Assert.assertFalse(output.contains("Metadata:"));
+  }
+
+  @Test
+  public void textModeQueryResultEmptyObjectRendersResult() throws Exception {
+    ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+    OutputFormatter formatter = new OutputFormatter(
+        OutputFormatter.OutputMode.TEXT, false, new PrintStream(stdout), System.err);
+    formatter.queryResult("Query successful !!", "{}");
+    formatter.flush();
+
+    String output = stdout.toString(StandardCharsets.UTF_8.name());
+    Assert.assertTrue(output.contains("Query successful !!"));
+    Assert.assertTrue(output.contains("Result:"));
+    Assert.assertTrue(output.contains("{}"));
+    Assert.assertFalse(output.contains("Metadata:"));
+  }
+
+  @Test
+  public void textModeQueryResultIndentsPrettyPrintedJsonLineFeeds() throws Exception {
+    ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+    OutputFormatter formatter = new OutputFormatter(
+        OutputFormatter.OutputMode.TEXT, false, new PrintStream(stdout), System.err);
+    formatter.queryResult("Query successful !!", "{\"a\":1,\"nested\":{\"b\":2}}");
+    formatter.flush();
+
+    String output = stdout.toString(StandardCharsets.UTF_8.name());
+    Assert.assertTrue(output.contains("  Result:"));
+    Assert.assertTrue(output.contains("\n  {"));
+    Assert.assertTrue(output.contains("\n    \"nested\""));
+  }
+
+  @Test
   public void textModeSuccessMessageOnlyPrintsMessage() throws Exception {
     ByteArrayOutputStream stdout = new ByteArrayOutputStream();
     OutputFormatter formatter = new OutputFormatter(

--- a/src/test/java/org/tron/walletcli/cli/OutputFormatterTest.java
+++ b/src/test/java/org/tron/walletcli/cli/OutputFormatterTest.java
@@ -32,11 +32,11 @@ public class OutputFormatterTest {
   }
 
   @Test
-  public void jsonArraysAreWrappedUnderResultField() throws Exception {
+  public void queryResultJsonArraysAreWrappedUnderResultField() throws Exception {
     ByteArrayOutputStream stdout = new ByteArrayOutputStream();
     OutputFormatter formatter = new OutputFormatter(
         OutputFormatter.OutputMode.JSON, false, new PrintStream(stdout), System.err);
-    formatter.printMessage("[1,2,3]", "failed");
+    formatter.queryResult("Query successful !!", "[1,2,3]");
     formatter.flush();
 
     String json = stdout.toString(StandardCharsets.UTF_8.name());
@@ -45,6 +45,20 @@ public class OutputFormatterTest {
     Assert.assertTrue(root.has("data") && root.get("data").isJsonObject());
     Assert.assertTrue(root.getAsJsonObject("data").has("result"));
     Assert.assertTrue(root.getAsJsonObject("data").get("result").isJsonArray());
+  }
+
+  @Test
+  public void queryResultJsonObjectUsesParsedDataInJsonMode() throws Exception {
+    ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+    OutputFormatter formatter = new OutputFormatter(
+        OutputFormatter.OutputMode.JSON, false, new PrintStream(stdout), System.err);
+    formatter.queryResult("Query successful !!", "{\"a\":1}");
+    formatter.flush();
+
+    String json = stdout.toString(StandardCharsets.UTF_8.name());
+    JsonObject root = JsonParser.parseString(json).getAsJsonObject();
+    Assert.assertTrue(root.get("success").getAsBoolean());
+    Assert.assertEquals(1, root.getAsJsonObject("data").get("a").getAsInt());
   }
 
   @Test
@@ -84,6 +98,52 @@ public class OutputFormatterTest {
     Assert.assertTrue(output.contains("Metadata:"));
     Assert.assertTrue(output.contains("txid : abc123"));
     Assert.assertFalse(output.contains("message :"));
+  }
+
+  @Test
+  public void textModeQueryResultFlatJsonObjectRendersMetadata() throws Exception {
+    ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+    OutputFormatter formatter = new OutputFormatter(
+        OutputFormatter.OutputMode.TEXT, false, new PrintStream(stdout), System.err);
+    formatter.queryResult("Query successful !!", "{\"a\":1,\"active\":true}");
+    formatter.flush();
+
+    String output = stdout.toString(StandardCharsets.UTF_8.name());
+    Assert.assertTrue(output.contains("Query successful !!"));
+    Assert.assertTrue(output.contains("Metadata:"));
+    Assert.assertTrue(output.contains("a      : 1"));
+    Assert.assertTrue(output.contains("active : true"));
+    Assert.assertFalse(output.contains("Result:"));
+  }
+
+  @Test
+  public void textModeQueryResultNestedJsonObjectRendersResult() throws Exception {
+    ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+    OutputFormatter formatter = new OutputFormatter(
+        OutputFormatter.OutputMode.TEXT, false, new PrintStream(stdout), System.err);
+    formatter.queryResult("Query successful !!", "{\"a\":1,\"nested\":{\"b\":2}}");
+    formatter.flush();
+
+    String output = stdout.toString(StandardCharsets.UTF_8.name());
+    Assert.assertTrue(output.contains("Query successful !!"));
+    Assert.assertTrue(output.contains("Result:"));
+    Assert.assertTrue(output.contains("\"nested\""));
+    Assert.assertFalse(output.contains("Metadata:"));
+  }
+
+  @Test
+  public void textModeQueryResultArrayRendersResult() throws Exception {
+    ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+    OutputFormatter formatter = new OutputFormatter(
+        OutputFormatter.OutputMode.TEXT, false, new PrintStream(stdout), System.err);
+    formatter.queryResult("Query successful !!", "[1,2,3]");
+    formatter.flush();
+
+    String output = stdout.toString(StandardCharsets.UTF_8.name());
+    Assert.assertTrue(output.contains("Query successful !!"));
+    Assert.assertTrue(output.contains("Result:"));
+    Assert.assertTrue(output.contains("\"result\""));
+    Assert.assertFalse(output.contains("Metadata:"));
   }
 
   @Test

--- a/src/test/java/org/tron/walletcli/cli/StandardCliRunnerTest.java
+++ b/src/test/java/org/tron/walletcli/cli/StandardCliRunnerTest.java
@@ -18,7 +18,6 @@ import org.tron.walletserver.WalletApi;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
@@ -117,6 +116,37 @@ public class StandardCliRunnerTest {
     Assert.assertSame(originalOut, System.out);
     Assert.assertSame(originalErr, System.err);
     Assert.assertSame(originalIn, System.in);
+  }
+
+  @Test
+  public void postCommandVersionAndInteractiveAreCommandUsageErrors() {
+    assertPostCommandModeFlagIsUsageError("--version");
+    assertPostCommandModeFlagIsUsageError("--interactive");
+  }
+
+  private void assertPostCommandModeFlagIsUsageError(String flag) {
+    CommandRegistry registry = new CommandRegistry();
+    registry.add(CommandDefinition.builder()
+        .authPolicy(CommandDefinition.AuthPolicy.NEVER)
+        .name("ok")
+        .description("Simple success command")
+        .handler((ctx, opts, wrapper, out) -> {
+          Map<String, Object> json = Collections.<String, Object>singletonMap("status", "ok");
+          out.success("ok", json);
+        })
+        .build());
+
+    ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+    ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+    GlobalOptions opts = GlobalOptions.parse(new String[]{"ok", flag});
+    int exitCode = new StandardCliRunner(
+        registry, opts, new PrintStream(stdout), new PrintStream(stderr)).execute();
+
+    Assert.assertEquals(2, exitCode);
+    Assert.assertEquals("", new String(stdout.toByteArray(), StandardCharsets.UTF_8));
+    String error = new String(stderr.toByteArray(), StandardCharsets.UTF_8);
+    Assert.assertTrue(error.contains("Error: Unknown option: " + flag));
+    Assert.assertTrue(error.contains("Usage:"));
   }
 
   @Test


### PR DESCRIPTION
1. GlobalOptions parses the full argv: after the command token, recognized globals (--network, --output, --wallet, --grpc-endpoint, etc.) are applied and removed from command args; --help/-h after the command are left for the command parser; unknown trailing flags pass through unchanged. Malformed or invalid values for known globals still fail at the global layer (validated globally).

2. Client.requestsJsonOutput no longer stops scanning at the first non-flag so post-command --output json is respected.

3. OutputFormatter adds queryResult(): text mode renders small flat primitive maps as Metadata, larger/nested/array payloads as indented Result: JSON; success/formatMessage-only paths wrap plain strings for TEXT JSON payloads.

4. QueryCommands and ContractCommands use queryResult for RPC-style successes; several protobuf paths now emit not_found when the RPC returns null.

5. Updates standard-cli-contract-spec and qa/contracts.tsv (post-command network succeeds; unknown post-command option stays command-local usage).

6. Adds GlobalOptions, OutputFormatter, and ClientMain tests for the above.