### PR TITLE
test(permission): cover default active operation bitmap

### DIFF
--- a/src/main/java/org/tron/core/manager/UpdateAccountPermissionInteractive.java
+++ b/src/main/java/org/tron/core/manager/UpdateAccountPermissionInteractive.java
@@ -44,6 +44,8 @@ public class UpdateAccountPermissionInteractive {
       41, 42, 43, 44, 45, 46, 48, 49, 52, 53, 54,
       55, 56, 57, 58, 59
   );
+  static final String DEFAULT_ACTIVE_OPERATIONS =
+      "7fff1fc0033ef30f000000000000000000000000000000000000000000000000";
   public static final Map<String, String> operationsMap = new HashMap<>();
 
   static {
@@ -86,9 +88,15 @@ public class UpdateAccountPermissionInteractive {
     operationsMap.put("59", "Cancel Unstake");
   }
 
-  private static String opLabel(int code) {
+  static String opLabel(int code) {
     String name = operationsMap.get(String.valueOf(code));
-    return name != null ? name : "Unsupported/Disabled op " + code;
+    if (name != null) {
+      return name;
+    }
+    ContractType type = ContractType.forNumber(code);
+    return type != null
+        ? "Unlisted op " + code + " (" + type.name() + ")"
+        : "Unknown op " + code;
   }
 
   private static String contractTypeName(int code) {
@@ -115,7 +123,7 @@ public class UpdateAccountPermissionInteractive {
       active.setType(2);
       active.setPermissionName("active");
       active.setThreshold(1L);
-      active.setOperations("7fff1fc0033ef30f000000000000000000000000000000000000000000000000");
+      active.setOperations(DEFAULT_ACTIVE_OPERATIONS);
       active.setKeys(Lists.newArrayList(new Key(address, 1L)));
       activePermissions = Lists.newArrayList(active);
     }

--- a/src/test/java/org/tron/core/manager/UpdateAccountPermissionInteractiveTest.java
+++ b/src/test/java/org/tron/core/manager/UpdateAccountPermissionInteractiveTest.java
@@ -1,0 +1,28 @@
+package org.tron.core.manager;
+
+import static org.tron.common.utils.ByteUtil.hexStringToIntegerList;
+
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class UpdateAccountPermissionInteractiveTest {
+
+  @Test
+  public void defaultActiveOperationsExcludeShieldedTransferContract() {
+    List<Integer> operations =
+        hexStringToIntegerList(UpdateAccountPermissionInteractive.DEFAULT_ACTIVE_OPERATIONS);
+
+    Assert.assertFalse(operations.contains(51));
+    Assert.assertTrue(operations.contains(49));
+    Assert.assertTrue(operations.contains(52));
+  }
+
+  @Test
+  public void opLabelDistinguishesUnlistedAndUnknownOperations() {
+    Assert.assertEquals("Transfer TRX", UpdateAccountPermissionInteractive.opLabel(1));
+    Assert.assertEquals("Unlisted op 51 (ShieldedTransferContract)",
+        UpdateAccountPermissionInteractive.opLabel(51));
+    Assert.assertEquals("Unknown op 255", UpdateAccountPermissionInteractive.opLabel(255));
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up to #935.

- Extract the default active-permission operations bitmap into a named constant.
- Use clearer labels for operations that are present in the bitmap but not listed in the wallet-cli friendly label map.
- Add regression coverage to ensure the default active bitmap does not include ContractType 51 again.

## Notes

The wording now distinguishes enum-backed unlisted operations from truly unknown operation codes:
- `Unlisted op 51 (ShieldedTransferContract)`
- `Unknown op 255`

## Verification

- `git diff --check`
- Attempted `./gradlew test --tests org.tron.core.manager.UpdateAccountPermissionInteractiveTest`, but this local machine does not have a Java Runtime installed.