### PR TITLE
fix(permission): exclude disabled ContractType 51 and surface unknown ops in  UI

### DIFF
--- a/src/main/java/org/tron/core/manager/UpdateAccountPermissionInteractive.java
+++ b/src/main/java/org/tron/core/manager/UpdateAccountPermissionInteractive.java
@@ -86,6 +86,16 @@ public class UpdateAccountPermissionInteractive {
     operationsMap.put("59", "Cancel Unstake");
   }
 
+  private static String opLabel(int code) {
+    String name = operationsMap.get(String.valueOf(code));
+    return name != null ? name : "Unsupported/Disabled op " + code;
+  }
+
+  private static String contractTypeName(int code) {
+    ContractType type = ContractType.forNumber(code);
+    return type != null ? type.name() : "UNKNOWN";
+  }
+
   public String start(String address) {
     System.out.println("\n=== UpdateAccountPermission Interactive Mode ===");
     Response.Account account = WalletApi.queryAccount(WalletApi.decodeFromBase58Check(address));
@@ -105,7 +115,7 @@ public class UpdateAccountPermissionInteractive {
       active.setType(2);
       active.setPermissionName("active");
       active.setThreshold(1L);
-      active.setOperations("7fff1fc0033efb0f000000000000000000000000000000000000000000000000");
+      active.setOperations("7fff1fc0033ef30f000000000000000000000000000000000000000000000000");
       active.setKeys(Lists.newArrayList(new Key(address, 1L)));
       activePermissions = Lists.newArrayList(active);
     }
@@ -443,13 +453,12 @@ public class UpdateAccountPermissionInteractive {
     Collections.sort(currentOps);
 
     while (true) {
-      List<Integer> allowedOps = currentOps.stream()
-          .filter(i -> operationsMap.get(String.valueOf(i)) != null).sorted().collect(Collectors.toList());
+      List<Integer> allowedOps = currentOps.stream().sorted().collect(Collectors.toList());
       System.out.println("\nCurrent allowed operations:");
       for (int i = 0; i < allowedOps.size(); i++) {
         int code = allowedOps.get(i);
-        System.out.println((i + 1) + ". " + operationsMap.get(String.valueOf(code))
-            + " -> " + ContractType.forNumber(code).name() + "(" + code + ")");
+        System.out.println((i + 1) + ". " + opLabel(code)
+            + " -> " + contractTypeName(code) + "(" + code + ")");
       }
 
       System.out.println("\nOperations editing (enter 'q' to finish editing operations):");
@@ -471,8 +480,8 @@ public class UpdateAccountPermissionInteractive {
         System.out.println("Current operations that can be deleted:");
         for (int i = 0; i < allowedOps.size(); i++) {
           int code = allowedOps.get(i);
-          System.out.println((i + 1) + ". " + operationsMap.get(String.valueOf(code))
-              + " -> " + ContractType.forNumber(code).name() + "(" + code + ")");
+          System.out.println((i + 1) + ". " + opLabel(code)
+              + " -> " + contractTypeName(code) + "(" + code + ")");
         }
 
         System.out.print("Enter indexes to delete (comma separated), or 'q' to cancel: ");
@@ -698,9 +707,7 @@ public class UpdateAccountPermissionInteractive {
       System.out.println("  Operations : (none)");
     } else {
       String opsDisplay = ops.stream()
-          .map(String::valueOf)
-          .filter(operationsMap::containsKey)
-          .map(operationsMap::get)
+          .map(UpdateAccountPermissionInteractive::opLabel)
           .collect(Collectors.joining(", "));
       System.out.println("  Operations : " + opsDisplay);
     }
@@ -814,11 +821,7 @@ public class UpdateAccountPermissionInteractive {
     } else {
       System.out.println("  Operations :");
       for (Integer code : ops) {
-        String name = operationsMap.get(String.valueOf(code));
-        if (name == null) {
-          continue;
-        }
-        System.out.printf("      - %-3d (%s)%n", code, name);
+        System.out.printf("      - %-3d (%s)%n", code, opLabel(code));
       }
     }
     System.out.println("  Threshold  : " + p.getThreshold());


### PR DESCRIPTION
## Summary

Fixes two related problems in the interactive `updateaccountpermission` flow, both stemming from how the active-permission operations bitmap is handled.

## 1. Default active permission grants a disabled ContractType 

When an account has **no existing active permission**, the flow applied a hardcoded default operations bitmap that granted **ContractType 51 (ShieldedTransferContract)**. Shielded transfer is disabled on mainnet and most networks, so the node rejected the whole `AccountPermissionUpdate`:

```
CONTRACT_VALIDATE_ERROR, Contract validate error : 51 isn't a validate ContractType
UpdateAccountPermission  failed !!!
```

This triggered even when the user only edited owner_permission, because the default active permission is auto-applied.

**Fix:** clear bit 51 in the default bitmap (`UpdateAccountPermissionInteractive.java`): byte index 6 `0xfb` -> `0xf3`, i.e. `7fff1fc0033efb0f...` -> `7fff1fc0033ef30f...`. This matches the canonical `ALL_OPERATIONS` / `AVAILABLE_OPERATIONS` lists in the same file, which already exclude 51.

## 2. Unknown/disabled ops were silently hidden and undeletable in the UI

Operations absent from `operationsMap` (such as the disabled ContractType 51) were filtered out of the preview and the edit/delete menus. As a result a user could neither **see** nor **remove** such an op through the interactive UI — making the problem above impossible to self-diagnose or fix manually.

**Fix:** add `opLabel(code)` and `contractTypeName(code)` helpers and render every operation with a visible placeholder (e.g. `Unsupported/Disabled op 51`) instead of dropping it. Four sites updated:
- "Current allowed operations" list in `editActivePermissions` (removed the silent `.filter(...)`)
- the delete list
- `printPermissionSummary` preview
- `printPermissionDetail` final preview

An unknown/disabled op is now visible and deletable.

## Verification

- Decoded both bitmaps: **only** op 51 is removed; no other bits change.
- `./gradlew compileJava` passes.
- No tests pinned the old bitmap string.

## Scope

- Single file changed: `UpdateAccountPermissionInteractive.java`.
- The add-operation menu already sources from `AVAILABLE_OPERATIONS` (which excludes 51), so it was left unchanged.

Fixes #934 