### PR TITLE
feat(crypto): add post-quantum signature support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1790,21 +1790,26 @@ password:
 fileName = TYQq6zp51unQDNELmT4xKMWh5WLcwpCDZJ.json
 importWalletByKeystore successful !!
 ```
-## Post-quantum signatures (Falcon-512 / FN-DSA-512)
+## Post-quantum signatures (FN-DSA-512 / ML-DSA-44)
 
-Wallet-cli supports post-quantum signatures based on Falcon-512 (scheme tag `FN_DSA_512`),
-the same scheme accepted on-chain when the `ALLOW_FN_DSA_512` proposal is active on the
-target network. PQ wallets are stored in the regular `Wallet/` keystore directory with the
-same scrypt+AES-CTR encryption as ECKey/SM2 wallets; the keystore JSON carries a
-`"scheme":"FN_DSA_512"` discriminator so dispatch is per-wallet, not network-wide.
+Wallet-cli supports post-quantum signatures with two NIST-standardised schemes:
 
-PQ key sizes (Falcon-512):
+- **`FN_DSA_512`** — Falcon-512 (FIPS-206 draft). Accepted on-chain when the
+  `ALLOW_FN_DSA_512` proposal is active.
+- **`ML_DSA_44`** — ML-DSA-44 / CRYSTALS-Dilithium-2 (FIPS-204). Accepted on-chain
+  when the `ALLOW_ML_DSA_44` proposal is active.
 
-- seed: 48 bytes
-- public key: 896 bytes
-- private key (`f‖g‖F`): 1280 bytes
-- extended private key (`f‖g‖F‖h`, what the keystore stores): 2176 bytes
-- signature: up to 752 bytes
+PQ wallets are stored in the regular `Wallet/` keystore directory with the same
+scrypt+AES-CTR encryption as ECKey/SM2 wallets; the keystore JSON carries a
+`"scheme"` discriminator (`"FN_DSA_512"` or `"ML_DSA_44"`) so dispatch is per-wallet,
+not network-wide.
+
+PQ key sizes:
+
+| Scheme       | seed | public key | private key (on-disk persisted form)                        | signature                |
+|--------------|------|-----------:|-------------------------------------------------------------|--------------------------|
+| `FN_DSA_512` | 48 B |      896 B | 2176 B — extended `f‖g‖F‖h` (h appended so BC can recover pk) | variable, up to 666 B    |
+| `ML_DSA_44`  | 32 B |     1312 B | 2560 B — encoded `rho‖K‖tr‖s1‖s2‖t0` (pk re-derivable from it) | fixed 2420 B             |
 
 The address is derived with the same formula as ECDSA / SM2:
 `0x41 ‖ Keccak-256(public_key)[12..32]`, so a PQ address is indistinguishable from a
@@ -1814,31 +1819,35 @@ regular T-address until it signs a transaction (PQ signatures land in
 ### Generate a PQ keypair (no keystore)
 
     >GeneratePQKey [scheme]
-> Generate a Falcon-512 keypair and print the address, public key and extended private key.
-The scheme defaults to `FN_DSA_512` if omitted. The key is **not** persisted — use this for
-inspection or to seed an `ImportWalletPQ` flow.
+> Generate a PQ keypair and print the address, public key and persisted private key.
+The scheme defaults to `FN_DSA_512` if omitted; pass `ML_DSA_44` to get a Dilithium-2
+keypair. The key is **not** persisted — use this for inspection or to seed an
+`ImportWalletPQ` flow.
 
 Example:
 ```console
-wallet> GeneratePQKey
-Scheme:        FN_DSA_512
-Address:       TXxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-PublicKey:     <896 bytes hex (1792 hex chars)>
-PrivateKey:    <2176 bytes hex (4352 hex chars; extended form f||g||F||h)>
+wallet> GeneratePQKey ML_DSA_44
+scheme:        ML_DSA_44
+address:       TXxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+seed (32 bytes):                <64 hex chars>
+publicKey (1312 bytes):         <2624 hex chars>
+privateKey (2560 bytes):        <5120 hex chars>
+privateKey persisted form ...:  <5120 hex chars>
 
-WARNING: store the private key securely. It is the only way to spend from this address.
+WARNING: store either the seed or the persisted private key securely.
 ```
 
 ### Register a PQ wallet (creates a keystore)
 
     >RegisterWalletPQ [scheme]
-> Generate a fresh Falcon-512 keypair, prompt for a password (twice) and write an encrypted
+> Generate a fresh PQ keypair, prompt for a password (twice) and write an encrypted
 keystore file under `Wallet/`. After registration you can `Login` with the resulting
 address and password just like any other wallet.
 
-Example:
+Examples:
 ```console
-wallet> RegisterWalletPQ
+wallet> RegisterWalletPQ                # defaults to FN_DSA_512
+wallet> RegisterWalletPQ ML_DSA_44
 Please input password.
 password:
 Please input password again.
@@ -1846,78 +1855,89 @@ password:
 RegisterWalletPQ successful, keystore file: ./Wallet/TXxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.json
 ```
 
-### Import a PQ wallet from a seed or extended private key
+### Import a PQ wallet from a seed or persisted private key
 
-    >ImportWalletPQ [scheme] <seed_or_extended_private_key_hex_or_file>
-> Import an existing Falcon-512 keypair. The argument is **required** and may be
-either the hex string itself or a path to a file containing it. The format is
-auto-detected by length:
+    >ImportWalletPQ [scheme] <seed_or_persisted_private_key_hex_or_file>
+> Import an existing PQ keypair. The argument is **required** and may be either the
+hex string itself or a path to a file containing it. The format is auto-detected by
+length against the chosen scheme:
 >
-> - **48 bytes / 96 hex chars** — a Falcon-512 seed; the full keypair is derived
->   deterministically (BC `FixedSecureRandom`-driven `FalconKeyPairGenerator`).
-> - **2176 bytes / 4352 hex chars** — the full extended private key (`f‖g‖F‖h`),
->   used verbatim.
+> - **FN_DSA_512**: 48-byte / 96-hex-char seed (derives the full keypair
+>   deterministically), or 2176-byte / 4352-hex-char extended private key
+>   (`f‖g‖F‖h`, used verbatim).
+> - **ML_DSA_44**: 32-byte / 64-hex-char seed, or 2560-byte / 5120-hex-char
+>   encoded private key (`rho‖K‖tr‖s1‖s2‖t0`).
 >
-> **Why no interactive prompt?** The 4352-hex-char extended form exceeds the
-typical TTY canonical-mode line buffer (~1024 chars on macOS) and gets silently
-truncated by the kernel. The command therefore only accepts the hex (or a file
-path) as a CLI argument.
+> **Why no interactive prompt?** The persisted-private-key hex exceeds the typical
+TTY canonical-mode line buffer (~1024 chars on macOS) and gets silently truncated
+by the kernel. The command therefore only accepts the hex (or a file path) as a
+CLI argument.
 
 Examples:
 ```console
-# Import from a 96-hex-char seed (short — fine on a single line)
-wallet> ImportWalletPQ FN_DSA_512 0102030405060708...   (96 hex chars)
-Please input password.
-password:
-Please input password again.
-password:
-ImportWalletPQ successful, keystore file: ./Wallet/TXxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.json
+# Falcon-512 seed (96 hex chars — fine on a single line)
+wallet> ImportWalletPQ FN_DSA_512 0102030405060708...
 
-# Import from a file containing the seed or extended private key
+# ML-DSA-44 seed
+wallet> ImportWalletPQ ML_DSA_44 0102030405060708...   (64 hex chars)
+
+# From a file containing the seed or persisted private key
 wallet> ImportWalletPQ FN_DSA_512 /tmp/my-falcon-seed.hex
 wallet> ImportWalletPQ FN_DSA_512 /tmp/my-falcon-extpriv.hex
+wallet> ImportWalletPQ ML_DSA_44  /tmp/my-mldsa-seed.hex
+wallet> ImportWalletPQ ML_DSA_44  /tmp/my-mldsa-priv.hex
 ```
 
 ### Signing transactions with a PQ wallet
 
 Once you are logged in to a PQ keystore, the normal commands (`SendCoin`,
-`TransferAsset`, `TriggerContract`, `AddTransactionSign`, …) sign with Falcon-512
-transparently and route the signature into `Transaction.pq_auth_sig`. The
+`TransferAsset`, `TriggerContract`, `AddTransactionSign`, …) sign with the wallet's
+scheme transparently and route the signature into `Transaction.pq_auth_sig`. The
 `isEckey` selector is bypassed for the active PQ wallet, so you can mix PQ wallets
 and ECKey/SM2 wallets in the same multi-sign session — each contributor signs with
 the algorithm that matches their own keystore.
 
-> **Note:** transactions signed by a PQ wallet are only accepted on networks where the
-`ALLOW_FN_DSA_512` proposal is active. Against a node that does not understand the
-proposal, the transaction will be rejected even though wallet-cli builds and signs it
-correctly.
+> **Note:** transactions signed by a PQ wallet are only accepted on networks where
+the matching proposal is active (`ALLOW_FN_DSA_512` for Falcon-512,
+`ALLOW_ML_DSA_44` for ML-DSA-44). Against a node that does not understand the
+proposal, the transaction will be rejected even though wallet-cli builds and signs
+it correctly.
 
 ### Standard CLI (non-interactive)
 
-The standard CLI exposes the same three operations as scriptable commands. They use the
-same `MASTER_PASSWORD` environment variable for non-interactive password entry as the
-other `*-wallet` commands.
+The standard CLI exposes the same three operations as scriptable commands. They
+use the same `MASTER_PASSWORD` environment variable for non-interactive password
+entry as the other `*-wallet` commands. Pass `--scheme ML_DSA_44` to opt into
+Dilithium-2; the default remains `FN_DSA_512`.
 
 ```bash
 # Generate a keypair and print JSON (no keystore is written)
 java -jar build/libs/wallet-cli.jar --output json generate-pq-key
 java -jar build/libs/wallet-cli.jar --output json generate-pq-key --scheme FN_DSA_512
+java -jar build/libs/wallet-cli.jar --output json generate-pq-key --scheme ML_DSA_44
 
 # Create an encrypted PQ keystore
 MASTER_PASSWORD='testpassword123A' \
   java -jar build/libs/wallet-cli.jar --output json register-wallet-pq --name pqalice
+MASTER_PASSWORD='testpassword123A' \
+  java -jar build/libs/wallet-cli.jar --output json register-wallet-pq \
+    --name pqalice --scheme ML_DSA_44
 
-# Import an existing keypair from its extended-private-key hex
+# Import an existing keypair from its persisted-private-key (or seed) hex
 MASTER_PASSWORD='testpassword123A' \
   java -jar build/libs/wallet-cli.jar --output json import-wallet-pq \
     --name pqalice \
-    --extended-private-key-hex <4352-hex-char string>
+    --extended-private-key-hex <persisted-private-key or seed hex>
+MASTER_PASSWORD='testpassword123A' \
+  java -jar build/libs/wallet-cli.jar --output json import-wallet-pq \
+    --name pqalice --scheme ML_DSA_44 \
+    --extended-private-key-hex <ML-DSA-44 seed or encoded private key hex>
 ```
 
 `generate-pq-key` returns a JSON envelope containing `scheme`, `address`,
 `public_key_hex`, and `private_key_hex`. `register-wallet-pq` and
-`import-wallet-pq` return the keystore filename and the derived address, exactly like
-the standard-CLI `register-wallet` / `import-wallet` commands.
+`import-wallet-pq` return the keystore filename and the derived address, exactly
+like the standard-CLI `register-wallet` / `import-wallet` commands.
 
 ## import wallet by ledger
     >ImportWalletByLedger

--- a/README.md
+++ b/README.md
@@ -1857,7 +1857,7 @@ auto-detected by length:
 >   deterministically (BC `FixedSecureRandom`-driven `FalconKeyPairGenerator`).
 > - **2176 bytes / 4352 hex chars** — the full extended private key (`f‖g‖F‖h`),
 >   used verbatim.
-
+>
 > **Why no interactive prompt?** The 4352-hex-char extended form exceeds the
 typical TTY canonical-mode line buffer (~1024 chars on macOS) and gets silently
 truncated by the kernel. The command therefore only accepts the hex (or a file

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ For more information on a specific command, just type the command in the termina
 |                    [ViewBackupRecords](#View-backup-records)                     |                [ViewTransactionHistory](#View-transaction-history)                |                             [VoteWitness](#How-to-vote)                             |
 |                       [WithdrawBalance](#withdraw-balance)                       |                [WithdrawExpireUnfreeze](#withdraw-expire-unfreeze)                |                      [TronlinkMultiSign](#tronlink-multi-sign)                      |                                                 
 |                     [EncodingConverter](#encoding-converter)                     |        [GetPrivateKeyByMnemonic](#How-to-get-privateKey-through-mnemonic)         |            [GetPaginatedNowWitnessList](#Get-paginated-now-witness-list)            |                                                 
+|     [GeneratePQKey](#post-quantum-signatures-falcon-512--fn-dsa-512)              |   [RegisterWalletPQ](#post-quantum-signatures-falcon-512--fn-dsa-512)             |   [ImportWalletPQ](#post-quantum-signatures-falcon-512--fn-dsa-512)                 |
 
 
 Type any one of the listed commands, to display how-to tips.
@@ -1845,23 +1846,36 @@ password:
 RegisterWalletPQ successful, keystore file: ./Wallet/TXxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.json
 ```
 
-### Import a PQ wallet from an extended private key
+### Import a PQ wallet from a seed or extended private key
 
-    >ImportWalletPQ [scheme]
-> Import an existing Falcon-512 keypair from the 2176-byte extended private key
-(hex-encoded). You will be prompted for the hex string (or pass it as a second argument)
-and for a password to encrypt the resulting keystore.
+    >ImportWalletPQ [scheme] <seed_or_extended_private_key_hex_or_file>
+> Import an existing Falcon-512 keypair. The argument is **required** and may be
+either the hex string itself or a path to a file containing it. The format is
+auto-detected by length:
+>
+> - **48 bytes / 96 hex chars** — a Falcon-512 seed; the full keypair is derived
+>   deterministically (BC `FixedSecureRandom`-driven `FalconKeyPairGenerator`).
+> - **2176 bytes / 4352 hex chars** — the full extended private key (`f‖g‖F‖h`),
+>   used verbatim.
 
-Example:
+> **Why no interactive prompt?** The 4352-hex-char extended form exceeds the
+typical TTY canonical-mode line buffer (~1024 chars on macOS) and gets silently
+truncated by the kernel. The command therefore only accepts the hex (or a file
+path) as a CLI argument.
+
+Examples:
 ```console
-wallet> ImportWalletPQ FN_DSA_512
-Please input the extended private key (priv||pub hex):
-<paste 4352 hex chars>
+# Import from a 96-hex-char seed (short — fine on a single line)
+wallet> ImportWalletPQ FN_DSA_512 0102030405060708...   (96 hex chars)
 Please input password.
 password:
 Please input password again.
 password:
 ImportWalletPQ successful, keystore file: ./Wallet/TXxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.json
+
+# Import from a file containing the seed or extended private key
+wallet> ImportWalletPQ FN_DSA_512 /tmp/my-falcon-seed.hex
+wallet> ImportWalletPQ FN_DSA_512 /tmp/my-falcon-extpriv.hex
 ```
 
 ### Signing transactions with a PQ wallet

--- a/README.md
+++ b/README.md
@@ -1789,6 +1789,122 @@ password:
 fileName = TYQq6zp51unQDNELmT4xKMWh5WLcwpCDZJ.json
 importWalletByKeystore successful !!
 ```
+## Post-quantum signatures (Falcon-512 / FN-DSA-512)
+
+Wallet-cli supports post-quantum signatures based on Falcon-512 (scheme tag `FN_DSA_512`),
+the same scheme accepted on-chain when the `ALLOW_FN_DSA_512` proposal is active on the
+target network. PQ wallets are stored in the regular `Wallet/` keystore directory with the
+same scrypt+AES-CTR encryption as ECKey/SM2 wallets; the keystore JSON carries a
+`"scheme":"FN_DSA_512"` discriminator so dispatch is per-wallet, not network-wide.
+
+PQ key sizes (Falcon-512):
+
+- seed: 48 bytes
+- public key: 896 bytes
+- private key (`f‖g‖F`): 1280 bytes
+- extended private key (`f‖g‖F‖h`, what the keystore stores): 2176 bytes
+- signature: up to 752 bytes
+
+The address is derived with the same formula as ECDSA / SM2:
+`0x41 ‖ Keccak-256(public_key)[12..32]`, so a PQ address is indistinguishable from a
+regular T-address until it signs a transaction (PQ signatures land in
+`Transaction.pq_auth_sig` instead of `Transaction.signature`).
+
+### Generate a PQ keypair (no keystore)
+
+    >GeneratePQKey [scheme]
+> Generate a Falcon-512 keypair and print the address, public key and extended private key.
+The scheme defaults to `FN_DSA_512` if omitted. The key is **not** persisted — use this for
+inspection or to seed an `ImportWalletPQ` flow.
+
+Example:
+```console
+wallet> GeneratePQKey
+Scheme:        FN_DSA_512
+Address:       TXxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+PublicKey:     <896 bytes hex (1792 hex chars)>
+PrivateKey:    <2176 bytes hex (4352 hex chars; extended form f||g||F||h)>
+
+WARNING: store the private key securely. It is the only way to spend from this address.
+```
+
+### Register a PQ wallet (creates a keystore)
+
+    >RegisterWalletPQ [scheme]
+> Generate a fresh Falcon-512 keypair, prompt for a password (twice) and write an encrypted
+keystore file under `Wallet/`. After registration you can `Login` with the resulting
+address and password just like any other wallet.
+
+Example:
+```console
+wallet> RegisterWalletPQ
+Please input password.
+password:
+Please input password again.
+password:
+RegisterWalletPQ successful, keystore file: ./Wallet/TXxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.json
+```
+
+### Import a PQ wallet from an extended private key
+
+    >ImportWalletPQ [scheme]
+> Import an existing Falcon-512 keypair from the 2176-byte extended private key
+(hex-encoded). You will be prompted for the hex string (or pass it as a second argument)
+and for a password to encrypt the resulting keystore.
+
+Example:
+```console
+wallet> ImportWalletPQ FN_DSA_512
+Please input the extended private key (priv||pub hex):
+<paste 4352 hex chars>
+Please input password.
+password:
+Please input password again.
+password:
+ImportWalletPQ successful, keystore file: ./Wallet/TXxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.json
+```
+
+### Signing transactions with a PQ wallet
+
+Once you are logged in to a PQ keystore, the normal commands (`SendCoin`,
+`TransferAsset`, `TriggerContract`, `AddTransactionSign`, …) sign with Falcon-512
+transparently and route the signature into `Transaction.pq_auth_sig`. The
+`isEckey` selector is bypassed for the active PQ wallet, so you can mix PQ wallets
+and ECKey/SM2 wallets in the same multi-sign session — each contributor signs with
+the algorithm that matches their own keystore.
+
+> **Note:** transactions signed by a PQ wallet are only accepted on networks where the
+`ALLOW_FN_DSA_512` proposal is active. Against a node that does not understand the
+proposal, the transaction will be rejected even though wallet-cli builds and signs it
+correctly.
+
+### Standard CLI (non-interactive)
+
+The standard CLI exposes the same three operations as scriptable commands. They use the
+same `MASTER_PASSWORD` environment variable for non-interactive password entry as the
+other `*-wallet` commands.
+
+```bash
+# Generate a keypair and print JSON (no keystore is written)
+java -jar build/libs/wallet-cli.jar --output json generate-pq-key
+java -jar build/libs/wallet-cli.jar --output json generate-pq-key --scheme FN_DSA_512
+
+# Create an encrypted PQ keystore
+MASTER_PASSWORD='testpassword123A' \
+  java -jar build/libs/wallet-cli.jar --output json register-wallet-pq --name pqalice
+
+# Import an existing keypair from its extended-private-key hex
+MASTER_PASSWORD='testpassword123A' \
+  java -jar build/libs/wallet-cli.jar --output json import-wallet-pq \
+    --name pqalice \
+    --extended-private-key-hex <4352-hex-char string>
+```
+
+`generate-pq-key` returns a JSON envelope containing `scheme`, `address`,
+`public_key_hex`, and `private_key_hex`. `register-wallet-pq` and
+`import-wallet-pq` return the keystore filename and the derived address, exactly like
+the standard-CLI `register-wallet` / `import-wallet` commands.
+
 ## import wallet by ledger
     >ImportWalletByLedger
 >import the derived account of ledger to wallet-cli

--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ dependencies {
     implementation group: 'com.google.code.gson', name: 'gson', version: '2.11.0'
 
     implementation group: 'com.googlecode.protobuf-java-format', name: 'protobuf-java-format', version: '1.4'
-    implementation group: 'org.bouncycastle', name: 'bcprov-jdk18on', version: '1.78.1'
+    implementation group: 'org.bouncycastle', name: 'bcprov-jdk18on', version: '1.84'
     implementation group: 'com.typesafe', name: 'config', version: '1.3.2'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.14.0'
     implementation group: 'com.alibaba', name: 'fastjson', version: '1.2.83'

--- a/src/main/java/org/tron/common/crypto/Hash.java
+++ b/src/main/java/org/tron/common/crypto/Hash.java
@@ -23,7 +23,6 @@ import static java.util.Arrays.copyOfRange;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
-import java.security.Security;
 import lombok.extern.slf4j.Slf4j;
 import org.tron.common.crypto.jce.TronCastleProvider;
 import org.tron.common.utils.ByteArray;
@@ -38,7 +37,6 @@ public class Hash {
   private static final String HASH_512_ALGORITHM_NAME;
 
   static {
-    Security.addProvider(TronCastleProvider.getInstance());
     CRYPTO_PROVIDER = TronCastleProvider.getInstance();
     HASH_256_ALGORITHM_NAME = "TRON-KECCAK-256";
     HASH_512_ALGORITHM_NAME = "TRON-KECCAK-512";

--- a/src/main/java/org/tron/common/crypto/Hash.java
+++ b/src/main/java/org/tron/common/crypto/Hash.java
@@ -39,7 +39,7 @@ public class Hash {
 
   static {
     Security.addProvider(TronCastleProvider.getInstance());
-    CRYPTO_PROVIDER = Security.getProvider("BC");
+    CRYPTO_PROVIDER = TronCastleProvider.getInstance();
     HASH_256_ALGORITHM_NAME = "TRON-KECCAK-256";
     HASH_512_ALGORITHM_NAME = "TRON-KECCAK-512";
   }

--- a/src/main/java/org/tron/common/crypto/jce/TronCastleProvider.java
+++ b/src/main/java/org/tron/common/crypto/jce/TronCastleProvider.java
@@ -36,15 +36,12 @@ public final class TronCastleProvider {
 
             INSTANCE = (p != null) ? p : new BouncyCastleProvider();
 
-            INSTANCE.put("MessageDigest.TRON-KECCAK-256", "org.tron.common.crypto.cryptohash.Keccak256");
-            INSTANCE.put("MessageDigest.TRON-KECCAK-512", "org.tron.common.crypto.cryptohash.Keccak512");
+            INSTANCE.put("MessageDigest.TRON-KECCAK-256",
+                "org.tron.common.crypto.cryptohash.Keccak256");
+            INSTANCE.put("MessageDigest.TRON-KECCAK-512",
+                "org.tron.common.crypto.cryptohash.Keccak512");
 
-            if (p == null) {
-                Security.addProvider(INSTANCE);
-            } else {
-                Security.removeProvider("BC");
-                Security.addProvider(INSTANCE);
-            }
+            Security.addProvider(INSTANCE);
         }
     }
 }

--- a/src/main/java/org/tron/common/crypto/jce/TronCastleProvider.java
+++ b/src/main/java/org/tron/common/crypto/jce/TronCastleProvider.java
@@ -36,10 +36,15 @@ public final class TronCastleProvider {
 
             INSTANCE = (p != null) ? p : new BouncyCastleProvider();
 
-            INSTANCE.put("MessageDigest.TRON-KECCAK-256", "org.tron.common.crypto" +
-                    ".cryptohash.Keccak256");
-            INSTANCE.put("MessageDigest.TRON-KECCAK-512", "org.tron.common.crypto" +
-                    ".cryptohash.Keccak512");
+            INSTANCE.put("MessageDigest.TRON-KECCAK-256", "org.tron.common.crypto.cryptohash.Keccak256");
+            INSTANCE.put("MessageDigest.TRON-KECCAK-512", "org.tron.common.crypto.cryptohash.Keccak512");
+
+            if (p == null) {
+                Security.addProvider(INSTANCE);
+            } else {
+                Security.removeProvider("BC");
+                Security.addProvider(INSTANCE);
+            }
         }
     }
 }

--- a/src/main/java/org/tron/common/crypto/pqc/FNDSA512.java
+++ b/src/main/java/org/tron/common/crypto/pqc/FNDSA512.java
@@ -21,14 +21,14 @@ import org.tron.protos.Protocol.PQScheme;
  *
  * <p>Falcon signatures are <strong>variable-length</strong>: every accepted
  * signature must fall within {@code [}{@link #SIGNATURE_MIN_LENGTH}{@code ,}
- * {@link #SIGNATURE_LENGTH}{@code ]}. {@link #SIGNATURE_LENGTH} (666) matches
- * the java-tron {@code ALLOW_FN_DSA_512} chain cap and the canonical Falcon
- * Round-3 / FIPS-206 draft {@code sbytelen} for Falcon-512;
- * {@link #SIGNATURE_MIN_LENGTH} (41) is the smallest syntactically well-formed
- * encoding. BC's signer does not implement Falcon's rejection step on
- * over-length outputs (its internal buffer permits up to 689 B);
- * {@link #sign(byte[], byte[])} adds that loop so produced signatures always
- * respect the canonical cap.
+ * {@link #SIGNATURE_MAX_LENGTH}{@code ]}. {@link #SIGNATURE_MAX_LENGTH} (667) is
+ * the TRON/EIP-8052 upper bound after re-inserting Falcon's stripped header byte
+ * into a 666-byte headerless slot; {@link #SIGNATURE_MIN_LENGTH} (617) is the
+ * smallest syntactically well-formed compressed encoding (header byte + 40-byte
+ * nonce + 512 minimal {@code compressed_s2} coefficients).
+ * BouncyCastle does not implement Falcon's spec-mandated rejection sampling
+ * (its internal buffer permits up to 689 B); {@link #sign(byte[], byte[])} adds
+ * that loop so produced signatures always respect the canonical cap.
  */
 public final class FNDSA512 implements PQSignature {
 
@@ -55,23 +55,34 @@ public final class FNDSA512 implements PQSignature {
   public static final int PRIVATE_KEY_WITH_PUBLIC_KEY_LENGTH =
       PRIVATE_KEY_LENGTH + PUBLIC_KEY_LENGTH;
   /**
-   * Canonical maximum Falcon-512 signature length per Falcon Round-3 / FIPS-206
-   * draft ({@code sbytelen}). Also the protocol-level upper bound: anything
-   * longer is rejected by the verifier and never produced by
-   * {@link #sign(byte[], byte[])} (which loops with fresh randomness if BC
-   * exceeds it).
+   * TRON/EIP-8052 maximum Falcon-512 signature length after re-inserting the
+   * stripped header byte into a 666-byte headerless signature slot.
    */
-  public static final int SIGNATURE_LENGTH = 666;
+  public static final int SIGNATURE_MAX_LENGTH = 667;
   /**
-   * Smallest syntactically well-formed Falcon-512 encoding: 1-byte header +
-   * 40-byte nonce, with {@code compressed_s2} potentially empty. Real valid
-   * signatures sit well above this — the bound exists to reject obviously
-   * malformed inputs without invoking BC.
+   * Backward-compatible alias for callers that treat the signature length value
+   * as the variable-length upper bound.
    */
-  public static final int SIGNATURE_MIN_LENGTH = 41;
+  public static final int SIGNATURE_LENGTH = SIGNATURE_MAX_LENGTH;
+  /**
+   * Smallest syntactically well-formed Falcon-512 compressed encoding: 1-byte header
+   * + 40-byte nonce + 576-byte {@code compressed_s2}. The compressed form encodes
+   * N=512 coefficients and each coefficient takes at least 9 bits.
+   */
+  public static final int SIGNATURE_MIN_LENGTH = 617;
+  /**
+   * Canonical Falcon-512 header byte ({@code 0x30 + logn}, logn=9): identifies the
+   * compressed encoding. BC's {@code FalconSigner} only ever produces this byte and
+   * rejects any other first byte; {@link #verify} enforces it explicitly so the
+   * "compressed-only" rule is pinned in our own code rather than relying on BC
+   * internals. The padded ({@code 0x49}) and constant-time ({@code 0x59}) encodings
+   * are deliberately not accepted — admitting them would make the same (key, message)
+   * verifiable under multiple distinct byte strings (signature malleability).
+   */
+  public static final byte SIGNATURE_HEADER = 0x39;
   /**
    * Maximum signing retries before {@link #sign(byte[], byte[])} gives up.
-   * Empirically BC produces signatures above {@link #SIGNATURE_LENGTH} with
+   * Empirically BC produces signatures above {@link #SIGNATURE_MAX_LENGTH} with
    * probability ≪ 1/5000, so 16 attempts is comfortably above the
    * spec-targeted rejection rate (~2^-40) — failure probability after 16
    * retries on honest input is astronomically small.
@@ -151,15 +162,15 @@ public final class FNDSA512 implements PQSignature {
     return PUBLIC_KEY_LENGTH;
   }
 
-  /** Returns the protocol-level signature length upper bound (signatures are variable-length). */
+  /** Returns the canonical signature length upper bound (signatures are variable-length). */
   @Override
   public int getSignatureLength() {
-    return SIGNATURE_LENGTH;
+    return SIGNATURE_MAX_LENGTH;
   }
 
   /**
    * FN-DSA signatures are variable-length; the lower bound is the smallest
-   * syntactically well-formed encoding (1-byte header + 40-byte nonce).
+   * syntactically well-formed compressed encoding.
    */
   @Override
   public int getSignatureMinLength() {
@@ -231,13 +242,20 @@ public final class FNDSA512 implements PQSignature {
     }
     if (signature == null
         || signature.length < SIGNATURE_MIN_LENGTH
-        || signature.length > SIGNATURE_LENGTH) {
+        || signature.length > SIGNATURE_MAX_LENGTH) {
       throw new IllegalArgumentException(
           "FN-DSA signature length must be "
-              + SIGNATURE_MIN_LENGTH + ".." + SIGNATURE_LENGTH);
+              + SIGNATURE_MIN_LENGTH + ".." + SIGNATURE_MAX_LENGTH);
     }
     if (message == null) {
       throw new IllegalArgumentException("message must not be null");
+    }
+    // Reject non-canonical encodings (padded 0x49 / constant-time 0x59) so only the
+    // compressed form is verifiable — see SIGNATURE_HEADER. Ordered after the argument
+    // checks above: malformed arguments throw, a non-canonical-but-well-formed
+    // signature is simply an invalid signature (return false).
+    if (signature[0] != SIGNATURE_HEADER) {
+      return false;
     }
     FalconPublicKeyParameters pk = new FalconPublicKeyParameters(PARAMS, publicKey);
     FalconSigner verifier = new FalconSigner();
@@ -258,10 +276,10 @@ public final class FNDSA512 implements PQSignature {
    * <p>Signing is randomized: the same {@code (privateKey, message)} yields different
    * signature bytes on every call. Only keygen is deterministic from the 48-byte seed.
    * Downstream code must not cache or dedup by signature-bytes hash; key on the derived
-   * address instead.
+   * address instead (see the PQ multisig dedup in {@code PrecompiledContracts}).
    *
    * <p>Per Falcon Round-3 / FIPS-206 draft the signature MUST be ≤
-   * {@link #SIGNATURE_LENGTH} bytes; if it exceeds, the signer must resample
+   * {@link #SIGNATURE_MAX_LENGTH} bytes; if it exceeds, the signer must resample
    * with a fresh nonce. BouncyCastle does <strong>not</strong> implement this
    * rejection step — its internal buffer permits up to 689 B and would return
    * those longer signatures. This wrapper enforces the spec cap by discarding
@@ -288,7 +306,7 @@ public final class FNDSA512 implements PQSignature {
     for (int attempt = 0; attempt < SIGN_RETRY_BUDGET; attempt++) {
       try {
         byte[] sig = signer.generateSignature(message);
-        if (sig.length <= SIGNATURE_LENGTH) {
+        if (sig.length <= SIGNATURE_MAX_LENGTH) {
           return sig;
         }
         // BC produced a spec-overlong signature; retry with fresh randomness.
@@ -302,7 +320,7 @@ public final class FNDSA512 implements PQSignature {
     }
     throw new IllegalStateException(
         "FN-DSA signing failed: could not produce a signature ≤ "
-            + SIGNATURE_LENGTH + " bytes after " + SIGN_RETRY_BUDGET + " attempts",
+            + SIGNATURE_MAX_LENGTH + " bytes after " + SIGN_RETRY_BUDGET + " attempts",
         lastFailure);
   }
 
@@ -316,7 +334,10 @@ public final class FNDSA512 implements PQSignature {
    * See bcgit/bc-java#2297.
    */
   public static byte[] derivePublicKey(byte[] privateKey) {
-    if (privateKey != null && privateKey.length == PRIVATE_KEY_WITH_PUBLIC_KEY_LENGTH) {
+    if (privateKey == null) {
+      throw new IllegalArgumentException("privateKey must not be null");
+    }
+    if (privateKey.length == PRIVATE_KEY_WITH_PUBLIC_KEY_LENGTH) {
       byte[] pk = new byte[PUBLIC_KEY_LENGTH];
       System.arraycopy(privateKey, PRIVATE_KEY_LENGTH, pk, 0, PUBLIC_KEY_LENGTH);
       return pk;

--- a/src/main/java/org/tron/common/crypto/pqc/FNDSA512.java
+++ b/src/main/java/org/tron/common/crypto/pqc/FNDSA512.java
@@ -1,0 +1,298 @@
+package org.tron.common.crypto.pqc;
+
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
+import org.bouncycastle.crypto.params.ParametersWithRandom;
+import org.bouncycastle.crypto.prng.FixedSecureRandom;
+import org.bouncycastle.pqc.crypto.falcon.FalconKeyGenerationParameters;
+import org.bouncycastle.pqc.crypto.falcon.FalconKeyPairGenerator;
+import org.bouncycastle.pqc.crypto.falcon.FalconParameters;
+import org.bouncycastle.pqc.crypto.falcon.FalconPrivateKeyParameters;
+import org.bouncycastle.pqc.crypto.falcon.FalconPublicKeyParameters;
+import org.bouncycastle.pqc.crypto.falcon.FalconSigner;
+import org.tron.protos.Protocol.PQScheme;
+
+/**
+ * FIPS 206 (draft) FN-DSA / Falcon-512 keypair-bound signer/verifier. Instance
+ * methods sign/verify with the bound keypair, static {@link #sign(byte[], byte[])}
+ * / {@link #verify} provide stateless entry points used by
+ * {@link PQSchemeRegistry}.
+ *
+ * <p>Falcon signatures are <strong>variable-length</strong>: {@link #SIGNATURE_LENGTH}
+ * is the protocol-level upper bound, not an exact length. The
+ * {@link PQSignature#validateSignature} default treats this as
+ * {@code <= SIGNATURE_LENGTH}. BouncyCastle 1.79's {@code FalconNIST.CRYPTO_BYTES}
+ * for Falcon-512 is 690 bytes, well below the 752-byte protocol cap.
+ */
+public final class FNDSA512 implements PQSignature {
+
+  /**
+   * Falcon-512 encoded private key from BC: f || g || F, where f and g are each
+   * {@link #F_G_ENCODED_LENGTH} bytes (6 bits per coefficient × N=512 / 8) and F is
+   * {@link #BIG_F_ENCODED_LENGTH} bytes (8 bits per coefficient × N=512 / 8).
+   */
+  public static final int F_G_ENCODED_LENGTH = 384;
+  public static final int BIG_F_ENCODED_LENGTH = 512;
+  public static final int PRIVATE_KEY_LENGTH =
+      F_G_ENCODED_LENGTH + F_G_ENCODED_LENGTH + BIG_F_ENCODED_LENGTH;
+  /**
+   * Falcon-512 public key from BC: 14 * N / 8 = 896 bytes (the modq-encoded h polynomial).
+   * The 1-byte serialization header is stripped from {@code getH()}.
+   */
+  public static final int PUBLIC_KEY_LENGTH = 896;
+  /**
+   * Extended private key encoding {@code f ‖ g ‖ F ‖ h}: the standard BC private key
+   * (1280 B) with the 896-byte public key {@code h} appended. Lets the holder recover
+   * the address without re-running keygen, since BC currently has no public API for
+   * deriving {@code h} from {@code (f, g)} alone (see bcgit/bc-java#2297).
+   */
+  public static final int PRIVATE_KEY_WITH_PUBLIC_KEY_LENGTH =
+      PRIVATE_KEY_LENGTH + PUBLIC_KEY_LENGTH;
+  /** Protocol-level upper bound on Falcon-512 signature length (variable). */
+  public static final int SIGNATURE_LENGTH = 752;
+  /** Falcon keygen seeds an internal SHAKE256 from 48 bytes of randomness. */
+  public static final int SEED_LENGTH = 48;
+
+  private static final FalconParameters PARAMS = FalconParameters.falcon_512;
+
+  private final byte[] privateKey;
+  private final byte[] publicKey;
+
+  public FNDSA512() {
+    AsymmetricCipherKeyPair kp = generateKeyPair(new SecureRandom());
+    this.privateKey = ((FalconPrivateKeyParameters) kp.getPrivate()).getEncoded();
+    this.publicKey = ((FalconPublicKeyParameters) kp.getPublic()).getH();
+  }
+
+  public FNDSA512(byte[] seed) {
+    if (seed == null || seed.length != SEED_LENGTH) {
+      throw new IllegalArgumentException("FN-DSA seed length must be " + SEED_LENGTH);
+    }
+    AsymmetricCipherKeyPair kp = generateKeyPair(new FixedSecureRandom(seed));
+    this.privateKey = ((FalconPrivateKeyParameters) kp.getPrivate()).getEncoded();
+    this.publicKey = ((FalconPublicKeyParameters) kp.getPublic()).getH();
+  }
+
+  public FNDSA512(byte[] privateKey, byte[] publicKey) {
+    if (privateKey == null || privateKey.length != PRIVATE_KEY_LENGTH) {
+      throw new IllegalArgumentException(
+          "FN-DSA private key length must be " + PRIVATE_KEY_LENGTH);
+    }
+    if (publicKey == null || publicKey.length != PUBLIC_KEY_LENGTH) {
+      throw new IllegalArgumentException(
+          "FN-DSA public key length must be " + PUBLIC_KEY_LENGTH);
+    }
+    requireConsistent(privateKey, publicKey);
+    this.privateKey = privateKey.clone();
+    this.publicKey = publicKey.clone();
+  }
+
+  /**
+   * Builds an instance from the extended private key encoding {@code f ‖ g ‖ F ‖ h}
+   * ({@link #PRIVATE_KEY_WITH_PUBLIC_KEY_LENGTH} bytes), as produced by
+   * {@link #getPrivateKeyWithPublicKey()}. Provided as a static factory rather
+   * than an additional {@code FNDSA512(byte[])} constructor because Java cannot
+   * overload {@link #FNDSA512(byte[]) the seed constructor} on length alone.
+   */
+  public static FNDSA512 fromPrivateKeyWithPublicKey(byte[] extendedPrivateKey) {
+    if (extendedPrivateKey == null
+        || extendedPrivateKey.length != PRIVATE_KEY_WITH_PUBLIC_KEY_LENGTH) {
+      throw new IllegalArgumentException(
+          "FN-DSA extended private key length must be "
+              + PRIVATE_KEY_WITH_PUBLIC_KEY_LENGTH);
+    }
+    byte[] sk = new byte[PRIVATE_KEY_LENGTH];
+    byte[] pk = new byte[PUBLIC_KEY_LENGTH];
+    System.arraycopy(extendedPrivateKey, 0, sk, 0, PRIVATE_KEY_LENGTH);
+    System.arraycopy(extendedPrivateKey, PRIVATE_KEY_LENGTH, pk, 0, PUBLIC_KEY_LENGTH);
+    return new FNDSA512(sk, pk);
+  }
+
+  @Override
+  public PQScheme getScheme() {
+    return PQScheme.FN_DSA_512;
+  }
+
+  @Override
+  public int getPrivateKeyLength() {
+    return PRIVATE_KEY_LENGTH;
+  }
+
+  @Override
+  public int getPublicKeyLength() {
+    return PUBLIC_KEY_LENGTH;
+  }
+
+  /** Returns the protocol-level signature length upper bound (signatures are variable-length). */
+  @Override
+  public int getSignatureLength() {
+    return SIGNATURE_LENGTH;
+  }
+
+  @Override
+  public byte[] getPrivateKey() {
+    return privateKey.clone();
+  }
+
+  /**
+   * FN-DSA accepts the bare {@link #PRIVATE_KEY_LENGTH} form as well as the
+   * extended {@link #PRIVATE_KEY_WITH_PUBLIC_KEY_LENGTH} form used for local
+   * witness config. Override of {@link PQSignature#validatePrivateKey}.
+   */
+  @Override
+  public void validatePrivateKey(byte[] privateKey) {
+    validatePrivateKeyBytes(privateKey);
+  }
+
+  /**
+   * Returns the private key with the 896-byte public key {@code h} appended:
+   * {@code f ‖ g ‖ F ‖ h} (total {@link #PRIVATE_KEY_WITH_PUBLIC_KEY_LENGTH} bytes).
+   * Use this format on disk / in config when the consumer needs to recover the
+   * address from the private key alone — neither BC's encoded private key nor
+   * the 48-byte keygen seed (without re-running keygen) suffice today.
+   */
+  public byte[] getPrivateKeyWithPublicKey() {
+    byte[] out = new byte[PRIVATE_KEY_WITH_PUBLIC_KEY_LENGTH];
+    System.arraycopy(privateKey, 0, out, 0, PRIVATE_KEY_LENGTH);
+    System.arraycopy(publicKey, 0, out, PRIVATE_KEY_LENGTH, PUBLIC_KEY_LENGTH);
+    return out;
+  }
+
+  @Override
+  public byte[] getPublicKey() {
+    return publicKey.clone();
+  }
+
+  @Override
+  public byte[] getAddress() {
+    return PQSchemeRegistry.computeAddress(PQScheme.FN_DSA_512, publicKey);
+  }
+
+  @Override
+  public byte[] sign(byte[] message) {
+    return sign(privateKey, message);
+  }
+
+  @Override
+  public boolean verify(byte[] message, byte[] signature) {
+    return verify(publicKey, message, signature);
+  }
+
+  public static boolean verify(byte[] publicKey, byte[] message, byte[] signature) {
+    if (publicKey == null || publicKey.length != PUBLIC_KEY_LENGTH) {
+      throw new IllegalArgumentException(
+          "FN-DSA public key length must be " + PUBLIC_KEY_LENGTH);
+    }
+    if (signature == null || signature.length == 0 || signature.length > SIGNATURE_LENGTH) {
+      throw new IllegalArgumentException(
+          "FN-DSA signature length must be 1.." + SIGNATURE_LENGTH);
+    }
+    if (message == null) {
+      throw new IllegalArgumentException("message must not be null");
+    }
+    FalconPublicKeyParameters pk = new FalconPublicKeyParameters(PARAMS, publicKey);
+    FalconSigner verifier = new FalconSigner();
+    verifier.init(false, pk);
+    try {
+      return verifier.verifySignature(message, signature);
+    } catch (RuntimeException e) {
+      return false;
+    }
+  }
+
+  /**
+   * Signs {@code message} using either the bare private key
+   * ({@link #PRIVATE_KEY_LENGTH} bytes, {@code f ‖ g ‖ F}) or the extended form
+   * ({@link #PRIVATE_KEY_WITH_PUBLIC_KEY_LENGTH} bytes, {@code f ‖ g ‖ F ‖ h}).
+   * The trailing {@code h} segment is ignored — only {@code (f, g, F)} feed BC's signer.
+   */
+  public static byte[] sign(byte[] privateKey, byte[] message) {
+    validatePrivateKeyBytes(privateKey);
+    if (message == null) {
+      throw new IllegalArgumentException("message must not be null");
+    }
+    byte[] f = new byte[F_G_ENCODED_LENGTH];
+    byte[] g = new byte[F_G_ENCODED_LENGTH];
+    byte[] bigF = new byte[BIG_F_ENCODED_LENGTH];
+    System.arraycopy(privateKey, 0, f, 0, f.length);
+    System.arraycopy(privateKey, f.length, g, 0, g.length);
+    System.arraycopy(privateKey, f.length + g.length, bigF, 0, bigF.length);
+    FalconPrivateKeyParameters sk = new FalconPrivateKeyParameters(PARAMS, f, g, bigF, new byte[0]);
+    FalconSigner signer = new FalconSigner();
+    signer.init(true, new ParametersWithRandom(sk, new SecureRandom()));
+    try {
+      return signer.generateSignature(message);
+    } catch (Exception e) {
+      throw new IllegalStateException("FN-DSA signing failed", e);
+    }
+  }
+
+  /**
+   * Recovers the public key when the input is in the extended form
+   * {@code f ‖ g ‖ F ‖ h} ({@link #PRIVATE_KEY_WITH_PUBLIC_KEY_LENGTH} bytes).
+   * Throws {@link UnsupportedOperationException} for the bare {@code f ‖ g ‖ F}
+   * form: BouncyCastle currently has no public API to compute {@code h = g · f⁻¹}
+   * mod q, so callers must persist {@code h} alongside the private key (use
+   * {@link #getPrivateKeyWithPublicKey()}) or re-run keygen from a stored seed.
+   * See bcgit/bc-java#2297.
+   */
+  public static byte[] derivePublicKey(byte[] privateKey) {
+    if (privateKey != null && privateKey.length == PRIVATE_KEY_WITH_PUBLIC_KEY_LENGTH) {
+      byte[] pk = new byte[PUBLIC_KEY_LENGTH];
+      System.arraycopy(privateKey, PRIVATE_KEY_LENGTH, pk, 0, PUBLIC_KEY_LENGTH);
+      return pk;
+    }
+    throw new UnsupportedOperationException(
+        "FN-DSA public key cannot be derived from the bare encoded private key; "
+            + "supply the extended form (f ‖ g ‖ F ‖ h) or both halves to the "
+            + "(privateKey, publicKey) constructor");
+  }
+
+  public static byte[] computeAddress(byte[] publicKey) {
+    return PQSchemeRegistry.computeAddress(PQScheme.FN_DSA_512, publicKey);
+  }
+
+  private static AsymmetricCipherKeyPair generateKeyPair(SecureRandom random) {
+    FalconKeyPairGenerator generator = new FalconKeyPairGenerator();
+    generator.init(new FalconKeyGenerationParameters(random, PARAMS));
+    return generator.generateKeyPair();
+  }
+
+  /**
+   * Domain-separated probe used by {@link #requireConsistent}; not a security
+   * boundary (Falcon hashes the message internally), the constant just makes the
+   * keypair self-check searchable in logs/stack traces.
+   */
+  private static final byte[] CONSISTENCY_PROBE =
+      "tron:FN-DSA-512:keypair-consistency-probe".getBytes(StandardCharsets.UTF_8);
+
+  /**
+   * Probe that the supplied (sk, pk) actually form a keypair. Falcon has no
+   * public API to derive {@code h} from {@code (f, g)} alone (bcgit/bc-java#2297),
+   * so we sign and verify a fixed probe message. Runs once per witness load and
+   * costs a few ms on Falcon-512 — acceptable for a startup-time misconfiguration
+   * check, and avoids advertising an address that signatures will never satisfy.
+   */
+  private static void requireConsistent(byte[] privateKey, byte[] publicKey) {
+    byte[] sig;
+    try {
+      sig = sign(privateKey, CONSISTENCY_PROBE);
+    } catch (RuntimeException e) {
+      throw new IllegalArgumentException("FN-DSA private/public key mismatch", e);
+    }
+    if (!verify(publicKey, CONSISTENCY_PROBE, sig)) {
+      throw new IllegalArgumentException("FN-DSA private/public key mismatch");
+    }
+  }
+
+  private static void validatePrivateKeyBytes(byte[] privateKey) {
+    if (privateKey == null
+        || (privateKey.length != PRIVATE_KEY_LENGTH
+            && privateKey.length != PRIVATE_KEY_WITH_PUBLIC_KEY_LENGTH)) {
+      throw new IllegalArgumentException(
+          "FN-DSA private key length must be " + PRIVATE_KEY_LENGTH
+              + " or " + PRIVATE_KEY_WITH_PUBLIC_KEY_LENGTH);
+    }
+  }
+}

--- a/src/main/java/org/tron/common/crypto/pqc/FNDSA512.java
+++ b/src/main/java/org/tron/common/crypto/pqc/FNDSA512.java
@@ -19,11 +19,16 @@ import org.tron.protos.Protocol.PQScheme;
  * / {@link #verify} provide stateless entry points used by
  * {@link PQSchemeRegistry}.
  *
- * <p>Falcon signatures are <strong>variable-length</strong>: {@link #SIGNATURE_LENGTH}
- * is the protocol-level upper bound, not an exact length. The
- * {@link PQSignature#validateSignature} default treats this as
- * {@code <= SIGNATURE_LENGTH}. BouncyCastle 1.79's {@code FalconNIST.CRYPTO_BYTES}
- * for Falcon-512 is 690 bytes, well below the 752-byte protocol cap.
+ * <p>Falcon signatures are <strong>variable-length</strong>: every accepted
+ * signature must fall within {@code [}{@link #SIGNATURE_MIN_LENGTH}{@code ,}
+ * {@link #SIGNATURE_LENGTH}{@code ]}. {@link #SIGNATURE_LENGTH} (666) matches
+ * the java-tron {@code ALLOW_FN_DSA_512} chain cap and the canonical Falcon
+ * Round-3 / FIPS-206 draft {@code sbytelen} for Falcon-512;
+ * {@link #SIGNATURE_MIN_LENGTH} (41) is the smallest syntactically well-formed
+ * encoding. BC's signer does not implement Falcon's rejection step on
+ * over-length outputs (its internal buffer permits up to 689 B);
+ * {@link #sign(byte[], byte[])} adds that loop so produced signatures always
+ * respect the canonical cap.
  */
 public final class FNDSA512 implements PQSignature {
 
@@ -49,12 +54,34 @@ public final class FNDSA512 implements PQSignature {
    */
   public static final int PRIVATE_KEY_WITH_PUBLIC_KEY_LENGTH =
       PRIVATE_KEY_LENGTH + PUBLIC_KEY_LENGTH;
-  /** Protocol-level upper bound on Falcon-512 signature length (variable). */
-  public static final int SIGNATURE_LENGTH = 752;
+  /**
+   * Canonical maximum Falcon-512 signature length per Falcon Round-3 / FIPS-206
+   * draft ({@code sbytelen}). Also the protocol-level upper bound: anything
+   * longer is rejected by the verifier and never produced by
+   * {@link #sign(byte[], byte[])} (which loops with fresh randomness if BC
+   * exceeds it).
+   */
+  public static final int SIGNATURE_LENGTH = 666;
+  /**
+   * Smallest syntactically well-formed Falcon-512 encoding: 1-byte header +
+   * 40-byte nonce, with {@code compressed_s2} potentially empty. Real valid
+   * signatures sit well above this — the bound exists to reject obviously
+   * malformed inputs without invoking BC.
+   */
+  public static final int SIGNATURE_MIN_LENGTH = 41;
+  /**
+   * Maximum signing retries before {@link #sign(byte[], byte[])} gives up.
+   * Empirically BC produces signatures above {@link #SIGNATURE_LENGTH} with
+   * probability ≪ 1/5000, so 16 attempts is comfortably above the
+   * spec-targeted rejection rate (~2^-40) — failure probability after 16
+   * retries on honest input is astronomically small.
+   */
+  private static final int SIGN_RETRY_BUDGET = 16;
   /** Falcon keygen seeds an internal SHAKE256 from 48 bytes of randomness. */
   public static final int SEED_LENGTH = 48;
 
   private static final FalconParameters PARAMS = FalconParameters.falcon_512;
+  private static final SecureRandom SIGNING_RNG = new SecureRandom();
 
   private final byte[] privateKey;
   private final byte[] publicKey;
@@ -130,6 +157,15 @@ public final class FNDSA512 implements PQSignature {
     return SIGNATURE_LENGTH;
   }
 
+  /**
+   * FN-DSA signatures are variable-length; the lower bound is the smallest
+   * syntactically well-formed encoding (1-byte header + 40-byte nonce).
+   */
+  @Override
+  public int getSignatureMinLength() {
+    return SIGNATURE_MIN_LENGTH;
+  }
+
   @Override
   public byte[] getPrivateKey() {
     return privateKey.clone();
@@ -159,6 +195,15 @@ public final class FNDSA512 implements PQSignature {
     return out;
   }
 
+  /**
+   * FN-DSA persists the extended {@code f ‖ g ‖ F ‖ h} form so the keystore can
+   * recover {@code h} without re-running keygen.
+   */
+  @Override
+  public byte[] getPersistedPrivateKey() {
+    return getPrivateKeyWithPublicKey();
+  }
+
   @Override
   public byte[] getPublicKey() {
     return publicKey.clone();
@@ -184,9 +229,12 @@ public final class FNDSA512 implements PQSignature {
       throw new IllegalArgumentException(
           "FN-DSA public key length must be " + PUBLIC_KEY_LENGTH);
     }
-    if (signature == null || signature.length == 0 || signature.length > SIGNATURE_LENGTH) {
+    if (signature == null
+        || signature.length < SIGNATURE_MIN_LENGTH
+        || signature.length > SIGNATURE_LENGTH) {
       throw new IllegalArgumentException(
-          "FN-DSA signature length must be 1.." + SIGNATURE_LENGTH);
+          "FN-DSA signature length must be "
+              + SIGNATURE_MIN_LENGTH + ".." + SIGNATURE_LENGTH);
     }
     if (message == null) {
       throw new IllegalArgumentException("message must not be null");
@@ -206,6 +254,21 @@ public final class FNDSA512 implements PQSignature {
    * ({@link #PRIVATE_KEY_LENGTH} bytes, {@code f ‖ g ‖ F}) or the extended form
    * ({@link #PRIVATE_KEY_WITH_PUBLIC_KEY_LENGTH} bytes, {@code f ‖ g ‖ F ‖ h}).
    * The trailing {@code h} segment is ignored — only {@code (f, g, F)} feed BC's signer.
+   *
+   * <p>Signing is randomized: the same {@code (privateKey, message)} yields different
+   * signature bytes on every call. Only keygen is deterministic from the 48-byte seed.
+   * Downstream code must not cache or dedup by signature-bytes hash; key on the derived
+   * address instead.
+   *
+   * <p>Per Falcon Round-3 / FIPS-206 draft the signature MUST be ≤
+   * {@link #SIGNATURE_LENGTH} bytes; if it exceeds, the signer must resample
+   * with a fresh nonce. BouncyCastle does <strong>not</strong> implement this
+   * rejection step — its internal buffer permits up to 689 B and would return
+   * those longer signatures. This wrapper enforces the spec cap by discarding
+   * over-length BC outputs (and BC's own {@code IllegalStateException} from
+   * {@code comp_encode} overflow) and retrying up to {@link #SIGN_RETRY_BUDGET}
+   * times. Each retry draws fresh randomness from {@code SIGNING_RNG}, so on
+   * honest input the budget is astronomically unlikely to be exhausted.
    */
   public static byte[] sign(byte[] privateKey, byte[] message) {
     validatePrivateKeyBytes(privateKey);
@@ -220,12 +283,27 @@ public final class FNDSA512 implements PQSignature {
     System.arraycopy(privateKey, f.length + g.length, bigF, 0, bigF.length);
     FalconPrivateKeyParameters sk = new FalconPrivateKeyParameters(PARAMS, f, g, bigF, new byte[0]);
     FalconSigner signer = new FalconSigner();
-    signer.init(true, new ParametersWithRandom(sk, new SecureRandom()));
-    try {
-      return signer.generateSignature(message);
-    } catch (Exception e) {
-      throw new IllegalStateException("FN-DSA signing failed", e);
+    signer.init(true, new ParametersWithRandom(sk, SIGNING_RNG));
+    Exception lastFailure = null;
+    for (int attempt = 0; attempt < SIGN_RETRY_BUDGET; attempt++) {
+      try {
+        byte[] sig = signer.generateSignature(message);
+        if (sig.length <= SIGNATURE_LENGTH) {
+          return sig;
+        }
+        // BC produced a spec-overlong signature; retry with fresh randomness.
+      } catch (IllegalStateException e) {
+        // BC's comp_encode overflowed its internal buffer — equivalent to
+        // a spec-overlong signature; retry.
+        lastFailure = e;
+      } catch (Exception e) {
+        throw new IllegalStateException("FN-DSA signing failed", e);
+      }
     }
+    throw new IllegalStateException(
+        "FN-DSA signing failed: could not produce a signature ≤ "
+            + SIGNATURE_LENGTH + " bytes after " + SIGN_RETRY_BUDGET + " attempts",
+        lastFailure);
   }
 
   /**

--- a/src/main/java/org/tron/common/crypto/pqc/MLDSA44.java
+++ b/src/main/java/org/tron/common/crypto/pqc/MLDSA44.java
@@ -1,0 +1,200 @@
+package org.tron.common.crypto.pqc;
+
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
+import org.bouncycastle.pqc.crypto.mldsa.MLDSAKeyGenerationParameters;
+import org.bouncycastle.pqc.crypto.mldsa.MLDSAKeyPairGenerator;
+import org.bouncycastle.pqc.crypto.mldsa.MLDSAParameters;
+import org.bouncycastle.pqc.crypto.mldsa.MLDSAPrivateKeyParameters;
+import org.bouncycastle.pqc.crypto.mldsa.MLDSAPublicKeyParameters;
+import org.bouncycastle.pqc.crypto.mldsa.MLDSASigner;
+import org.bouncycastle.crypto.params.ParametersWithRandom;
+import org.bouncycastle.crypto.prng.FixedSecureRandom;
+import org.tron.protos.Protocol.PQScheme;
+
+/**
+ * FIPS 204 ML-DSA-44 (CRYSTALS-Dilithium-2) keypair-bound signer/verifier.
+ * ML-DSA-44 signatures are fixed-length (2420 B). The expanded private key
+ * encoding {@code rho ‖ K ‖ tr ‖ s1 ‖ s2 ‖ t0} (2560 B) lets BC recover the
+ * public key directly, so there is no extended priv-with-pub form like Falcon.
+ */
+public final class MLDSA44 implements PQSignature {
+
+  public static final int PRIVATE_KEY_LENGTH = 2560;
+  public static final int PUBLIC_KEY_LENGTH = 1312;
+  public static final int SIGNATURE_LENGTH = 2420;
+  public static final int SEED_LENGTH = 32;
+
+  private static final MLDSAParameters PARAMS = MLDSAParameters.ml_dsa_44;
+
+  private final byte[] privateKey;
+  private final byte[] publicKey;
+
+  public MLDSA44() {
+    AsymmetricCipherKeyPair kp = generateKeyPair(new SecureRandom());
+    this.privateKey = ((MLDSAPrivateKeyParameters) kp.getPrivate()).getEncoded();
+    this.publicKey = ((MLDSAPublicKeyParameters) kp.getPublic()).getEncoded();
+  }
+
+  public MLDSA44(byte[] seed) {
+    if (seed == null || seed.length != SEED_LENGTH) {
+      throw new IllegalArgumentException("ML-DSA seed length must be " + SEED_LENGTH);
+    }
+    AsymmetricCipherKeyPair kp = generateKeyPair(new FixedSecureRandom(seed));
+    this.privateKey = ((MLDSAPrivateKeyParameters) kp.getPrivate()).getEncoded();
+    this.publicKey = ((MLDSAPublicKeyParameters) kp.getPublic()).getEncoded();
+  }
+
+  public MLDSA44(byte[] privateKey, byte[] publicKey) {
+    if (privateKey == null || privateKey.length != PRIVATE_KEY_LENGTH) {
+      throw new IllegalArgumentException(
+          "ML-DSA private key length must be " + PRIVATE_KEY_LENGTH);
+    }
+    if (publicKey == null || publicKey.length != PUBLIC_KEY_LENGTH) {
+      throw new IllegalArgumentException(
+          "ML-DSA public key length must be " + PUBLIC_KEY_LENGTH);
+    }
+    requireConsistent(privateKey, publicKey);
+    this.privateKey = privateKey.clone();
+    this.publicKey = publicKey.clone();
+  }
+
+  @Override
+  public PQScheme getScheme() {
+    return PQScheme.ML_DSA_44;
+  }
+
+  @Override
+  public int getPrivateKeyLength() {
+    return PRIVATE_KEY_LENGTH;
+  }
+
+  @Override
+  public int getPublicKeyLength() {
+    return PUBLIC_KEY_LENGTH;
+  }
+
+  @Override
+  public int getSignatureLength() {
+    return SIGNATURE_LENGTH;
+  }
+
+  @Override
+  public byte[] getPrivateKey() {
+    return privateKey.clone();
+  }
+
+  @Override
+  public byte[] getPublicKey() {
+    return publicKey.clone();
+  }
+
+  @Override
+  public byte[] getAddress() {
+    return PQSchemeRegistry.computeAddress(PQScheme.ML_DSA_44, publicKey);
+  }
+
+  @Override
+  public byte[] sign(byte[] message) {
+    return sign(privateKey, message);
+  }
+
+  @Override
+  public boolean verify(byte[] message, byte[] signature) {
+    return verify(publicKey, message, signature);
+  }
+
+  /**
+   * Fixed-length validation: signatures shorter or longer than
+   * {@link #SIGNATURE_LENGTH} are invalid by construction.
+   */
+  @Override
+  public void validateSignature(byte[] signature) {
+    if (signature == null || signature.length != SIGNATURE_LENGTH) {
+      throw new IllegalArgumentException(
+          "invalid " + getScheme() + " signature length: "
+              + (signature == null ? "null" : signature.length)
+              + ", expected " + SIGNATURE_LENGTH);
+    }
+  }
+
+  public static boolean verify(byte[] publicKey, byte[] message, byte[] signature) {
+    if (publicKey == null || publicKey.length != PUBLIC_KEY_LENGTH) {
+      throw new IllegalArgumentException(
+          "ML-DSA public key length must be " + PUBLIC_KEY_LENGTH);
+    }
+    if (signature == null || signature.length != SIGNATURE_LENGTH) {
+      throw new IllegalArgumentException(
+          "ML-DSA signature length must be " + SIGNATURE_LENGTH);
+    }
+    if (message == null) {
+      throw new IllegalArgumentException("message must not be null");
+    }
+    MLDSAPublicKeyParameters pk = new MLDSAPublicKeyParameters(PARAMS, publicKey);
+    MLDSASigner verifier = new MLDSASigner();
+    verifier.init(false, pk);
+    verifier.update(message, 0, message.length);
+    try {
+      return verifier.verifySignature(signature);
+    } catch (RuntimeException e) {
+      return false;
+    }
+  }
+
+  public static byte[] sign(byte[] privateKey, byte[] message) {
+    if (privateKey == null || privateKey.length != PRIVATE_KEY_LENGTH) {
+      throw new IllegalArgumentException(
+          "ML-DSA private key length must be " + PRIVATE_KEY_LENGTH);
+    }
+    if (message == null) {
+      throw new IllegalArgumentException("message must not be null");
+    }
+    MLDSAPrivateKeyParameters sk = new MLDSAPrivateKeyParameters(PARAMS, privateKey);
+    MLDSASigner signer = new MLDSASigner();
+    signer.init(true, new ParametersWithRandom(sk, new SecureRandom()));
+    signer.update(message, 0, message.length);
+    try {
+      return signer.generateSignature();
+    } catch (Exception e) {
+      throw new IllegalStateException("ML-DSA signing failed", e);
+    }
+  }
+
+  /**
+   * Recovers the public key from the expanded private key. BC's encoded
+   * private key includes {@code rho} and the witness {@code t0}; {@code t1} is
+   * re-derived inside {@link MLDSAPrivateKeyParameters}, so {@code pk = rho ‖ t1}
+   * is recoverable without persisting it alongside.
+   */
+  public static byte[] derivePublicKey(byte[] privateKey) {
+    if (privateKey == null || privateKey.length != PRIVATE_KEY_LENGTH) {
+      throw new IllegalArgumentException(
+          "ML-DSA private key length must be " + PRIVATE_KEY_LENGTH);
+    }
+    MLDSAPrivateKeyParameters sk = new MLDSAPrivateKeyParameters(PARAMS, privateKey);
+    return sk.getPublicKey();
+  }
+
+  public static byte[] computeAddress(byte[] publicKey) {
+    return PQSchemeRegistry.computeAddress(PQScheme.ML_DSA_44, publicKey);
+  }
+
+  private static AsymmetricCipherKeyPair generateKeyPair(SecureRandom random) {
+    MLDSAKeyPairGenerator generator = new MLDSAKeyPairGenerator();
+    generator.init(new MLDSAKeyGenerationParameters(random, PARAMS));
+    return generator.generateKeyPair();
+  }
+
+  private static void requireConsistent(byte[] privateKey, byte[] publicKey) {
+    byte[] derived;
+    try {
+      derived = derivePublicKey(privateKey);
+    } catch (RuntimeException e) {
+      throw new IllegalArgumentException("ML-DSA private key is malformed", e);
+    }
+    if (!MessageDigest.isEqual(derived, publicKey)) {
+      throw new IllegalArgumentException("ML-DSA private/public key mismatch");
+    }
+  }
+}

--- a/src/main/java/org/tron/common/crypto/pqc/PQSchemeRegistry.java
+++ b/src/main/java/org/tron/common/crypto/pqc/PQSchemeRegistry.java
@@ -1,0 +1,223 @@
+package org.tron.common.crypto.pqc;
+
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Map;
+import org.tron.common.crypto.Hash;
+import org.tron.protos.Protocol.PQScheme;
+
+/**
+ * Static dispatch table for post-quantum signature schemes keyed by
+ * {@link PQScheme}. Each entry binds a scheme to its public-key length,
+ * signature length, seed length, fingerprint hash function, and stateless
+ * sign/verify/keygen operations. Legacy ECDSA secp256k1 / SM2 schemes are NOT
+ * registered — they flow through the existing {@code SignInterface} path.
+ *
+ * <p><b>Address binding (V2).</b> A PQ-derived TRON address is
+ * {@code 0x41 ‖ deriveHash(scheme, public_key)[12..32]}, matching the ECDSA
+ * flow's {@code 0x41 ‖ Keccak-256(public_key)[12..32]} so PQ and ECDSA
+ * addresses share the same derivation shape. The hash function is scheme-
+ * specific (see {@link #deriveHash}); {@code FN_DSA_512} uses Keccak-256.
+ *
+ * <p><b>Wire-format default.</b> {@code UNKNOWN_PQ_SCHEME = 0} is the proto3
+ * default (reserved for the {@code UNKNOWN_} API-evolution slot); on the wire
+ * it is interpreted as {@code FN_DSA_512} so V2-launch witnesses pay zero
+ * bytes for the scheme tag. All public methods normalize via
+ * {@link #resolve(PQScheme)} before dispatch.
+ */
+public final class PQSchemeRegistry {
+
+  /** Stateless sign/verify/keygen dispatch bound to a single PQ scheme. */
+  public interface SignatureOps {
+    byte[] sign(byte[] privateKey, byte[] message);
+
+    boolean verify(byte[] publicKey, byte[] message, byte[] signature);
+
+    PQSignature fromSeed(byte[] seed);
+
+    PQSignature fromKeypair(byte[] privateKey, byte[] publicKey);
+  }
+
+  /**
+   * Fingerprint hash used to derive a 21-byte TRON address from a PQ public key.
+   * V2 first launch uses Keccak-256 for FN_DSA_512 to match the ECDSA address
+   * derivation; later schemes may bind to a different hash if the PQ scheme has
+   * its own canonical fingerprint.
+   */
+  public interface FingerprintHash {
+    /** Returns the full digest of {@code data} (no truncation). */
+    byte[] digest(byte[] data);
+  }
+
+  private static final FingerprintHash KECCAK_256 = Hash::sha3;
+
+  private static final class SchemeInfo {
+    final int privateKeyLength;
+    final int publicKeyLength;
+    final int signatureLength;
+    final int seedLength;
+    final FingerprintHash hash;
+    final SignatureOps ops;
+
+    SchemeInfo(int privateKeyLength, int publicKeyLength, int signatureLength,
+        int seedLength, FingerprintHash hash, SignatureOps ops) {
+      this.privateKeyLength = privateKeyLength;
+      this.publicKeyLength = publicKeyLength;
+      this.signatureLength = signatureLength;
+      this.seedLength = seedLength;
+      this.hash = hash;
+      this.ops = ops;
+    }
+  }
+
+  private static final Map<PQScheme, SchemeInfo> SCHEMES;
+
+  static {
+    EnumMap<PQScheme, SchemeInfo> m = new EnumMap<>(PQScheme.class);
+    m.put(PQScheme.FN_DSA_512, new SchemeInfo(
+        FNDSA512.PRIVATE_KEY_LENGTH, FNDSA512.PUBLIC_KEY_LENGTH,
+        FNDSA512.SIGNATURE_LENGTH, FNDSA512.SEED_LENGTH,
+        KECCAK_256,
+        new SignatureOps() {
+          @Override
+          public byte[] sign(byte[] privateKey, byte[] message) {
+            return FNDSA512.sign(privateKey, message);
+          }
+
+          @Override
+          public boolean verify(byte[] publicKey, byte[] message, byte[] signature) {
+            return FNDSA512.verify(publicKey, message, signature);
+          }
+
+          @Override
+          public PQSignature fromSeed(byte[] seed) {
+            return new FNDSA512(seed);
+          }
+
+          @Override
+          public PQSignature fromKeypair(byte[] privateKey, byte[] publicKey) {
+            return new FNDSA512(privateKey, publicKey);
+          }
+        }));
+    SCHEMES = Collections.unmodifiableMap(m);
+  }
+
+  private PQSchemeRegistry() {
+  }
+
+  /**
+   * Map a wire-format {@link PQScheme} to its registered scheme. The proto3
+   * default {@code UNKNOWN_PQ_SCHEME} is normalized to {@code FN_DSA_512} so
+   * V2-launch witnesses that omit the scheme tag are decoded as Falcon-512.
+   * {@code null} and {@code UNRECOGNIZED} pass through unchanged so the
+   * caller-side {@code contains}/{@code require} checks reject them.
+   */
+  public static PQScheme resolve(PQScheme scheme) {
+    if (scheme == PQScheme.UNKNOWN_PQ_SCHEME) {
+      return PQScheme.FN_DSA_512;
+    }
+    return scheme;
+  }
+
+  public static boolean contains(PQScheme scheme) {
+    PQScheme resolved = resolve(scheme);
+    return resolved != null && SCHEMES.containsKey(resolved);
+  }
+
+  public static int getPrivateKeyLength(PQScheme scheme) {
+    return require(scheme).privateKeyLength;
+  }
+
+  public static int getPublicKeyLength(PQScheme scheme) {
+    return require(scheme).publicKeyLength;
+  }
+
+  public static int getSignatureLength(PQScheme scheme) {
+    return require(scheme).signatureLength;
+  }
+
+  public static int getSeedLength(PQScheme scheme) {
+    return require(scheme).seedLength;
+  }
+
+  /**
+   * Per-scheme signature-length predicate. Fixed-length schemes require exact
+   * equality with {@link #getSignatureLength(PQScheme)}; variable-length
+   * schemes ({@code FN_DSA_512}) treat that value as an upper bound and accept
+   * any {@code 1..max}.
+   */
+  public static boolean isValidSignatureLength(PQScheme scheme, int length) {
+    PQScheme resolved = resolve(scheme);
+    SchemeInfo info = require(resolved);
+    if (resolved == PQScheme.FN_DSA_512) {
+      return length > 0 && length <= info.signatureLength;
+    }
+    return length == info.signatureLength;
+  }
+
+  public static byte[] sign(PQScheme scheme, byte[] privateKey, byte[] message) {
+    return require(scheme).ops.sign(privateKey, message);
+  }
+
+  public static boolean verify(
+      PQScheme scheme, byte[] publicKey, byte[] message, byte[] signature) {
+    return require(scheme).ops.verify(publicKey, message, signature);
+  }
+
+  public static PQSignature fromSeed(PQScheme scheme, byte[] seed) {
+    return require(scheme).ops.fromSeed(seed);
+  }
+
+  /**
+   * Build a keypair-bound {@link PQSignature} from already-derived private and
+   * public key bytes. Used by the witness-config path when the operator has
+   * pre-computed the keypair off-line and wants to bypass on-node keygen.
+   * Validates {@code privateKey} and {@code publicKey} lengths against the
+   * scheme; cryptographic consistency between the two halves is the caller's
+   * responsibility.
+   */
+  public static PQSignature fromKeypair(
+      PQScheme scheme, byte[] privateKey, byte[] publicKey) {
+    return require(scheme).ops.fromKeypair(privateKey, publicKey);
+  }
+
+  /**
+   * Scheme-dispatched fingerprint hash of a PQ public key. Returns the full
+   * digest; callers truncate to 20 bytes when deriving the address suffix.
+   */
+  public static byte[] deriveHash(PQScheme scheme, byte[] publicKey) {
+    SchemeInfo info = require(scheme);
+    if (publicKey == null || publicKey.length != info.publicKeyLength) {
+      throw new IllegalArgumentException(
+          "invalid public key length for " + scheme + ": "
+              + (publicKey == null ? -1 : publicKey.length));
+    }
+    return info.hash.digest(publicKey);
+  }
+
+  /**
+   * Derive the 21-byte TRON address from a PQ public key as
+   * {@code 0x41 ‖ deriveHash(scheme, public_key)[12..32]} — the rightmost 20
+   * bytes of the digest, matching the ECDSA address derivation slice.
+   */
+  public static byte[] computeAddress(PQScheme scheme, byte[] publicKey) {
+    byte[] h = deriveHash(scheme, publicKey);
+    byte[] addr = new byte[21];
+    addr[0] = 0x41;
+    System.arraycopy(h, h.length - 20, addr, 1, 20);
+    return addr;
+  }
+
+  private static SchemeInfo require(PQScheme scheme) {
+    if (scheme == null) {
+      throw new IllegalArgumentException("scheme must not be null");
+    }
+    PQScheme resolved = resolve(scheme);
+    SchemeInfo info = SCHEMES.get(resolved);
+    if (info == null) {
+      throw new IllegalArgumentException(
+          "no PQSignature registered for scheme: " + scheme);
+    }
+    return info;
+  }
+}

--- a/src/main/java/org/tron/common/crypto/pqc/PQSchemeRegistry.java
+++ b/src/main/java/org/tron/common/crypto/pqc/PQSchemeRegistry.java
@@ -20,10 +20,9 @@ import org.tron.protos.Protocol.PQScheme;
  * specific (see {@link #deriveHash}); {@code FN_DSA_512} uses Keccak-256.
  *
  * <p><b>Wire-format default.</b> {@code UNKNOWN_PQ_SCHEME = 0} is the proto3
- * default (reserved for the {@code UNKNOWN_} API-evolution slot); on the wire
- * it is interpreted as {@code FN_DSA_512} so V2-launch witnesses pay zero
- * bytes for the scheme tag. All public methods normalize via
- * {@link #resolve(PQScheme)} before dispatch.
+ * default (reserved for the {@code UNKNOWN_} API-evolution slot) and is
+ * rejected by {@link #contains(PQScheme)} / {@link #require(PQScheme)} —
+ * callers must specify a concrete scheme.
  */
 public final class PQSchemeRegistry {
 
@@ -36,6 +35,18 @@ public final class PQSchemeRegistry {
     PQSignature fromSeed(byte[] seed);
 
     PQSignature fromKeypair(byte[] privateKey, byte[] publicKey);
+
+    /**
+     * Rebuilds a {@link PQSignature} from the byte form persisted by the
+     * keystore (see {@link PQSignature#getPersistedPrivateKey()}). For schemes
+     * whose encoded private key alone determines the public key this just
+     * derives the public half. For FN-DSA-512 the input is the extended form
+     * {@code f ‖ g ‖ F ‖ h}.
+     */
+    PQSignature fromPersistedPrivateKey(byte[] persistedPrivateKey);
+
+    /** Returns the length in bytes of the form returned by {@link #fromPersistedPrivateKey}. */
+    int persistedPrivateKeyLength();
   }
 
   /**
@@ -55,15 +66,17 @@ public final class PQSchemeRegistry {
     final int privateKeyLength;
     final int publicKeyLength;
     final int signatureLength;
+    final int signatureMinLength;
     final int seedLength;
     final FingerprintHash hash;
     final SignatureOps ops;
 
     SchemeInfo(int privateKeyLength, int publicKeyLength, int signatureLength,
-        int seedLength, FingerprintHash hash, SignatureOps ops) {
+        int signatureMinLength, int seedLength, FingerprintHash hash, SignatureOps ops) {
       this.privateKeyLength = privateKeyLength;
       this.publicKeyLength = publicKeyLength;
       this.signatureLength = signatureLength;
+      this.signatureMinLength = signatureMinLength;
       this.seedLength = seedLength;
       this.hash = hash;
       this.ops = ops;
@@ -76,7 +89,8 @@ public final class PQSchemeRegistry {
     EnumMap<PQScheme, SchemeInfo> m = new EnumMap<>(PQScheme.class);
     m.put(PQScheme.FN_DSA_512, new SchemeInfo(
         FNDSA512.PRIVATE_KEY_LENGTH, FNDSA512.PUBLIC_KEY_LENGTH,
-        FNDSA512.SIGNATURE_LENGTH, FNDSA512.SEED_LENGTH,
+        FNDSA512.SIGNATURE_LENGTH, FNDSA512.SIGNATURE_MIN_LENGTH,
+        FNDSA512.SEED_LENGTH,
         KECCAK_256,
         new SignatureOps() {
           @Override
@@ -98,6 +112,53 @@ public final class PQSchemeRegistry {
           public PQSignature fromKeypair(byte[] privateKey, byte[] publicKey) {
             return new FNDSA512(privateKey, publicKey);
           }
+
+          @Override
+          public PQSignature fromPersistedPrivateKey(byte[] persistedPrivateKey) {
+            return FNDSA512.fromPrivateKeyWithPublicKey(persistedPrivateKey);
+          }
+
+          @Override
+          public int persistedPrivateKeyLength() {
+            return FNDSA512.PRIVATE_KEY_WITH_PUBLIC_KEY_LENGTH;
+          }
+        }));
+    m.put(PQScheme.ML_DSA_44, new SchemeInfo(
+        MLDSA44.PRIVATE_KEY_LENGTH, MLDSA44.PUBLIC_KEY_LENGTH,
+        MLDSA44.SIGNATURE_LENGTH, MLDSA44.SIGNATURE_LENGTH,
+        MLDSA44.SEED_LENGTH,
+        KECCAK_256,
+        new SignatureOps() {
+          @Override
+          public byte[] sign(byte[] privateKey, byte[] message) {
+            return MLDSA44.sign(privateKey, message);
+          }
+
+          @Override
+          public boolean verify(byte[] publicKey, byte[] message, byte[] signature) {
+            return MLDSA44.verify(publicKey, message, signature);
+          }
+
+          @Override
+          public PQSignature fromSeed(byte[] seed) {
+            return new MLDSA44(seed);
+          }
+
+          @Override
+          public PQSignature fromKeypair(byte[] privateKey, byte[] publicKey) {
+            return new MLDSA44(privateKey, publicKey);
+          }
+
+          @Override
+          public PQSignature fromPersistedPrivateKey(byte[] persistedPrivateKey) {
+            byte[] pk = MLDSA44.derivePublicKey(persistedPrivateKey);
+            return new MLDSA44(persistedPrivateKey, pk);
+          }
+
+          @Override
+          public int persistedPrivateKeyLength() {
+            return MLDSA44.PRIVATE_KEY_LENGTH;
+          }
         }));
     SCHEMES = Collections.unmodifiableMap(m);
   }
@@ -105,23 +166,8 @@ public final class PQSchemeRegistry {
   private PQSchemeRegistry() {
   }
 
-  /**
-   * Map a wire-format {@link PQScheme} to its registered scheme. The proto3
-   * default {@code UNKNOWN_PQ_SCHEME} is normalized to {@code FN_DSA_512} so
-   * V2-launch witnesses that omit the scheme tag are decoded as Falcon-512.
-   * {@code null} and {@code UNRECOGNIZED} pass through unchanged so the
-   * caller-side {@code contains}/{@code require} checks reject them.
-   */
-  public static PQScheme resolve(PQScheme scheme) {
-    if (scheme == PQScheme.UNKNOWN_PQ_SCHEME) {
-      return PQScheme.FN_DSA_512;
-    }
-    return scheme;
-  }
-
   public static boolean contains(PQScheme scheme) {
-    PQScheme resolved = resolve(scheme);
-    return resolved != null && SCHEMES.containsKey(resolved);
+    return scheme != null && SCHEMES.containsKey(scheme);
   }
 
   public static int getPrivateKeyLength(PQScheme scheme) {
@@ -141,18 +187,14 @@ public final class PQSchemeRegistry {
   }
 
   /**
-   * Per-scheme signature-length predicate. Fixed-length schemes require exact
-   * equality with {@link #getSignatureLength(PQScheme)}; variable-length
-   * schemes ({@code FN_DSA_512}) treat that value as an upper bound and accept
-   * any {@code 1..max}.
+   * Per-scheme signature-length predicate. Variable-length schemes
+   * ({@code FN_DSA_512}) accept any length in
+   * {@code [getSignatureMinLength, getSignatureLength]}; fixed-length schemes
+   * collapse that range to a single value.
    */
   public static boolean isValidSignatureLength(PQScheme scheme, int length) {
-    PQScheme resolved = resolve(scheme);
-    SchemeInfo info = require(resolved);
-    if (resolved == PQScheme.FN_DSA_512) {
-      return length > 0 && length <= info.signatureLength;
-    }
-    return length == info.signatureLength;
+    SchemeInfo info = require(scheme);
+    return length >= info.signatureMinLength && length <= info.signatureLength;
   }
 
   public static byte[] sign(PQScheme scheme, byte[] privateKey, byte[] message) {
@@ -166,6 +208,15 @@ public final class PQSchemeRegistry {
 
   public static PQSignature fromSeed(PQScheme scheme, byte[] seed) {
     return require(scheme).ops.fromSeed(seed);
+  }
+
+  public static PQSignature fromPersistedPrivateKey(
+      PQScheme scheme, byte[] persistedPrivateKey) {
+    return require(scheme).ops.fromPersistedPrivateKey(persistedPrivateKey);
+  }
+
+  public static int getPersistedPrivateKeyLength(PQScheme scheme) {
+    return require(scheme).ops.persistedPrivateKeyLength();
   }
 
   /**
@@ -212,8 +263,7 @@ public final class PQSchemeRegistry {
     if (scheme == null) {
       throw new IllegalArgumentException("scheme must not be null");
     }
-    PQScheme resolved = resolve(scheme);
-    SchemeInfo info = SCHEMES.get(resolved);
+    SchemeInfo info = SCHEMES.get(scheme);
     if (info == null) {
       throw new IllegalArgumentException(
           "no PQSignature registered for scheme: " + scheme);

--- a/src/main/java/org/tron/common/crypto/pqc/PQSignature.java
+++ b/src/main/java/org/tron/common/crypto/pqc/PQSignature.java
@@ -1,0 +1,72 @@
+package org.tron.common.crypto.pqc;
+
+import org.tron.protos.Protocol.PQScheme;
+
+/**
+ * Post-quantum signature scheme facade bound to a keypair. Instance methods
+ * (sign/verify/getAddress/getPublicKey/getPrivateKey) operate on the held
+ * keypair. Stateless dispatch by {@link PQScheme} is provided by
+ * {@link PQSchemeRegistry}.
+ */
+public interface PQSignature {
+
+  PQScheme getScheme();
+
+  int getPrivateKeyLength();
+
+  int getPublicKeyLength();
+
+  int getSignatureLength();
+
+  byte[] getPrivateKey();
+
+  byte[] getPublicKey();
+
+  /**
+   * 21-byte TRON address derived from the held public key as
+   * {@code 0x41 ‖ deriveHash(scheme, public_key)[12..32]} (see
+   * {@link PQSchemeRegistry#computeAddress}).
+   */
+  byte[] getAddress();
+
+  /** Sign {@code message} with the held private key; returns the raw signature. */
+  byte[] sign(byte[] message);
+
+  /**
+   * Verify {@code signature} over {@code message} against the held public key.
+   *
+   * @return true iff the signature is cryptographically valid for the bound keypair
+   */
+  boolean verify(byte[] message, byte[] signature);
+
+  default void validatePrivateKey(byte[] privateKey) {
+    if (privateKey == null || privateKey.length != getPrivateKeyLength()) {
+      throw new IllegalArgumentException(
+          "invalid " + getScheme() + " private key length: "
+              + (privateKey == null ? "null" : privateKey.length)
+              + ", expected " + getPrivateKeyLength());
+    }
+  }
+
+  default void validatePublicKey(byte[] publicKey) {
+    if (publicKey == null || publicKey.length != getPublicKeyLength()) {
+      throw new IllegalArgumentException(
+          "invalid " + getScheme() + " public key length: "
+              + (publicKey == null ? "null" : publicKey.length)
+              + ", expected " + getPublicKeyLength());
+    }
+  }
+
+  /**
+   * Default upper-bound check, sufficient for variable-length schemes (FN_DSA_512).
+   * Fixed-length schemes override this with strict equality.
+   */
+  default void validateSignature(byte[] signature) {
+    if (signature == null || signature.length == 0 || signature.length > getSignatureLength()) {
+      throw new IllegalArgumentException(
+          "invalid " + getScheme() + " signature length: "
+              + (signature == null ? "null" : signature.length)
+              + ", expected 1.." + getSignatureLength());
+    }
+  }
+}

--- a/src/main/java/org/tron/common/crypto/pqc/PQSignature.java
+++ b/src/main/java/org/tron/common/crypto/pqc/PQSignature.java
@@ -18,9 +18,30 @@ public interface PQSignature {
 
   int getSignatureLength();
 
+  /**
+   * Minimum syntactically well-formed signature length. Defaults to
+   * {@link #getSignatureLength()} for fixed-length schemes; variable-length
+   * schemes (e.g. FN-DSA-512) override.
+   */
+  default int getSignatureMinLength() {
+    return getSignatureLength();
+  }
+
   byte[] getPrivateKey();
 
   byte[] getPublicKey();
+
+  /**
+   * Returns the byte form persisted by the keystore. For schemes whose encoded
+   * private key alone suffices to recover the public key (e.g. ML-DSA-44) this
+   * is just {@link #getPrivateKey()}. For schemes that need the public key
+   * appended to recover the keypair without re-running keygen (e.g. FN-DSA-512
+   * — see {@code bcgit/bc-java#2297}) this returns the extended encoding
+   * {@code privateKey ‖ publicKey}.
+   */
+  default byte[] getPersistedPrivateKey() {
+    return getPrivateKey();
+  }
 
   /**
    * 21-byte TRON address derived from the held public key as
@@ -58,15 +79,18 @@ public interface PQSignature {
   }
 
   /**
-   * Default upper-bound check, sufficient for variable-length schemes (FN_DSA_512).
-   * Fixed-length schemes override this with strict equality.
+   * Default range check, sufficient for variable-length schemes (FN_DSA_512).
+   * Fixed-length schemes override {@link #getSignatureMinLength()} to equal
+   * {@link #getSignatureLength()}, which collapses this to a strict equality.
    */
   default void validateSignature(byte[] signature) {
-    if (signature == null || signature.length == 0 || signature.length > getSignatureLength()) {
+    int min = getSignatureMinLength();
+    int max = getSignatureLength();
+    if (signature == null || signature.length < min || signature.length > max) {
       throw new IllegalArgumentException(
           "invalid " + getScheme() + " signature length: "
               + (signature == null ? "null" : signature.length)
-              + ", expected 1.." + getSignatureLength());
+              + ", expected " + min + ".." + max);
     }
   }
 }

--- a/src/main/java/org/tron/common/utils/Hash.java
+++ b/src/main/java/org/tron/common/utils/Hash.java
@@ -66,7 +66,7 @@ public class Hash {
 
   static {
     Security.addProvider(TronCastleProvider.getInstance());
-    CRYPTO_PROVIDER = Security.getProvider("BC");
+    CRYPTO_PROVIDER = TronCastleProvider.getInstance();
     HASH_256_ALGORITHM_NAME = "TRON-KECCAK-256";
     HASH_512_ALGORITHM_NAME = "TRON-KECCAK-512";
     EMPTY_TRIE_HASH = sha3(encodeElement(EMPTY_BYTE_ARRAY));

--- a/src/main/java/org/tron/common/utils/Hash.java
+++ b/src/main/java/org/tron/common/utils/Hash.java
@@ -26,7 +26,6 @@ import static org.tron.common.utils.ByteUtil.isSingleZero;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
-import java.security.Security;
 import java.util.Arrays;
 import lombok.extern.slf4j.Slf4j;
 import org.bouncycastle.math.ec.ECPoint;
@@ -65,7 +64,6 @@ public class Hash {
   private static final int SIZE_THRESHOLD = 56;
 
   static {
-    Security.addProvider(TronCastleProvider.getInstance());
     CRYPTO_PROVIDER = TronCastleProvider.getInstance();
     HASH_256_ALGORITHM_NAME = "TRON-KECCAK-256";
     HASH_512_ALGORITHM_NAME = "TRON-KECCAK-512";

--- a/src/main/java/org/tron/common/utils/TransactionUtils.java
+++ b/src/main/java/org/tron/common/utils/TransactionUtils.java
@@ -17,17 +17,13 @@ package org.tron.common.utils;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
-import java.security.SignatureException;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Scanner;
 import org.bouncycastle.util.encoders.Hex;
-import org.tron.common.crypto.ECKey;
-import org.tron.common.crypto.ECKey.ECDSASignature;
 import org.tron.common.crypto.Sha256Sm3Hash;
 import org.tron.common.crypto.SignInterface;
 import org.tron.common.crypto.SignatureInterface;
-import org.tron.common.crypto.pqc.FNDSA512;
+import org.tron.common.crypto.pqc.PQSchemeRegistry;
+import org.tron.common.crypto.pqc.PQSignature;
 import org.tron.core.exception.CancelException;
 import org.tron.protos.Protocol.PQAuthSig;
 import org.tron.protos.Protocol.PQScheme;
@@ -294,65 +290,6 @@ public class TransactionUtils {
     }
   }
 
-  public static String getBase64FromByteString(ByteString sign) {
-    byte[] r = sign.substring(0, 32).toByteArray();
-    byte[] s = sign.substring(32, 64).toByteArray();
-    byte v = sign.byteAt(64);
-    if (v < 27) {
-      v += 27; // revId -> v
-    }
-    ECDSASignature signature = ECDSASignature.fromComponents(r, s, v);
-    return signature.toBase64();
-  }
-
-  /*
-   * 1. check hash
-   * 2. check double spent
-   * 3. check sign
-   * 4. check balance
-   */
-  public static boolean validTransaction(Transaction signedTransaction) {
-    assert (signedTransaction.getSignatureCount()
-        == signedTransaction.getRawData().getContractCount());
-    List<Transaction.Contract> listContract = signedTransaction.getRawData().getContractList();
-    byte[] hash = Sha256Sm3Hash.hash(signedTransaction.getRawData().toByteArray());
-    int count = signedTransaction.getSignatureCount();
-
-    // Accept transactions with at least one PQAuthSig even if there are no normal signatures
-    if (count == 0 && signedTransaction.getPqAuthSigCount() == 0) {
-      return false;
-    }
-
-    // Check normal signatures
-    for (int i = 0; i < count; ++i) {
-      try {
-        Transaction.Contract contract = listContract.get(i);
-        byte[] owner = getOwner(contract);
-        byte[] address =
-            ECKey.signatureToAddress(
-                hash, getBase64FromByteString(signedTransaction.getSignature(i)));
-        if (!Arrays.equals(owner, address)) {
-          return false;
-        }
-      } catch (SignatureException e) {
-        e.printStackTrace();
-        return false;
-      }
-    }
-
-    // Check PQ signatures
-    for (int i = 0; i < signedTransaction.getPqAuthSigCount(); ++i) {
-      org.tron.protos.Protocol.PQAuthSig pqAuthSig = signedTransaction.getPqAuthSig(i);
-      if (pqAuthSig.getPublicKey() == null || pqAuthSig.getPublicKey().isEmpty()) {
-        return false;
-      }
-      if (pqAuthSig.getSignature() == null || pqAuthSig.getSignature().isEmpty()) {
-        return false;
-      }
-    }
-    return true;
-  }
-
   public static Chain.Transaction sign(Chain.Transaction transaction, SignInterface myKey)
       throws InvalidProtocolBufferException {
     return Chain.Transaction.parseFrom(
@@ -370,19 +307,23 @@ public class TransactionUtils {
   }
 
   public static Chain.Transaction signPQ(
-      Chain.Transaction transaction, FNDSA512 signer, PQScheme scheme)
+      Chain.Transaction transaction, PQSignature signer, PQScheme scheme)
       throws InvalidProtocolBufferException {
     return Chain.Transaction.parseFrom(
         signPQ(Transaction.parseFrom(transaction.toByteArray()), signer, scheme).toByteArray());
   }
 
-  public static Transaction signPQ(Transaction transaction, FNDSA512 signer, PQScheme scheme) {
-    if (scheme == null || scheme == PQScheme.UNKNOWN_PQ_SCHEME || !org.tron.common.crypto.pqc.PQSchemeRegistry.contains(scheme)) {
-        throw new IllegalArgumentException("Unsupported or unknown PQScheme: " + scheme);
+  public static Transaction signPQ(Transaction transaction, PQSignature signer, PQScheme scheme) {
+    if (!PQSchemeRegistry.contains(scheme)) {
+      throw new IllegalArgumentException("Unsupported or unknown PQScheme: " + scheme);
+    }
+    if (signer.getScheme() != scheme) {
+      throw new IllegalArgumentException("Signer scheme " + signer.getScheme()
+          + " does not match requested scheme " + scheme);
     }
     byte[] hash = Sha256Sm3Hash.hash(transaction.getRawData().toByteArray());
     byte[] sig = signer.sign(hash);
-    org.tron.protos.Protocol.PQAuthSig pqSig = org.tron.protos.Protocol.PQAuthSig.newBuilder()
+    PQAuthSig pqSig = PQAuthSig.newBuilder()
         .setScheme(scheme)
         .setPublicKey(ByteString.copyFrom(signer.getPublicKey()))
         .setSignature(ByteString.copyFrom(sig))

--- a/src/main/java/org/tron/common/utils/TransactionUtils.java
+++ b/src/main/java/org/tron/common/utils/TransactionUtils.java
@@ -317,9 +317,13 @@ public class TransactionUtils {
     List<Transaction.Contract> listContract = signedTransaction.getRawData().getContractList();
     byte[] hash = Sha256Sm3Hash.hash(signedTransaction.getRawData().toByteArray());
     int count = signedTransaction.getSignatureCount();
-    if (count == 0) {
+
+    // Accept transactions with at least one PQAuthSig even if there are no normal signatures
+    if (count == 0 && signedTransaction.getPqAuthSigCount() == 0) {
       return false;
     }
+
+    // Check normal signatures
     for (int i = 0; i < count; ++i) {
       try {
         Transaction.Contract contract = listContract.get(i);
@@ -332,6 +336,17 @@ public class TransactionUtils {
         }
       } catch (SignatureException e) {
         e.printStackTrace();
+        return false;
+      }
+    }
+
+    // Check PQ signatures
+    for (int i = 0; i < signedTransaction.getPqAuthSigCount(); ++i) {
+      org.tron.protos.Protocol.PQAuthSig pqAuthSig = signedTransaction.getPqAuthSig(i);
+      if (pqAuthSig.getPublicKey() == null || pqAuthSig.getPublicKey().isEmpty()) {
+        return false;
+      }
+      if (pqAuthSig.getSignature() == null || pqAuthSig.getSignature().isEmpty()) {
         return false;
       }
     }
@@ -362,9 +377,12 @@ public class TransactionUtils {
   }
 
   public static Transaction signPQ(Transaction transaction, FNDSA512 signer, PQScheme scheme) {
+    if (scheme == null || scheme == PQScheme.UNKNOWN_PQ_SCHEME || !org.tron.common.crypto.pqc.PQSchemeRegistry.contains(scheme)) {
+        throw new IllegalArgumentException("Unsupported or unknown PQScheme: " + scheme);
+    }
     byte[] hash = Sha256Sm3Hash.hash(transaction.getRawData().toByteArray());
     byte[] sig = signer.sign(hash);
-    PQAuthSig pqSig = PQAuthSig.newBuilder()
+    org.tron.protos.Protocol.PQAuthSig pqSig = org.tron.protos.Protocol.PQAuthSig.newBuilder()
         .setScheme(scheme)
         .setPublicKey(ByteString.copyFrom(signer.getPublicKey()))
         .setSignature(ByteString.copyFrom(sig))

--- a/src/main/java/org/tron/common/utils/TransactionUtils.java
+++ b/src/main/java/org/tron/common/utils/TransactionUtils.java
@@ -27,7 +27,10 @@ import org.tron.common.crypto.ECKey.ECDSASignature;
 import org.tron.common.crypto.Sha256Sm3Hash;
 import org.tron.common.crypto.SignInterface;
 import org.tron.common.crypto.SignatureInterface;
+import org.tron.common.crypto.pqc.FNDSA512;
 import org.tron.core.exception.CancelException;
+import org.tron.protos.Protocol.PQAuthSig;
+import org.tron.protos.Protocol.PQScheme;
 import org.tron.protos.Protocol.Transaction;
 import org.tron.protos.contract.AccountContract;
 import org.tron.protos.contract.AccountContract.AccountCreateContract;
@@ -349,6 +352,24 @@ public class TransactionUtils {
     transactionBuilderSigned.addSignature(bsSign);
     transaction = transactionBuilderSigned.build();
     return transaction;
+  }
+
+  public static Chain.Transaction signPQ(
+      Chain.Transaction transaction, FNDSA512 signer, PQScheme scheme)
+      throws InvalidProtocolBufferException {
+    return Chain.Transaction.parseFrom(
+        signPQ(Transaction.parseFrom(transaction.toByteArray()), signer, scheme).toByteArray());
+  }
+
+  public static Transaction signPQ(Transaction transaction, FNDSA512 signer, PQScheme scheme) {
+    byte[] hash = Sha256Sm3Hash.hash(transaction.getRawData().toByteArray());
+    byte[] sig = signer.sign(hash);
+    PQAuthSig pqSig = PQAuthSig.newBuilder()
+        .setScheme(scheme)
+        .setPublicKey(ByteString.copyFrom(signer.getPublicKey()))
+        .setSignature(ByteString.copyFrom(sig))
+        .build();
+    return transaction.toBuilder().addPqAuthSig(pqSig).build();
   }
 
   public static Transaction setTimestamp(Transaction transaction) {

--- a/src/main/java/org/tron/keystore/CredentialsFalcon.java
+++ b/src/main/java/org/tron/keystore/CredentialsFalcon.java
@@ -1,0 +1,69 @@
+package org.tron.keystore;
+
+import org.tron.common.crypto.SignInterface;
+import org.tron.common.crypto.pqc.FNDSA512;
+import org.tron.walletserver.WalletApi;
+
+/**
+ * Credentials wrapper for Falcon-512 (FN-DSA-512) post-quantum keys. Kept off
+ * the {@link SignInterface} ECKey/SM2 union deliberately — PQ signing is
+ * dispatched per-wallet via {@link WalletFile#getScheme()}.
+ */
+public class CredentialsFalcon implements Credentials {
+
+  private final FNDSA512 fnDsa512;
+  private final String address;
+
+  private CredentialsFalcon(FNDSA512 fnDsa512, String address) {
+    this.fnDsa512 = fnDsa512;
+    this.address = address;
+  }
+
+  public FNDSA512 getFNDSA512() {
+    return fnDsa512;
+  }
+
+  @Override
+  public String getAddress() {
+    return address;
+  }
+
+  public static CredentialsFalcon create(FNDSA512 fnDsa512) {
+    String address = WalletApi.encode58Check(fnDsa512.getAddress());
+    return new CredentialsFalcon(fnDsa512, address);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    CredentialsFalcon that = (CredentialsFalcon) o;
+    if (fnDsa512 != null ? !fnDsa512.equals(that.fnDsa512) : that.fnDsa512 != null) {
+      return false;
+    }
+    return address != null ? address.equals(that.address) : that.address == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = fnDsa512 != null ? fnDsa512.hashCode() : 0;
+    result = 31 * result + (address != null ? address.hashCode() : 0);
+    return result;
+  }
+
+  /**
+   * PQ credentials are not part of the ECKey/SM2 SignInterface dispatch.
+   * The signing path branches on {@link WalletFile#getScheme()} before
+   * reaching any caller that touches {@code getPair()}.
+   */
+  @Override
+  public SignInterface getPair() {
+    throw new UnsupportedOperationException(
+        "Falcon (FN_DSA_512) credentials are not exposed via SignInterface; "
+            + "use getFNDSA512() and the PQ signing path.");
+  }
+}

--- a/src/main/java/org/tron/keystore/CredentialsFalcon.java
+++ b/src/main/java/org/tron/keystore/CredentialsFalcon.java
@@ -55,15 +55,58 @@ public class CredentialsFalcon implements Credentials {
     return result;
   }
 
-  /**
-   * PQ credentials are not part of the ECKey/SM2 SignInterface dispatch.
-   * The signing path branches on {@link WalletFile#getScheme()} before
-   * reaching any caller that touches {@code getPair()}.
-   */
   @Override
   public SignInterface getPair() {
-    throw new UnsupportedOperationException(
-        "Falcon (FN_DSA_512) credentials are not exposed via SignInterface; "
-            + "use getFNDSA512() and the PQ signing path.");
+    return new SignInterface() {
+      @Override
+      public byte[] hash(byte[] message) {
+        throw new UnsupportedOperationException("Not supported for PQ credentials");
+      }
+
+      @Override
+      public byte[] getPrivateKey() {
+        return fnDsa512.getPrivateKeyWithPublicKey();
+      }
+
+      @Override
+      public byte[] getPubKey() {
+        return fnDsa512.getPublicKey();
+      }
+
+      @Override
+      public byte[] getAddress() {
+        return fnDsa512.getAddress();
+      }
+
+      @Override
+      public String signHash(byte[] hash) {
+        throw new UnsupportedOperationException("Not supported for PQ credentials");
+      }
+
+      @Override
+      public byte[] signToAddress(byte[] messageHash, String signatureBase64) throws java.security.SignatureException {
+        throw new UnsupportedOperationException("Not supported for PQ credentials");
+      }
+
+      @Override
+      public byte[] getNodeId() {
+        throw new UnsupportedOperationException("Not supported for PQ credentials");
+      }
+
+      @Override
+      public byte[] Base64toBytes(String signature) {
+        throw new UnsupportedOperationException("Not supported for PQ credentials");
+      }
+
+      @Override
+      public byte[] getPrivKeyBytes() {
+        return fnDsa512.getPrivateKeyWithPublicKey();
+      }
+
+      @Override
+      public org.tron.common.crypto.SignatureInterface sign(byte[] hash) {
+        throw new UnsupportedOperationException("Not supported for PQ credentials");
+      }
+    };
   }
 }

--- a/src/main/java/org/tron/keystore/CredentialsPQ.java
+++ b/src/main/java/org/tron/keystore/CredentialsPQ.java
@@ -1,26 +1,26 @@
 package org.tron.keystore;
 
 import org.tron.common.crypto.SignInterface;
-import org.tron.common.crypto.pqc.FNDSA512;
+import org.tron.common.crypto.pqc.PQSignature;
 import org.tron.walletserver.WalletApi;
 
 /**
- * Credentials wrapper for Falcon-512 (FN-DSA-512) post-quantum keys. Kept off
- * the {@link SignInterface} ECKey/SM2 union deliberately — PQ signing is
- * dispatched per-wallet via {@link WalletFile#getScheme()}.
+ * Credentials wrapper for post-quantum signature keys (FN-DSA-512, ML-DSA-44,
+ * ...). Kept off the {@link SignInterface} ECKey/SM2 union deliberately — PQ
+ * signing is dispatched per-wallet via {@link WalletFile#getScheme()}.
  */
-public class CredentialsFalcon implements Credentials {
+public class CredentialsPQ implements Credentials {
 
-  private final FNDSA512 fnDsa512;
+  private final PQSignature signer;
   private final String address;
 
-  private CredentialsFalcon(FNDSA512 fnDsa512, String address) {
-    this.fnDsa512 = fnDsa512;
+  private CredentialsPQ(PQSignature signer, String address) {
+    this.signer = signer;
     this.address = address;
   }
 
-  public FNDSA512 getFNDSA512() {
-    return fnDsa512;
+  public PQSignature getPQSignature() {
+    return signer;
   }
 
   @Override
@@ -28,9 +28,9 @@ public class CredentialsFalcon implements Credentials {
     return address;
   }
 
-  public static CredentialsFalcon create(FNDSA512 fnDsa512) {
-    String address = WalletApi.encode58Check(fnDsa512.getAddress());
-    return new CredentialsFalcon(fnDsa512, address);
+  public static CredentialsPQ create(PQSignature signer) {
+    String address = WalletApi.encode58Check(signer.getAddress());
+    return new CredentialsPQ(signer, address);
   }
 
   @Override
@@ -41,8 +41,8 @@ public class CredentialsFalcon implements Credentials {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    CredentialsFalcon that = (CredentialsFalcon) o;
-    if (fnDsa512 != null ? !fnDsa512.equals(that.fnDsa512) : that.fnDsa512 != null) {
+    CredentialsPQ that = (CredentialsPQ) o;
+    if (signer != null ? !signer.equals(that.signer) : that.signer != null) {
       return false;
     }
     return address != null ? address.equals(that.address) : that.address == null;
@@ -50,7 +50,7 @@ public class CredentialsFalcon implements Credentials {
 
   @Override
   public int hashCode() {
-    int result = fnDsa512 != null ? fnDsa512.hashCode() : 0;
+    int result = signer != null ? signer.hashCode() : 0;
     result = 31 * result + (address != null ? address.hashCode() : 0);
     return result;
   }
@@ -65,17 +65,17 @@ public class CredentialsFalcon implements Credentials {
 
       @Override
       public byte[] getPrivateKey() {
-        return fnDsa512.getPrivateKeyWithPublicKey();
+        return signer.getPersistedPrivateKey();
       }
 
       @Override
       public byte[] getPubKey() {
-        return fnDsa512.getPublicKey();
+        return signer.getPublicKey();
       }
 
       @Override
       public byte[] getAddress() {
-        return fnDsa512.getAddress();
+        return signer.getAddress();
       }
 
       @Override
@@ -100,7 +100,7 @@ public class CredentialsFalcon implements Credentials {
 
       @Override
       public byte[] getPrivKeyBytes() {
-        return fnDsa512.getPrivateKeyWithPublicKey();
+        return signer.getPersistedPrivateKey();
       }
 
       @Override

--- a/src/main/java/org/tron/keystore/Wallet.java
+++ b/src/main/java/org/tron/keystore/Wallet.java
@@ -7,9 +7,12 @@ import org.bouncycastle.crypto.params.KeyParameter;
 import org.tron.common.crypto.ECKey;
 import org.tron.common.crypto.Hash;
 import org.tron.common.crypto.SignInterface;
+import org.tron.common.crypto.pqc.FNDSA512;
+import org.tron.common.crypto.pqc.PQSchemeRegistry;
 import org.tron.common.crypto.sm2.SM2;
 import org.tron.common.utils.ByteArray;
 import org.tron.core.exception.CipherException;
+import org.tron.protos.Protocol.PQScheme;
 import org.tron.walletserver.WalletApi;
 
 import javax.crypto.BadPaddingException;
@@ -331,6 +334,82 @@ public class Wallet {
     SM2 sm2 = SM2.fromPrivate(privateKey);
     StringUtils.clear(privateKey);
     return sm2;
+  }
+
+  // Encrypt a PQ extended private key (f ‖ g ‖ F ‖ h) with scrypt+AES-CTR.
+  // Mirrors create() but routes the plaintext bytes directly, because the
+  // 2176-byte Falcon key does not flow through SignInterface.
+  public static WalletFile createPQ(byte[] password, PQScheme scheme,
+      byte[] extendedPrivateKey, byte[] publicKey, int n, int p)
+      throws CipherException {
+    if (scheme == null || !PQSchemeRegistry.contains(scheme)) {
+      throw new CipherException("Unsupported PQ scheme: " + scheme);
+    }
+    byte[] salt = generateRandomBytes(32);
+    byte[] derivedKey = generateDerivedScryptKey(password, salt, n, R, p, DKLEN);
+    byte[] encryptKey = Arrays.copyOfRange(derivedKey, 0, 16);
+    byte[] iv = generateRandomBytes(16);
+    byte[] cipherText = performCipherOperation(Cipher.ENCRYPT_MODE, iv, encryptKey,
+        extendedPrivateKey);
+    byte[] mac = generateMac(derivedKey, cipherText);
+    return createPQWalletFile(scheme, publicKey, cipherText, iv, salt, mac, n, p);
+  }
+
+  public static WalletFile createStandardPQ(byte[] password, PQScheme scheme,
+      byte[] extendedPrivateKey, byte[] publicKey) throws CipherException {
+    return createPQ(password, scheme, extendedPrivateKey, publicKey, N_STANDARD, P_STANDARD);
+  }
+
+  private static WalletFile createPQWalletFile(PQScheme scheme, byte[] publicKey,
+      byte[] cipherText, byte[] iv, byte[] salt, byte[] mac, int n, int p) {
+    WalletFile walletFile = new WalletFile();
+    walletFile.setScheme(scheme.name());
+    walletFile.setAddress(
+        WalletApi.encode58Check(PQSchemeRegistry.computeAddress(scheme, publicKey)));
+
+    WalletFile.Crypto crypto = new WalletFile.Crypto();
+    crypto.setCipher(CIPHER);
+    crypto.setCiphertext(ByteArray.toHexString(cipherText));
+    walletFile.setCrypto(crypto);
+
+    WalletFile.CipherParams cipherParams = new WalletFile.CipherParams();
+    cipherParams.setIv(ByteArray.toHexString(iv));
+    crypto.setCipherparams(cipherParams);
+
+    crypto.setKdf(SCRYPT);
+    WalletFile.ScryptKdfParams kdfParams = new WalletFile.ScryptKdfParams();
+    kdfParams.setDklen(DKLEN);
+    kdfParams.setN(n);
+    kdfParams.setP(p);
+    kdfParams.setR(R);
+    kdfParams.setSalt(ByteArray.toHexString(salt));
+    crypto.setKdfparams(kdfParams);
+
+    crypto.setMac(ByteArray.toHexString(mac));
+    walletFile.setCrypto(crypto);
+    walletFile.setId(UUID.randomUUID().toString());
+    walletFile.setVersion(CURRENT_VERSION);
+    return walletFile;
+  }
+
+  // Returns an FNDSA512 reconstructed from the stored extended private key
+  // (f ‖ g ‖ F ‖ h). Bare-private-key recovery is not possible — BC has no
+  // public API for h = g · f⁻¹ mod q — so the keystore persists h alongside.
+  public static FNDSA512 decryptPQ(byte[] password, WalletFile walletFile)
+      throws CipherException {
+    if (walletFile.getScheme() == null) {
+      throw new CipherException("Wallet has no PQ scheme tag");
+    }
+    PQScheme scheme = PQScheme.valueOf(walletFile.getScheme());
+    if (scheme != PQScheme.FN_DSA_512) {
+      throw new CipherException("Unsupported PQ scheme: " + scheme);
+    }
+    byte[] extended = decrypt2PrivateBytes(password, walletFile);
+    try {
+      return FNDSA512.fromPrivateKeyWithPublicKey(extended);
+    } finally {
+      StringUtils.clear(extended);
+    }
   }
 
   static void validate(WalletFile walletFile) throws CipherException {

--- a/src/main/java/org/tron/keystore/Wallet.java
+++ b/src/main/java/org/tron/keystore/Wallet.java
@@ -600,6 +600,119 @@ public class Wallet {
     }
   }
 
+  // Re-encrypts a PQ keystore under a new password while preserving the
+  // original segment shape: whichever of {ext, seed} were persisted are
+  // re-encrypted; the other stays absent. Scrypt parameters are re-derived
+  // from the wallet's existing kdf params (so callers cannot inadvertently
+  // downgrade N/p by passing wrong flags). Address and scheme are preserved.
+  // Throws if either MAC mismatches the old password or the persisted segments
+  // disagree on the keypair.
+  public static WalletFile reEncryptPQ(byte[] oldPassword, byte[] newPassword,
+      WalletFile walletFile) throws CipherException {
+    if (walletFile.getScheme() == null) {
+      throw new CipherException("Wallet has no PQ scheme tag");
+    }
+    final PQScheme scheme;
+    try {
+      scheme = PQScheme.valueOf(walletFile.getScheme());
+    } catch (IllegalArgumentException e) {
+      throw new CipherException("Unsupported PQ scheme: " + walletFile.getScheme(), e);
+    }
+    if (!PQSchemeRegistry.contains(scheme)) {
+      throw new CipherException("Unsupported PQ scheme: " + scheme);
+    }
+    int expectedSeedLen = PQSchemeRegistry.getSeedLength(scheme);
+
+    validate(walletFile);
+    WalletFile.Crypto crypto = walletFile.getCrypto();
+    boolean extPresent = isExtSegmentPresent(crypto);
+    boolean seedPresent = isSeedSegmentPresent(crypto);
+    requireSegmentShape(crypto, extPresent, seedPresent);
+    if (!extPresent && !seedPresent) {
+      throw new CipherException(
+          "PQ wallet has neither ciphertext nor seedciphertext");
+    }
+    if (!(crypto.getKdfparams() instanceof WalletFile.ScryptKdfParams)) {
+      throw new CipherException("PQ wallets must use scrypt KDF");
+    }
+    WalletFile.ScryptKdfParams kdf = (WalletFile.ScryptKdfParams) crypto.getKdfparams();
+
+    byte[] derivedKey = deriveScryptKey(oldPassword, crypto);
+    byte[] encryptKey = Arrays.copyOfRange(derivedKey, 0, 16);
+    byte[] extended = null;
+    byte[] seedBytes = null;
+    try {
+      byte[] extCipherText = null;
+      byte[] seedCipherText = null;
+      if (extPresent) {
+        extCipherText = ByteArray.fromHexString(crypto.getCiphertext());
+        byte[] storedMac = ByteArray.fromHexString(crypto.getMac());
+        if (!Arrays.equals(generateMac(derivedKey, extCipherText), storedMac)) {
+          throw new CipherException("Invalid password provided");
+        }
+      }
+      if (seedPresent) {
+        seedCipherText = ByteArray.fromHexString(crypto.getSeedciphertext());
+        byte[] storedMac = ByteArray.fromHexString(crypto.getSeedmac());
+        if (!Arrays.equals(generateMac(derivedKey, seedCipherText), storedMac)) {
+          throw new CipherException("Invalid password provided");
+        }
+      }
+
+      byte[] extIv = extPresent
+          ? ByteArray.fromHexString(crypto.getCipherparams().getIv()) : null;
+      byte[] seedIv = seedPresent
+          ? ByteArray.fromHexString(crypto.getSeedcipherparams().getIv()) : null;
+      if (extIv != null && seedIv != null && Arrays.equals(extIv, seedIv)) {
+        throw new CipherException("PQ keystore reuses IV across ext/seed segments");
+      }
+
+      byte[] publicKey;
+      if (extPresent) {
+        extended = performCipherOperation(Cipher.DECRYPT_MODE, extIv, encryptKey,
+            extCipherText);
+        publicKey = PQSchemeRegistry
+            .fromPersistedPrivateKey(scheme, extended).getPublicKey();
+        if (seedPresent) {
+          seedBytes = performCipherOperation(Cipher.DECRYPT_MODE, seedIv, encryptKey,
+              seedCipherText);
+          if (seedBytes.length != expectedSeedLen) {
+            throw new CipherException(
+                "Decrypted seed has unexpected length: " + seedBytes.length);
+          }
+          byte[] seedDerivedPk = PQSchemeRegistry.fromSeed(scheme, seedBytes).getPublicKey();
+          if (!Arrays.equals(seedDerivedPk, publicKey)) {
+            throw new CipherException(
+                "PQ keystore seed and extended private key disagree");
+          }
+        }
+      } else {
+        seedBytes = performCipherOperation(Cipher.DECRYPT_MODE, seedIv, encryptKey,
+            seedCipherText);
+        if (seedBytes.length != expectedSeedLen) {
+          throw new CipherException(
+              "Decrypted seed has unexpected length: " + seedBytes.length);
+        }
+        publicKey = PQSchemeRegistry.fromSeed(scheme, seedBytes).getPublicKey();
+      }
+
+      WalletFile reEncrypted = createPQ(newPassword, scheme, extended, seedBytes,
+          publicKey, kdf.getN(), kdf.getP());
+      reEncrypted.setId(walletFile.getId());
+      reEncrypted.setName(walletFile.getName());
+      return reEncrypted;
+    } finally {
+      StringUtils.clear(encryptKey);
+      StringUtils.clear(derivedKey);
+      if (extended != null) {
+        StringUtils.clear(extended);
+      }
+      if (seedBytes != null) {
+        StringUtils.clear(seedBytes);
+      }
+    }
+  }
+
   private static boolean isExtSegmentPresent(WalletFile.Crypto crypto) {
     return crypto.getCiphertext() != null
         || crypto.getCipherparams() != null

--- a/src/main/java/org/tron/keystore/Wallet.java
+++ b/src/main/java/org/tron/keystore/Wallet.java
@@ -336,32 +336,96 @@ public class Wallet {
     return sm2;
   }
 
-  // Encrypt a PQ extended private key (f ‖ g ‖ F ‖ h) with scrypt+AES-CTR.
-  // Mirrors create() but routes the plaintext bytes directly, because the
-  // 2176-byte Falcon key does not flow through SignInterface.
+  // Encrypt a PQ wallet under scrypt + AES-128-CTR. Either segment (the 2176-byte
+  // extended private key f‖g‖F‖h, or the 48-byte FN-DSA seed) may be persisted;
+  // at least one must be supplied. When both are supplied a single scrypt run
+  // produces a derived key DK that is shared by both segments: DK[0..16] keys
+  // AES-CTR, DK[16..32] keys the MAC. Each segment gets an INDEPENDENT random
+  // IV (AES-CTR reuses keystream if IVs collide under a shared key) and its
+  // own Keccak-256 MAC over (DK[16..32] ‖ ciphertext).
   public static WalletFile createPQ(byte[] password, PQScheme scheme,
-      byte[] extendedPrivateKey, byte[] publicKey, int n, int p)
+      byte[] extendedPrivateKey, byte[] seed, byte[] publicKey, int n, int p)
       throws CipherException {
     if (scheme == null || !PQSchemeRegistry.contains(scheme)) {
       throw new CipherException("Unsupported PQ scheme: " + scheme);
     }
+    if (publicKey == null
+        || publicKey.length != PQSchemeRegistry.getPublicKeyLength(scheme)) {
+      throw new CipherException("Invalid PQ public key length for " + scheme.name());
+    }
+    if (extendedPrivateKey == null && seed == null) {
+      throw new CipherException(
+          "createPQ requires at least one of extendedPrivateKey or seed");
+    }
+    int expectedExtLen = PQSchemeRegistry.getPrivateKeyLength(scheme)
+        + PQSchemeRegistry.getPublicKeyLength(scheme);
+    if (extendedPrivateKey != null && extendedPrivateKey.length != expectedExtLen) {
+      throw new CipherException("Invalid extended private key length: expected "
+          + expectedExtLen + " for " + scheme.name());
+    }
+    if (seed != null && seed.length != FNDSA512.SEED_LENGTH) {
+      throw new CipherException("Invalid seed length: expected "
+          + FNDSA512.SEED_LENGTH + " bytes");
+    }
+
     byte[] salt = generateRandomBytes(32);
     byte[] derivedKey = generateDerivedScryptKey(password, salt, n, R, p, DKLEN);
     byte[] encryptKey = Arrays.copyOfRange(derivedKey, 0, 16);
-    byte[] iv = generateRandomBytes(16);
-    byte[] cipherText = performCipherOperation(Cipher.ENCRYPT_MODE, iv, encryptKey,
-        extendedPrivateKey);
-    byte[] mac = generateMac(derivedKey, cipherText);
-    return createPQWalletFile(scheme, publicKey, cipherText, iv, salt, mac, n, p);
+    try {
+      byte[] extIv = null;
+      byte[] extCipherText = null;
+      byte[] extMac = null;
+      if (extendedPrivateKey != null) {
+        extIv = generateRandomBytes(16);
+        extCipherText = performCipherOperation(Cipher.ENCRYPT_MODE, extIv, encryptKey,
+            extendedPrivateKey);
+        extMac = generateMac(derivedKey, extCipherText);
+      }
+
+      byte[] seedIv = null;
+      byte[] seedCipherText = null;
+      byte[] seedMac = null;
+      if (seed != null) {
+        seedIv = generateRandomBytes(16);
+        // Independent-IV invariant: AES-CTR under a shared key with a colliding
+        // IV reveals the XOR of the two plaintexts. SecureRandom.nextBytes makes
+        // a collision astronomically unlikely, but enforce it explicitly anyway.
+        while (extIv != null && Arrays.equals(seedIv, extIv)) {
+          seedIv = generateRandomBytes(16);
+        }
+        seedCipherText = performCipherOperation(Cipher.ENCRYPT_MODE, seedIv, encryptKey,
+            seed);
+        seedMac = generateMac(derivedKey, seedCipherText);
+      }
+
+      return createPQWalletFile(scheme, publicKey,
+          extCipherText, extIv, extMac,
+          seedCipherText, seedIv, seedMac,
+          salt, n, p);
+    } finally {
+      StringUtils.clear(encryptKey);
+      StringUtils.clear(derivedKey);
+    }
   }
 
   public static WalletFile createStandardPQ(byte[] password, PQScheme scheme,
+      byte[] extendedPrivateKey, byte[] seed, byte[] publicKey) throws CipherException {
+    return createPQ(password, scheme, extendedPrivateKey, seed, publicKey,
+        N_STANDARD, P_STANDARD);
+  }
+
+  // Back-compat overload retained for callers that only supply the extended
+  // private key (no seed available). Persists the ext segment only.
+  public static WalletFile createStandardPQ(byte[] password, PQScheme scheme,
       byte[] extendedPrivateKey, byte[] publicKey) throws CipherException {
-    return createPQ(password, scheme, extendedPrivateKey, publicKey, N_STANDARD, P_STANDARD);
+    return createPQ(password, scheme, extendedPrivateKey, null, publicKey,
+        N_STANDARD, P_STANDARD);
   }
 
   private static WalletFile createPQWalletFile(PQScheme scheme, byte[] publicKey,
-      byte[] cipherText, byte[] iv, byte[] salt, byte[] mac, int n, int p) {
+      byte[] extCipherText, byte[] extIv, byte[] extMac,
+      byte[] seedCipherText, byte[] seedIv, byte[] seedMac,
+      byte[] salt, int n, int p) {
     WalletFile walletFile = new WalletFile();
     walletFile.setScheme(scheme.name());
     walletFile.setAddress(
@@ -369,12 +433,22 @@ public class Wallet {
 
     WalletFile.Crypto crypto = new WalletFile.Crypto();
     crypto.setCipher(CIPHER);
-    crypto.setCiphertext(ByteArray.toHexString(cipherText));
-    walletFile.setCrypto(crypto);
 
-    WalletFile.CipherParams cipherParams = new WalletFile.CipherParams();
-    cipherParams.setIv(ByteArray.toHexString(iv));
-    crypto.setCipherparams(cipherParams);
+    if (extCipherText != null) {
+      crypto.setCiphertext(ByteArray.toHexString(extCipherText));
+      WalletFile.CipherParams cipherParams = new WalletFile.CipherParams();
+      cipherParams.setIv(ByteArray.toHexString(extIv));
+      crypto.setCipherparams(cipherParams);
+      crypto.setMac(ByteArray.toHexString(extMac));
+    }
+
+    if (seedCipherText != null) {
+      crypto.setSeedciphertext(ByteArray.toHexString(seedCipherText));
+      WalletFile.CipherParams seedCipherParams = new WalletFile.CipherParams();
+      seedCipherParams.setIv(ByteArray.toHexString(seedIv));
+      crypto.setSeedcipherparams(seedCipherParams);
+      crypto.setSeedmac(ByteArray.toHexString(seedMac));
+    }
 
     crypto.setKdf(SCRYPT);
     WalletFile.ScryptKdfParams kdfParams = new WalletFile.ScryptKdfParams();
@@ -385,16 +459,18 @@ public class Wallet {
     kdfParams.setSalt(ByteArray.toHexString(salt));
     crypto.setKdfparams(kdfParams);
 
-    crypto.setMac(ByteArray.toHexString(mac));
     walletFile.setCrypto(crypto);
     walletFile.setId(UUID.randomUUID().toString());
     walletFile.setVersion(CURRENT_VERSION);
     return walletFile;
   }
 
-  // Returns an FNDSA512 reconstructed from the stored extended private key
-  // (f ‖ g ‖ F ‖ h). Bare-private-key recovery is not possible — BC has no
-  // public API for h = g · f⁻¹ mod q — so the keystore persists h alongside.
+  // Reconstructs an FNDSA512 from whichever segments are persisted. When both
+  // are present the seed↔ext consistency check guards against insider tamper
+  // (an attacker who knows the password and rewrites only the seed segment to
+  // point at a different keypair would still produce the *wrong* derived
+  // public key). The address consistency check defends against an attacker who
+  // rewrites the cleartext `address` field.
   public static FNDSA512 decryptPQ(byte[] password, WalletFile walletFile)
       throws CipherException {
     if (walletFile.getScheme() == null) {
@@ -404,12 +480,154 @@ public class Wallet {
     if (scheme != PQScheme.FN_DSA_512) {
       throw new CipherException("Unsupported PQ scheme: " + scheme);
     }
-    byte[] extended = decrypt2PrivateBytes(password, walletFile);
-    try {
-      return FNDSA512.fromPrivateKeyWithPublicKey(extended);
-    } finally {
-      StringUtils.clear(extended);
+
+    validate(walletFile);
+    WalletFile.Crypto crypto = walletFile.getCrypto();
+
+    boolean extPresent = isExtSegmentPresent(crypto);
+    boolean seedPresent = isSeedSegmentPresent(crypto);
+    requireSegmentShape(crypto, extPresent, seedPresent);
+    if (!extPresent && !seedPresent) {
+      throw new CipherException(
+          "PQ wallet has neither ciphertext nor seedciphertext");
     }
+
+    byte[] derivedKey = deriveScryptKey(password, crypto);
+    byte[] encryptKey = Arrays.copyOfRange(derivedKey, 0, 16);
+    byte[] extended = null;
+    byte[] seedBytes = null;
+    try {
+      // Verify every MAC that is present before decrypting any segment so a
+      // partial-tamper attack cannot produce a half-valid keypair.
+      byte[] extCipherText = null;
+      byte[] seedCipherText = null;
+      if (extPresent) {
+        extCipherText = ByteArray.fromHexString(crypto.getCiphertext());
+        byte[] storedMac = ByteArray.fromHexString(crypto.getMac());
+        byte[] derivedMac = generateMac(derivedKey, extCipherText);
+        if (!Arrays.equals(derivedMac, storedMac)) {
+          throw new CipherException("Invalid password provided");
+        }
+      }
+      if (seedPresent) {
+        seedCipherText = ByteArray.fromHexString(crypto.getSeedciphertext());
+        byte[] storedMac = ByteArray.fromHexString(crypto.getSeedmac());
+        byte[] derivedMac = generateMac(derivedKey, seedCipherText);
+        if (!Arrays.equals(derivedMac, storedMac)) {
+          throw new CipherException("Invalid password provided");
+        }
+      }
+
+      byte[] extIv = extPresent
+          ? ByteArray.fromHexString(crypto.getCipherparams().getIv()) : null;
+      byte[] seedIv = seedPresent
+          ? ByteArray.fromHexString(crypto.getSeedcipherparams().getIv()) : null;
+      if (extIv != null && seedIv != null && Arrays.equals(extIv, seedIv)) {
+        throw new CipherException("PQ keystore reuses IV across ext/seed segments");
+      }
+
+      FNDSA512 signer;
+      if (extPresent) {
+        extended = performCipherOperation(Cipher.DECRYPT_MODE, extIv, encryptKey,
+            extCipherText);
+        signer = FNDSA512.fromPrivateKeyWithPublicKey(extended);
+        if (seedPresent) {
+          seedBytes = performCipherOperation(Cipher.DECRYPT_MODE, seedIv, encryptKey,
+              seedCipherText);
+          if (seedBytes.length != FNDSA512.SEED_LENGTH) {
+            throw new CipherException(
+                "Decrypted seed has unexpected length: " + seedBytes.length);
+          }
+          // Cross-check: re-deriving from the seed must reproduce the same
+          // public key. Mismatch means seed and ext disagree (insider tamper
+          // or corruption); reject rather than silently preferring one.
+          FNDSA512 seedDerived = new FNDSA512(seedBytes);
+          if (!Arrays.equals(seedDerived.getPublicKey(), signer.getPublicKey())) {
+            throw new CipherException(
+                "PQ keystore seed and extended private key disagree");
+          }
+        }
+      } else {
+        seedBytes = performCipherOperation(Cipher.DECRYPT_MODE, seedIv, encryptKey,
+            seedCipherText);
+        if (seedBytes.length != FNDSA512.SEED_LENGTH) {
+          throw new CipherException(
+              "Decrypted seed has unexpected length: " + seedBytes.length);
+        }
+        signer = new FNDSA512(seedBytes);
+      }
+
+      // Address consistency: the cleartext `address` field is unauthenticated.
+      // Reject any keystore whose stored address does not match the address
+      // derived from the reconstructed public key.
+      String derivedAddress = WalletApi.encode58Check(
+          PQSchemeRegistry.computeAddress(scheme, signer.getPublicKey()));
+      if (walletFile.getAddress() != null
+          && !derivedAddress.equals(walletFile.getAddress())) {
+        throw new CipherException(
+            "PQ keystore address does not match the decrypted public key");
+      }
+
+      return signer;
+    } finally {
+      StringUtils.clear(encryptKey);
+      StringUtils.clear(derivedKey);
+      if (extended != null) {
+        StringUtils.clear(extended);
+      }
+      if (seedBytes != null) {
+        StringUtils.clear(seedBytes);
+      }
+    }
+  }
+
+  private static boolean isExtSegmentPresent(WalletFile.Crypto crypto) {
+    return crypto.getCiphertext() != null
+        || crypto.getCipherparams() != null
+        || crypto.getMac() != null;
+  }
+
+  private static boolean isSeedSegmentPresent(WalletFile.Crypto crypto) {
+    return crypto.getSeedciphertext() != null
+        || crypto.getSeedcipherparams() != null
+        || crypto.getSeedmac() != null;
+  }
+
+  private static void requireSegmentShape(WalletFile.Crypto crypto,
+      boolean extPresent, boolean seedPresent) throws CipherException {
+    if (extPresent
+        && (crypto.getCiphertext() == null
+            || crypto.getCipherparams() == null
+            || crypto.getCipherparams().getIv() == null
+            || crypto.getMac() == null)) {
+      throw new CipherException(
+          "PQ keystore extended-key segment is incomplete");
+    }
+    if (seedPresent
+        && (crypto.getSeedciphertext() == null
+            || crypto.getSeedcipherparams() == null
+            || crypto.getSeedcipherparams().getIv() == null
+            || crypto.getSeedmac() == null)) {
+      throw new CipherException(
+          "PQ keystore seed segment is incomplete");
+    }
+  }
+
+  private static byte[] deriveScryptKey(byte[] password, WalletFile.Crypto crypto)
+      throws CipherException {
+    WalletFile.KdfParams kdfParams = crypto.getKdfparams();
+    if (kdfParams instanceof WalletFile.ScryptKdfParams) {
+      WalletFile.ScryptKdfParams scryptKdfParams = (WalletFile.ScryptKdfParams) kdfParams;
+      byte[] salt = ByteArray.fromHexString(scryptKdfParams.getSalt());
+      return generateDerivedScryptKey(password, salt,
+          scryptKdfParams.getN(), scryptKdfParams.getR(),
+          scryptKdfParams.getP(), scryptKdfParams.getDklen());
+    } else if (kdfParams instanceof WalletFile.Aes128CtrKdfParams) {
+      WalletFile.Aes128CtrKdfParams aesParams = (WalletFile.Aes128CtrKdfParams) kdfParams;
+      byte[] salt = ByteArray.fromHexString(aesParams.getSalt());
+      return generateAes128CtrDerivedKey(password, salt, aesParams.getC(), aesParams.getPrf());
+    }
+    throw new CipherException("Unable to deserialize params: " + crypto.getKdf());
   }
 
   static void validate(WalletFile walletFile) throws CipherException {

--- a/src/main/java/org/tron/keystore/Wallet.java
+++ b/src/main/java/org/tron/keystore/Wallet.java
@@ -486,6 +486,80 @@ public class Wallet {
   // rewrites the cleartext `address` field.
   public static PQSignature decryptPQ(byte[] password, WalletFile walletFile)
       throws CipherException {
+    PQKeyMaterial material = verifyAndDecryptPQ(password, walletFile);
+    try {
+      // The signer holds its own copy of the key material, so it stays valid
+      // after the raw plaintext buffers are zeroed below.
+      return material.signer;
+    } finally {
+      material.clearSecrets();
+    }
+  }
+
+  // Re-encrypts a PQ keystore under a new password while preserving the
+  // original segment shape: whichever of {ext, seed} were persisted are
+  // re-encrypted; the other stays absent. Scrypt parameters are re-derived
+  // from the wallet's existing kdf params (so callers cannot inadvertently
+  // downgrade N/p by passing wrong flags). Address and scheme are preserved.
+  // Throws if either MAC mismatches the old password or the persisted segments
+  // disagree on the keypair.
+  public static WalletFile reEncryptPQ(byte[] oldPassword, byte[] newPassword,
+      WalletFile walletFile) throws CipherException {
+    PQKeyMaterial material = verifyAndDecryptPQ(oldPassword, walletFile);
+    try {
+      // verifyAndDecryptPQ derives the key via deriveScryptKey, which rejects
+      // any non-scrypt KDF, so the kdf params are guaranteed scrypt here.
+      WalletFile.ScryptKdfParams kdf =
+          (WalletFile.ScryptKdfParams) walletFile.getCrypto().getKdfparams();
+      WalletFile reEncrypted = createPQ(newPassword, material.scheme,
+          material.extended, material.seed, material.signer.getPublicKey(),
+          kdf.getN(), kdf.getP());
+      reEncrypted.setId(walletFile.getId());
+      reEncrypted.setName(walletFile.getName());
+      return reEncrypted;
+    } finally {
+      material.clearSecrets();
+    }
+  }
+
+  // Recovered secret material from a PQ keystore. The reconstructed signer
+  // holds its own copy of the key, so zeroing these raw buffers via
+  // clearSecrets() does not invalidate a returned signer.
+  private static final class PQKeyMaterial {
+    final PQScheme scheme;
+    final PQSignature signer;
+    final byte[] extended; // plaintext persisted private key, or null
+    final byte[] seed;     // plaintext keygen seed, or null
+
+    PQKeyMaterial(PQScheme scheme, PQSignature signer, byte[] extended, byte[] seed) {
+      this.scheme = scheme;
+      this.signer = signer;
+      this.extended = extended;
+      this.seed = seed;
+    }
+
+    void clearSecrets() {
+      if (extended != null) {
+        StringUtils.clear(extended);
+      }
+      if (seed != null) {
+        StringUtils.clear(seed);
+      }
+    }
+  }
+
+  // Shared decrypt-and-verify core for PQ keystores, used by both decryptPQ and
+  // reEncryptPQ so the security checks cannot drift between them. Resolves and
+  // validates the scheme, verifies every persisted segment's MAC under
+  // `password` BEFORE decrypting any segment, enforces the independent-IV and
+  // seed↔ext consistency invariants, reconstructs the keypair, and checks the
+  // recovered address against the keystore's cleartext `address` field.
+  //
+  // Returns the reconstructed signer together with the raw plaintext segments.
+  // The caller owns the returned secrets and MUST call clearSecrets() once done
+  // (on any failure this method clears them before throwing).
+  private static PQKeyMaterial verifyAndDecryptPQ(byte[] password, WalletFile walletFile)
+      throws CipherException {
     if (walletFile.getScheme() == null) {
       throw new CipherException("Wallet has no PQ scheme tag");
     }
@@ -523,16 +597,14 @@ public class Wallet {
       if (extPresent) {
         extCipherText = ByteArray.fromHexString(crypto.getCiphertext());
         byte[] storedMac = ByteArray.fromHexString(crypto.getMac());
-        byte[] derivedMac = generateMac(derivedKey, extCipherText);
-        if (!Arrays.equals(derivedMac, storedMac)) {
+        if (!Arrays.equals(generateMac(derivedKey, extCipherText), storedMac)) {
           throw new CipherException("Invalid password provided");
         }
       }
       if (seedPresent) {
         seedCipherText = ByteArray.fromHexString(crypto.getSeedciphertext());
         byte[] storedMac = ByteArray.fromHexString(crypto.getSeedmac());
-        byte[] derivedMac = generateMac(derivedKey, seedCipherText);
-        if (!Arrays.equals(derivedMac, storedMac)) {
+        if (!Arrays.equals(generateMac(derivedKey, seedCipherText), storedMac)) {
           throw new CipherException("Invalid password provided");
         }
       }
@@ -587,129 +659,20 @@ public class Wallet {
             "PQ keystore address does not match the decrypted public key");
       }
 
-      return signer;
-    } finally {
-      StringUtils.clear(encryptKey);
-      StringUtils.clear(derivedKey);
+      return new PQKeyMaterial(scheme, signer, extended, seedBytes);
+    } catch (CipherException | RuntimeException e) {
+      // Decryption may have produced plaintext secrets before a later check
+      // failed; zero them before propagating so they never outlive this call.
       if (extended != null) {
         StringUtils.clear(extended);
       }
       if (seedBytes != null) {
         StringUtils.clear(seedBytes);
       }
-    }
-  }
-
-  // Re-encrypts a PQ keystore under a new password while preserving the
-  // original segment shape: whichever of {ext, seed} were persisted are
-  // re-encrypted; the other stays absent. Scrypt parameters are re-derived
-  // from the wallet's existing kdf params (so callers cannot inadvertently
-  // downgrade N/p by passing wrong flags). Address and scheme are preserved.
-  // Throws if either MAC mismatches the old password or the persisted segments
-  // disagree on the keypair.
-  public static WalletFile reEncryptPQ(byte[] oldPassword, byte[] newPassword,
-      WalletFile walletFile) throws CipherException {
-    if (walletFile.getScheme() == null) {
-      throw new CipherException("Wallet has no PQ scheme tag");
-    }
-    final PQScheme scheme;
-    try {
-      scheme = PQScheme.valueOf(walletFile.getScheme());
-    } catch (IllegalArgumentException e) {
-      throw new CipherException("Unsupported PQ scheme: " + walletFile.getScheme(), e);
-    }
-    if (!PQSchemeRegistry.contains(scheme)) {
-      throw new CipherException("Unsupported PQ scheme: " + scheme);
-    }
-    int expectedSeedLen = PQSchemeRegistry.getSeedLength(scheme);
-
-    validate(walletFile);
-    WalletFile.Crypto crypto = walletFile.getCrypto();
-    boolean extPresent = isExtSegmentPresent(crypto);
-    boolean seedPresent = isSeedSegmentPresent(crypto);
-    requireSegmentShape(crypto, extPresent, seedPresent);
-    if (!extPresent && !seedPresent) {
-      throw new CipherException(
-          "PQ wallet has neither ciphertext nor seedciphertext");
-    }
-    if (!(crypto.getKdfparams() instanceof WalletFile.ScryptKdfParams)) {
-      throw new CipherException("PQ wallets must use scrypt KDF");
-    }
-    WalletFile.ScryptKdfParams kdf = (WalletFile.ScryptKdfParams) crypto.getKdfparams();
-
-    byte[] derivedKey = deriveScryptKey(oldPassword, crypto);
-    byte[] encryptKey = Arrays.copyOfRange(derivedKey, 0, 16);
-    byte[] extended = null;
-    byte[] seedBytes = null;
-    try {
-      byte[] extCipherText = null;
-      byte[] seedCipherText = null;
-      if (extPresent) {
-        extCipherText = ByteArray.fromHexString(crypto.getCiphertext());
-        byte[] storedMac = ByteArray.fromHexString(crypto.getMac());
-        if (!Arrays.equals(generateMac(derivedKey, extCipherText), storedMac)) {
-          throw new CipherException("Invalid password provided");
-        }
-      }
-      if (seedPresent) {
-        seedCipherText = ByteArray.fromHexString(crypto.getSeedciphertext());
-        byte[] storedMac = ByteArray.fromHexString(crypto.getSeedmac());
-        if (!Arrays.equals(generateMac(derivedKey, seedCipherText), storedMac)) {
-          throw new CipherException("Invalid password provided");
-        }
-      }
-
-      byte[] extIv = extPresent
-          ? ByteArray.fromHexString(crypto.getCipherparams().getIv()) : null;
-      byte[] seedIv = seedPresent
-          ? ByteArray.fromHexString(crypto.getSeedcipherparams().getIv()) : null;
-      if (extIv != null && seedIv != null && Arrays.equals(extIv, seedIv)) {
-        throw new CipherException("PQ keystore reuses IV across ext/seed segments");
-      }
-
-      byte[] publicKey;
-      if (extPresent) {
-        extended = performCipherOperation(Cipher.DECRYPT_MODE, extIv, encryptKey,
-            extCipherText);
-        publicKey = PQSchemeRegistry
-            .fromPersistedPrivateKey(scheme, extended).getPublicKey();
-        if (seedPresent) {
-          seedBytes = performCipherOperation(Cipher.DECRYPT_MODE, seedIv, encryptKey,
-              seedCipherText);
-          if (seedBytes.length != expectedSeedLen) {
-            throw new CipherException(
-                "Decrypted seed has unexpected length: " + seedBytes.length);
-          }
-          byte[] seedDerivedPk = PQSchemeRegistry.fromSeed(scheme, seedBytes).getPublicKey();
-          if (!Arrays.equals(seedDerivedPk, publicKey)) {
-            throw new CipherException(
-                "PQ keystore seed and extended private key disagree");
-          }
-        }
-      } else {
-        seedBytes = performCipherOperation(Cipher.DECRYPT_MODE, seedIv, encryptKey,
-            seedCipherText);
-        if (seedBytes.length != expectedSeedLen) {
-          throw new CipherException(
-              "Decrypted seed has unexpected length: " + seedBytes.length);
-        }
-        publicKey = PQSchemeRegistry.fromSeed(scheme, seedBytes).getPublicKey();
-      }
-
-      WalletFile reEncrypted = createPQ(newPassword, scheme, extended, seedBytes,
-          publicKey, kdf.getN(), kdf.getP());
-      reEncrypted.setId(walletFile.getId());
-      reEncrypted.setName(walletFile.getName());
-      return reEncrypted;
+      throw e;
     } finally {
       StringUtils.clear(encryptKey);
       StringUtils.clear(derivedKey);
-      if (extended != null) {
-        StringUtils.clear(extended);
-      }
-      if (seedBytes != null) {
-        StringUtils.clear(seedBytes);
-      }
     }
   }
 

--- a/src/main/java/org/tron/keystore/Wallet.java
+++ b/src/main/java/org/tron/keystore/Wallet.java
@@ -367,6 +367,19 @@ public class Wallet {
       throw new CipherException("Invalid seed length: expected "
           + FNDSA512.SEED_LENGTH + " bytes");
     }
+    if (extendedPrivateKey != null) {
+      byte[] derivedPublicKey =
+          FNDSA512.fromPrivateKeyWithPublicKey(extendedPrivateKey).getPublicKey();
+      if (!Arrays.equals(derivedPublicKey, publicKey)) {
+        throw new CipherException("Extended private key does not match supplied public key");
+      }
+    }
+    if (seed != null) {
+      byte[] derivedPublicKey = new FNDSA512(seed).getPublicKey();
+      if (!Arrays.equals(derivedPublicKey, publicKey)) {
+        throw new CipherException("Seed does not match supplied public key");
+      }
+    }
 
     byte[] salt = generateRandomBytes(32);
     byte[] derivedKey = generateDerivedScryptKey(password, salt, n, R, p, DKLEN);
@@ -476,7 +489,12 @@ public class Wallet {
     if (walletFile.getScheme() == null) {
       throw new CipherException("Wallet has no PQ scheme tag");
     }
-    PQScheme scheme = PQScheme.valueOf(walletFile.getScheme());
+    final PQScheme scheme;
+    try {
+      scheme = PQScheme.valueOf(walletFile.getScheme());
+    } catch (IllegalArgumentException e) {
+      throw new CipherException("Unsupported PQ scheme: " + walletFile.getScheme(), e);
+    }
     if (scheme != PQScheme.FN_DSA_512) {
       throw new CipherException("Unsupported PQ scheme: " + scheme);
     }
@@ -622,12 +640,8 @@ public class Wallet {
       return generateDerivedScryptKey(password, salt,
           scryptKdfParams.getN(), scryptKdfParams.getR(),
           scryptKdfParams.getP(), scryptKdfParams.getDklen());
-    } else if (kdfParams instanceof WalletFile.Aes128CtrKdfParams) {
-      WalletFile.Aes128CtrKdfParams aesParams = (WalletFile.Aes128CtrKdfParams) kdfParams;
-      byte[] salt = ByteArray.fromHexString(aesParams.getSalt());
-      return generateAes128CtrDerivedKey(password, salt, aesParams.getC(), aesParams.getPrf());
     }
-    throw new CipherException("Unable to deserialize params: " + crypto.getKdf());
+    throw new CipherException("PQ wallets must use scrypt KDF");
   }
 
   static void validate(WalletFile walletFile) throws CipherException {

--- a/src/main/java/org/tron/keystore/Wallet.java
+++ b/src/main/java/org/tron/keystore/Wallet.java
@@ -7,8 +7,8 @@ import org.bouncycastle.crypto.params.KeyParameter;
 import org.tron.common.crypto.ECKey;
 import org.tron.common.crypto.Hash;
 import org.tron.common.crypto.SignInterface;
-import org.tron.common.crypto.pqc.FNDSA512;
 import org.tron.common.crypto.pqc.PQSchemeRegistry;
+import org.tron.common.crypto.pqc.PQSignature;
 import org.tron.common.crypto.sm2.SM2;
 import org.tron.common.utils.ByteArray;
 import org.tron.core.exception.CipherException;
@@ -336,13 +336,13 @@ public class Wallet {
     return sm2;
   }
 
-  // Encrypt a PQ wallet under scrypt + AES-128-CTR. Either segment (the 2176-byte
-  // extended private key f‖g‖F‖h, or the 48-byte FN-DSA seed) may be persisted;
-  // at least one must be supplied. When both are supplied a single scrypt run
-  // produces a derived key DK that is shared by both segments: DK[0..16] keys
-  // AES-CTR, DK[16..32] keys the MAC. Each segment gets an INDEPENDENT random
-  // IV (AES-CTR reuses keystream if IVs collide under a shared key) and its
-  // own Keccak-256 MAC over (DK[16..32] ‖ ciphertext).
+  // Encrypt a PQ wallet under scrypt + AES-128-CTR. Either segment (the
+  // scheme-specific persisted private key, or the scheme-specific keygen seed)
+  // may be persisted; at least one must be supplied. When both are supplied a
+  // single scrypt run produces a derived key DK that is shared by both
+  // segments: DK[0..16] keys AES-CTR, DK[16..32] keys the MAC. Each segment
+  // gets an INDEPENDENT random IV (AES-CTR reuses keystream if IVs collide
+  // under a shared key) and its own Keccak-256 MAC over (DK[16..32] ‖ ciphertext).
   public static WalletFile createPQ(byte[] password, PQScheme scheme,
       byte[] extendedPrivateKey, byte[] seed, byte[] publicKey, int n, int p)
       throws CipherException {
@@ -357,25 +357,25 @@ public class Wallet {
       throw new CipherException(
           "createPQ requires at least one of extendedPrivateKey or seed");
     }
-    int expectedExtLen = PQSchemeRegistry.getPrivateKeyLength(scheme)
-        + PQSchemeRegistry.getPublicKeyLength(scheme);
+    int expectedExtLen = PQSchemeRegistry.getPersistedPrivateKeyLength(scheme);
     if (extendedPrivateKey != null && extendedPrivateKey.length != expectedExtLen) {
       throw new CipherException("Invalid extended private key length: expected "
           + expectedExtLen + " for " + scheme.name());
     }
-    if (seed != null && seed.length != FNDSA512.SEED_LENGTH) {
+    int expectedSeedLen = PQSchemeRegistry.getSeedLength(scheme);
+    if (seed != null && seed.length != expectedSeedLen) {
       throw new CipherException("Invalid seed length: expected "
-          + FNDSA512.SEED_LENGTH + " bytes");
+          + expectedSeedLen + " bytes for " + scheme.name());
     }
     if (extendedPrivateKey != null) {
-      byte[] derivedPublicKey =
-          FNDSA512.fromPrivateKeyWithPublicKey(extendedPrivateKey).getPublicKey();
+      byte[] derivedPublicKey = PQSchemeRegistry
+          .fromPersistedPrivateKey(scheme, extendedPrivateKey).getPublicKey();
       if (!Arrays.equals(derivedPublicKey, publicKey)) {
         throw new CipherException("Extended private key does not match supplied public key");
       }
     }
     if (seed != null) {
-      byte[] derivedPublicKey = new FNDSA512(seed).getPublicKey();
+      byte[] derivedPublicKey = PQSchemeRegistry.fromSeed(scheme, seed).getPublicKey();
       if (!Arrays.equals(derivedPublicKey, publicKey)) {
         throw new CipherException("Seed does not match supplied public key");
       }
@@ -478,13 +478,13 @@ public class Wallet {
     return walletFile;
   }
 
-  // Reconstructs an FNDSA512 from whichever segments are persisted. When both
+  // Reconstructs a PQSignature from whichever segments are persisted. When both
   // are present the seed↔ext consistency check guards against insider tamper
   // (an attacker who knows the password and rewrites only the seed segment to
   // point at a different keypair would still produce the *wrong* derived
   // public key). The address consistency check defends against an attacker who
   // rewrites the cleartext `address` field.
-  public static FNDSA512 decryptPQ(byte[] password, WalletFile walletFile)
+  public static PQSignature decryptPQ(byte[] password, WalletFile walletFile)
       throws CipherException {
     if (walletFile.getScheme() == null) {
       throw new CipherException("Wallet has no PQ scheme tag");
@@ -495,9 +495,10 @@ public class Wallet {
     } catch (IllegalArgumentException e) {
       throw new CipherException("Unsupported PQ scheme: " + walletFile.getScheme(), e);
     }
-    if (scheme != PQScheme.FN_DSA_512) {
+    if (!PQSchemeRegistry.contains(scheme)) {
       throw new CipherException("Unsupported PQ scheme: " + scheme);
     }
+    int expectedSeedLen = PQSchemeRegistry.getSeedLength(scheme);
 
     validate(walletFile);
     WalletFile.Crypto crypto = walletFile.getCrypto();
@@ -544,22 +545,22 @@ public class Wallet {
         throw new CipherException("PQ keystore reuses IV across ext/seed segments");
       }
 
-      FNDSA512 signer;
+      PQSignature signer;
       if (extPresent) {
         extended = performCipherOperation(Cipher.DECRYPT_MODE, extIv, encryptKey,
             extCipherText);
-        signer = FNDSA512.fromPrivateKeyWithPublicKey(extended);
+        signer = PQSchemeRegistry.fromPersistedPrivateKey(scheme, extended);
         if (seedPresent) {
           seedBytes = performCipherOperation(Cipher.DECRYPT_MODE, seedIv, encryptKey,
               seedCipherText);
-          if (seedBytes.length != FNDSA512.SEED_LENGTH) {
+          if (seedBytes.length != expectedSeedLen) {
             throw new CipherException(
                 "Decrypted seed has unexpected length: " + seedBytes.length);
           }
           // Cross-check: re-deriving from the seed must reproduce the same
           // public key. Mismatch means seed and ext disagree (insider tamper
           // or corruption); reject rather than silently preferring one.
-          FNDSA512 seedDerived = new FNDSA512(seedBytes);
+          PQSignature seedDerived = PQSchemeRegistry.fromSeed(scheme, seedBytes);
           if (!Arrays.equals(seedDerived.getPublicKey(), signer.getPublicKey())) {
             throw new CipherException(
                 "PQ keystore seed and extended private key disagree");
@@ -568,11 +569,11 @@ public class Wallet {
       } else {
         seedBytes = performCipherOperation(Cipher.DECRYPT_MODE, seedIv, encryptKey,
             seedCipherText);
-        if (seedBytes.length != FNDSA512.SEED_LENGTH) {
+        if (seedBytes.length != expectedSeedLen) {
           throw new CipherException(
               "Decrypted seed has unexpected length: " + seedBytes.length);
         }
-        signer = new FNDSA512(seedBytes);
+        signer = PQSchemeRegistry.fromSeed(scheme, seedBytes);
       }
 
       // Address consistency: the cleartext `address` field is unauthenticated.

--- a/src/main/java/org/tron/keystore/WalletFile.java
+++ b/src/main/java/org/tron/keystore/WalletFile.java
@@ -1,5 +1,6 @@
 package org.tron.keystore;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -24,6 +25,11 @@ public class WalletFile {
     private Crypto crypto;
     private String id;
     private int version;
+    // Signature scheme discriminator: null/"ECKEY" for legacy ECDSA wallets,
+    // "SM2" for SM2 wallets, "FN_DSA_512" for Falcon-512 PQ wallets. Omitted on
+    // serialization when null so existing keystore files stay byte-identical.
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String scheme;
     @Getter
     @Setter
     private File sourceFile;
@@ -77,6 +83,14 @@ public class WalletFile {
         this.version = version;
     }
 
+    public String getScheme() {
+        return scheme;
+    }
+
+    public void setScheme(String scheme) {
+        this.scheme = scheme;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -98,19 +112,25 @@ public class WalletFile {
                 : that.getCrypto() != null) {
             return false;
         } 
-        if (getId() != null 
+        if (getId() != null
                 ? !getId().equals(that.getId())
                 : that.getId() != null) {
             return false;
         }
+        if (getScheme() != null
+                ? !getScheme().equals(that.getScheme())
+                : that.getScheme() != null) {
+            return false;
+        }
         return version == that.version;
-    } 
+    }
 
     @Override
     public int hashCode() {
         int result = getAddress() != null ? getAddress().hashCode() : 0;
         result = 31 * result + (getCrypto() != null ? getCrypto().hashCode() : 0);
         result = 31 * result + (getId() != null ? getId().hashCode() : 0);
+        result = 31 * result + (getScheme() != null ? getScheme().hashCode() : 0);
         result = 31 * result + version;
         return result;
     }  

--- a/src/main/java/org/tron/keystore/WalletFile.java
+++ b/src/main/java/org/tron/keystore/WalletFile.java
@@ -145,6 +145,19 @@ public class WalletFile {
 
         private String mac;
 
+        // Optional parallel ciphertext for the 48-byte FN-DSA seed. When present,
+        // the seed is encrypted under the same scrypt-derived AES key as
+        // `ciphertext` but with an INDEPENDENT random IV and its own MAC.
+        // Omitted from JSON when null so legacy ECKey/SM2 wallets stay
+        // byte-identical and PQ wallets that only persist the extended private
+        // key do not emit empty fields.
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        private String seedciphertext;
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        private CipherParams seedcipherparams;
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        private String seedmac;
+
         public Crypto() {
         }
 
@@ -208,6 +221,30 @@ public class WalletFile {
             this.mac = mac;
         }
 
+        public String getSeedciphertext() {
+            return seedciphertext;
+        }
+
+        public void setSeedciphertext(String seedciphertext) {
+            this.seedciphertext = seedciphertext;
+        }
+
+        public CipherParams getSeedcipherparams() {
+            return seedcipherparams;
+        }
+
+        public void setSeedcipherparams(CipherParams seedcipherparams) {
+            this.seedcipherparams = seedcipherparams;
+        }
+
+        public String getSeedmac() {
+            return seedmac;
+        }
+
+        public void setSeedmac(String seedmac) {
+            this.seedmac = seedmac;
+        }
+
         @Override
         public boolean equals(Object o) {
             if (this == o) {
@@ -216,9 +253,9 @@ public class WalletFile {
             if (!(o instanceof Crypto)) {
                 return false;
             }
-            
+
             Crypto that = (Crypto) o;
-            
+
             if (getCipher() != null
                     ? !getCipher().equals(that.getCipher())
                     : that.getCipher() != null) {
@@ -244,9 +281,24 @@ public class WalletFile {
                     : that.getKdfparams() != null) {
                 return false;
             }
-            return getMac() != null
-                    ? getMac().equals(that.getMac()) : that.getMac() == null;
-        }  
+            if (getMac() != null
+                    ? !getMac().equals(that.getMac())
+                    : that.getMac() != null) {
+                return false;
+            }
+            if (getSeedciphertext() != null
+                    ? !getSeedciphertext().equals(that.getSeedciphertext())
+                    : that.getSeedciphertext() != null) {
+                return false;
+            }
+            if (getSeedcipherparams() != null
+                    ? !getSeedcipherparams().equals(that.getSeedcipherparams())
+                    : that.getSeedcipherparams() != null) {
+                return false;
+            }
+            return getSeedmac() != null
+                    ? getSeedmac().equals(that.getSeedmac()) : that.getSeedmac() == null;
+        }
 
         @Override
         public int hashCode() {
@@ -256,9 +308,12 @@ public class WalletFile {
             result = 31 * result + (getKdf() != null ? getKdf().hashCode() : 0);
             result = 31 * result + (getKdfparams() != null ? getKdfparams().hashCode() : 0);
             result = 31 * result + (getMac() != null ? getMac().hashCode() : 0);
+            result = 31 * result + (getSeedciphertext() != null ? getSeedciphertext().hashCode() : 0);
+            result = 31 * result + (getSeedcipherparams() != null ? getSeedcipherparams().hashCode() : 0);
+            result = 31 * result + (getSeedmac() != null ? getSeedmac().hashCode() : 0);
             return result;
         }
-        
+
     }
 
     public static class CipherParams {

--- a/src/main/java/org/tron/keystore/WalletUtils.java
+++ b/src/main/java/org/tron/keystore/WalletUtils.java
@@ -195,8 +195,8 @@ public class WalletUtils {
 
   public static Credentials loadCredentials(byte[] password, WalletFile walletFile)
       throws CipherException {
-    if ("FN_DSA_512".equals(walletFile.getScheme())) {
-      return CredentialsFalcon.create(Wallet.decryptPQ(password, walletFile));
+    if (walletFile.getScheme() != null && !walletFile.getScheme().isEmpty()) {
+      return CredentialsPQ.create(Wallet.decryptPQ(password, walletFile));
     }
     if (isEckey) {
       return CredentialsEckey.create(Wallet.decrypt(password, walletFile));

--- a/src/main/java/org/tron/keystore/WalletUtils.java
+++ b/src/main/java/org/tron/keystore/WalletUtils.java
@@ -190,15 +190,14 @@ public class WalletUtils {
   public static Credentials loadCredentials(byte[] password, File source)
       throws IOException, CipherException {
     WalletFile walletFile = objectMapper.readValue(source, WalletFile.class);
-
-    if (isEckey) {
-      return CredentialsEckey.create(Wallet.decrypt(password, walletFile));
-    }
-    return CredentialsSM2.create(Wallet.decryptSM2(password, walletFile));
+    return loadCredentials(password, walletFile);
   }
 
   public static Credentials loadCredentials(byte[] password, WalletFile walletFile)
       throws CipherException {
+    if ("FN_DSA_512".equals(walletFile.getScheme())) {
+      return CredentialsFalcon.create(Wallet.decryptPQ(password, walletFile));
+    }
     if (isEckey) {
       return CredentialsEckey.create(Wallet.decrypt(password, walletFile));
     }

--- a/src/main/java/org/tron/keystore/WalletUtils.java
+++ b/src/main/java/org/tron/keystore/WalletUtils.java
@@ -207,6 +207,15 @@ public class WalletUtils {
   public static WalletFile loadWalletFile(File source) throws IOException {
     return objectMapper.readValue(source, WalletFile.class);
   }
+
+  // Persists `walletFile` to `destination`, overwriting any existing content,
+  // and re-applies owner-only permissions. Unlike updateWalletFile this does
+  // NOT regenerate ciphertext — callers are responsible for producing the
+  // already-encrypted WalletFile (e.g. via Wallet.reEncryptPQ).
+  public static void writeWalletFile(WalletFile walletFile, File destination) throws IOException {
+    objectMapper.writeValue(destination, walletFile);
+    FilePermissionUtils.setOwnerOnlyFile(destination.toPath());
+  }
 //
 //    public static Credentials loadBip39Credentials(String password, String mnemonic) {
 //        byte[] seed = MnemonicUtils.generateSeed(mnemonic, password);

--- a/src/main/java/org/tron/walletcli/Client.java
+++ b/src/main/java/org/tron/walletcli/Client.java
@@ -3206,7 +3206,7 @@ public class Client {
       if (!PQSchemeRegistry.contains(scheme)) {
         return null;
       }
-      return scheme;
+      return PQSchemeRegistry.resolve(scheme);
     } catch (IllegalArgumentException e) {
       return null;
     }
@@ -3267,14 +3267,21 @@ public class Client {
   }
 
   private void importWalletPQ(String[] parameters) throws CipherException, IOException {
-    PQScheme scheme = parsePQScheme(parameters);
+    String hexOrPathArg = extractPQHexArg(parameters);
+    PQScheme scheme;
+    if (parameters != null && parameters.length >= 2) {
+        scheme = parsePQScheme(new String[] {parameters[0]});
+    } else if (parameters != null && parameters.length == 1 && hexOrPathArg == null) {
+        scheme = parsePQScheme(parameters);
+    } else {
+        scheme = PQScheme.FN_DSA_512;
+    }
     if (scheme == null) {
       System.out.println("Unsupported PQ scheme. Supported: FN_DSA_512");
       return;
     }
     int expected = PQSchemeRegistry.getPrivateKeyLength(scheme)
         + PQSchemeRegistry.getPublicKeyLength(scheme);
-    String hexOrPathArg = extractPQHexArg(parameters);
     if (hexOrPathArg == null) {
       System.out.println("ImportWalletPQ requires the key material as an argument: either a "
           + FNDSA512.SEED_LENGTH + "-byte / " + (FNDSA512.SEED_LENGTH * 2)
@@ -3293,14 +3300,18 @@ public class Client {
     }
     char[] password = walletApiWrapper.isUnifiedExist() ?
         byte2Char(walletApiWrapper.getWallet().getUnifiedPassword()) : Utils.inputPassword2Twice(false);
-    String fileName = walletApiWrapper.importWalletPQ(
-        password, scheme, material.extendedPrivateKey, material.seed);
-    StringUtils.clear(password);
-    if (material.extendedPrivateKey != null) {
-      java.util.Arrays.fill(material.extendedPrivateKey, (byte) 0);
-    }
-    if (material.seed != null) {
-      java.util.Arrays.fill(material.seed, (byte) 0);
+    String fileName;
+    try {
+      fileName = walletApiWrapper.importWalletPQ(
+          password, scheme, material.extendedPrivateKey, material.seed);
+    } finally {
+      StringUtils.clear(password);
+      if (material.extendedPrivateKey != null) {
+        java.util.Arrays.fill(material.extendedPrivateKey, (byte) 0);
+      }
+      if (material.seed != null) {
+        java.util.Arrays.fill(material.seed, (byte) 0);
+      }
     }
     if (fileName == null) {
       System.out.println("ImportWalletPQ " + failedHighlight() + " !!");
@@ -3336,9 +3347,9 @@ public class Client {
     if (parameters.length == 1 && parameters[0] != null && !parameters[0].isEmpty()) {
       try {
         PQScheme.valueOf(parameters[0]);
-        return null;
+        return null; // Scheme provided but no hex
       } catch (IllegalArgumentException e) {
-        return parameters[0];
+        return parameters[0]; // Not a scheme, so it must be hex/path
       }
     }
     return null;

--- a/src/main/java/org/tron/walletcli/Client.java
+++ b/src/main/java/org/tron/walletcli/Client.java
@@ -3219,17 +3219,31 @@ public class Client {
       return;
     }
     try {
-      FNDSA512 signer = new FNDSA512();
+      byte[] seed = new byte[FNDSA512.SEED_LENGTH];
+      new java.security.SecureRandom().nextBytes(seed);
+      FNDSA512 signer = new FNDSA512(seed);
       byte[] address = signer.getAddress();
       String addressStr = WalletApi.encode58Check(address);
+      String seedStr = ByteArray.toHexString(seed);
+      byte[] priv = signer.getPrivateKey();
+      byte[] extPriv = signer.getPrivateKeyWithPublicKey();
       String pubKeyStr = ByteArray.toHexString(signer.getPublicKey());
-      String extPrivStr = ByteArray.toHexString(signer.getPrivateKeyWithPublicKey());
+      String privKeyStr = ByteArray.toHexString(priv);
+      String extPrivStr = ByteArray.toHexString(extPriv);
       System.out.println("scheme: " + scheme.name());
       System.out.println("address: " + addressStr);
-      System.out.println("publicKey: " + pubKeyStr);
-      System.out.println("privateKey (extended f||g||F||h): " + extPrivStr);
-      System.out.println("WARNING: store the extended private key securely; "
-          + "the public key cannot be re-derived from f||g||F alone.");
+      System.out.println("seed (" + FNDSA512.SEED_LENGTH + " bytes): " + seedStr);
+      System.out.println("publicKey (" + signer.getPublicKey().length + " bytes): " + pubKeyStr);
+      System.out.println("privateKey (f||g||F, " + priv.length + " bytes): " + privKeyStr);
+      System.out.println("privateKey extended (f||g||F||h, " + extPriv.length + " bytes): "
+          + extPrivStr);
+      System.out.println("WARNING: store either the seed or the extended private key securely. "
+          + "The seed alone is sufficient to re-derive the full keypair; "
+          + "the bare private key f||g||F is NOT sufficient because the public key "
+          + "cannot be re-derived from it.");
+      java.util.Arrays.fill(seed, (byte) 0);
+      java.util.Arrays.fill(priv, (byte) 0);
+      java.util.Arrays.fill(extPriv, (byte) 0);
     } catch (Exception e) {
       System.out.println("GeneratePQKey " + failedHighlight() + " !!! " + e.getMessage());
     }
@@ -3258,22 +3272,36 @@ public class Client {
       System.out.println("Unsupported PQ scheme. Supported: FN_DSA_512");
       return;
     }
-    System.out.println("(Note: This operation will overwrite the old keystore file of the same address)");
-    char[] password = walletApiWrapper.isUnifiedExist() ?
-        byte2Char(walletApiWrapper.getWallet().getUnifiedPassword()) : Utils.inputPassword2Twice(false);
     int expected = PQSchemeRegistry.getPrivateKeyLength(scheme)
         + PQSchemeRegistry.getPublicKeyLength(scheme);
-    System.out.println("Please input the extended private key hex (f||g||F||h, "
-        + expected + " bytes / " + (expected * 2) + " hex chars):");
-    byte[] extPriv = inputPQExtendedPrivateKey(expected);
-    if (extPriv == null) {
-      System.out.println("ImportWalletPQ " + failedHighlight() + " !!");
-      StringUtils.clear(password);
+    String hexOrPathArg = extractPQHexArg(parameters);
+    if (hexOrPathArg == null) {
+      System.out.println("ImportWalletPQ requires the key material as an argument: either a "
+          + FNDSA512.SEED_LENGTH + "-byte / " + (FNDSA512.SEED_LENGTH * 2)
+          + "-hex-char seed, or the " + expected + "-byte / " + (expected * 2)
+          + "-hex-char extended private key (priv||pub).");
+      System.out.println("Usage:");
+      System.out.println("  ImportWalletPQ " + scheme.name() + " <hex>");
+      System.out.println("  ImportWalletPQ " + scheme.name() + " <path-to-file-containing-hex>");
       return;
     }
-    String fileName = walletApiWrapper.importWalletPQ(password, scheme, extPriv);
+    System.out.println("(Note: This operation will overwrite the old keystore file of the same address)");
+    PQKeyMaterial material = readPQKeyMaterialFromArg(hexOrPathArg, expected);
+    if (material == null) {
+      System.out.println("ImportWalletPQ " + failedHighlight() + " !!");
+      return;
+    }
+    char[] password = walletApiWrapper.isUnifiedExist() ?
+        byte2Char(walletApiWrapper.getWallet().getUnifiedPassword()) : Utils.inputPassword2Twice(false);
+    String fileName = walletApiWrapper.importWalletPQ(
+        password, scheme, material.extendedPrivateKey, material.seed);
     StringUtils.clear(password);
-    java.util.Arrays.fill(extPriv, (byte) 0);
+    if (material.extendedPrivateKey != null) {
+      java.util.Arrays.fill(material.extendedPrivateKey, (byte) 0);
+    }
+    if (material.seed != null) {
+      java.util.Arrays.fill(material.seed, (byte) 0);
+    }
     if (fileName == null) {
       System.out.println("ImportWalletPQ " + failedHighlight() + " !!");
       return;
@@ -3282,26 +3310,93 @@ public class Client {
         + File.separator + "Wallet" + File.separator + fileName);
   }
 
-  private byte[] inputPQExtendedPrivateKey(int expectedLen) throws IOException {
-    int hexLen = expectedLen * 2;
-    byte[] temp = new byte[hexLen + 16];
-    int nTime = 0;
-    while (nTime < retryTime) {
-      int len = System.in.read(temp, 0, temp.length);
-      if (len >= hexLen) {
-        byte[] hex = Arrays.copyOfRange(temp, 0, hexLen);
-        byte[] result = StringUtils.hexs2Bytes(hex);
-        StringUtils.clear(hex);
-        if (result != null && result.length == expectedLen) {
-          StringUtils.clear(temp);
-          return result;
-        }
-      }
-      System.out.println("Invalid extended private key hex, please try again.");
-      ++nTime;
+  /** Pair of (seed, extendedPrivateKey) returned by {@link #readPQKeyMaterialFromArg}. */
+  private static final class PQKeyMaterial {
+    final byte[] seed;
+    final byte[] extendedPrivateKey;
+    PQKeyMaterial(byte[] seed, byte[] extendedPrivateKey) {
+      this.seed = seed;
+      this.extendedPrivateKey = extendedPrivateKey;
     }
-    StringUtils.clear(temp);
+  }
+
+  /**
+   * Returns the hex (or file path) argument to ImportWalletPQ, if present.
+   * Accepts forms: {@code ImportWalletPQ <hex|path>} and
+   * {@code ImportWalletPQ <scheme> <hex|path>}. Returns {@code null} when no
+   * such argument was supplied (the caller should fall back to interactive input).
+   */
+  private static String extractPQHexArg(String[] parameters) {
+    if (parameters == null || parameters.length == 0) {
+      return null;
+    }
+    if (parameters.length >= 2 && parameters[1] != null && !parameters[1].isEmpty()) {
+      return parameters[1];
+    }
+    if (parameters.length == 1 && parameters[0] != null && !parameters[0].isEmpty()) {
+      try {
+        PQScheme.valueOf(parameters[0]);
+        return null;
+      } catch (IllegalArgumentException e) {
+        return parameters[0];
+      }
+    }
     return null;
+  }
+
+  /**
+   * Reads Falcon-512 key material from a CLI argument: either the hex string itself
+   * or a path to a file containing the hex. Auto-detects format by length:
+   * a {@link FNDSA512#SEED_LENGTH}-byte seed is expanded into the full extended
+   * private key (priv||pub); an {@code expectedLen}-byte extended private key is
+   * returned verbatim. Returns {@code null} (and prints a user-facing error) on
+   * any I/O failure, hex-decode failure, or length mismatch.
+   */
+  private static PQKeyMaterial readPQKeyMaterialFromArg(String hexOrPath, int expectedLen) {
+    String hex = hexOrPath;
+    java.io.File file = new java.io.File(hexOrPath);
+    if (file.isFile()) {
+      try {
+        hex = new String(java.nio.file.Files.readAllBytes(file.toPath()),
+            java.nio.charset.StandardCharsets.US_ASCII);
+      } catch (IOException e) {
+        System.out.println("Failed to read file: " + e.getMessage());
+        return null;
+      }
+    }
+    hex = hex.replaceAll("\\s+", "");
+    int seedHexLen = FNDSA512.SEED_LENGTH * 2;
+    int extHexLen = expectedLen * 2;
+    if (hex.length() != seedHexLen && hex.length() != extHexLen) {
+      System.out.println("Invalid PQ key length: got " + hex.length() + " hex chars, expected "
+          + seedHexLen + " (seed) or " + extHexLen + " (extended private key priv||pub).");
+      return null;
+    }
+    byte[] decoded = StringUtils.hexs2Bytes(
+        hex.getBytes(java.nio.charset.StandardCharsets.US_ASCII));
+    if (decoded == null) {
+      System.out.println("Invalid PQ key hex (not a valid hex string).");
+      return null;
+    }
+    if (decoded.length == FNDSA512.SEED_LENGTH) {
+      // Validate the seed produces a usable keypair, but pass the seed itself
+      // through so the keystore can persist BOTH segments (and so the bare
+      // seed remains available for future export / re-derivation).
+      try {
+        new FNDSA512(decoded);
+      } catch (RuntimeException e) {
+        java.util.Arrays.fill(decoded, (byte) 0);
+        System.out.println("Failed to derive Falcon-512 keypair from seed: " + e.getMessage());
+        return null;
+      }
+      return new PQKeyMaterial(decoded, null);
+    }
+    if (decoded.length != expectedLen) {
+      System.out.println("Invalid PQ key length after decode: got " + decoded.length
+          + " bytes, expected " + expectedLen + ".");
+      return null;
+    }
+    return new PQKeyMaterial(null, decoded);
   }
 
   private void updateAccountPermission(String[] parameters)

--- a/src/main/java/org/tron/walletcli/Client.java
+++ b/src/main/java/org/tron/walletcli/Client.java
@@ -31,6 +31,7 @@ import static org.tron.mnemonic.MnemonicUtils.getPrivateKeyFromMnemonic;
 import static org.tron.walletserver.WalletApi.addressValid;
 import static org.tron.walletserver.WalletApi.decodeFromBase58Check;
 
+import java.security.SecureRandom;
 import org.tron.walletcli.cli.GlobalOptions;
 import org.tron.walletcli.cli.CommandRegistry;
 import org.tron.walletcli.cli.OutputFormatter;
@@ -93,7 +94,7 @@ import org.tron.api.GrpcAPI.AddressPrKeyPairMessage;
 import org.tron.common.crypto.Hash;
 import org.tron.common.crypto.SignInterface;
 import org.tron.common.crypto.SignUtils;
-import org.tron.common.crypto.pqc.FNDSA512;
+import org.tron.common.crypto.pqc.PQSignature;
 import org.tron.common.crypto.pqc.PQSchemeRegistry;
 import org.tron.common.enums.NetType;
 import org.tron.common.utils.AbiUtil;
@@ -3206,7 +3207,7 @@ public class Client {
       if (!PQSchemeRegistry.contains(scheme)) {
         return null;
       }
-      return PQSchemeRegistry.resolve(scheme);
+      return scheme;
     } catch (IllegalArgumentException e) {
       return null;
     }
@@ -3215,44 +3216,67 @@ public class Client {
   private void generatePQKey(String[] parameters) {
     PQScheme scheme = parsePQScheme(parameters);
     if (scheme == null) {
-      System.out.println("Unsupported PQ scheme. Supported: FN_DSA_512");
+      System.out.println("Unsupported PQ scheme. Supported: " + supportedPQSchemes());
       return;
     }
+    int seedLength = PQSchemeRegistry.getSeedLength(scheme);
+    byte[] seed = new byte[seedLength];
+    byte[] priv = null;
+    byte[] persisted = null;
     try {
-      byte[] seed = new byte[FNDSA512.SEED_LENGTH];
-      new java.security.SecureRandom().nextBytes(seed);
-      FNDSA512 signer = new FNDSA512(seed);
+      new SecureRandom().nextBytes(seed);
+      PQSignature signer = PQSchemeRegistry.fromSeed(scheme, seed);
       byte[] address = signer.getAddress();
       String addressStr = WalletApi.encode58Check(address);
       String seedStr = ByteArray.toHexString(seed);
-      byte[] priv = signer.getPrivateKey();
-      byte[] extPriv = signer.getPrivateKeyWithPublicKey();
+      priv = signer.getPrivateKey();
+      persisted = signer.getPersistedPrivateKey();
       String pubKeyStr = ByteArray.toHexString(signer.getPublicKey());
       String privKeyStr = ByteArray.toHexString(priv);
-      String extPrivStr = ByteArray.toHexString(extPriv);
+      String persistedStr = ByteArray.toHexString(persisted);
       System.out.println("scheme: " + scheme.name());
-      System.out.println("address: " + addressStr);
-      System.out.println("seed (" + FNDSA512.SEED_LENGTH + " bytes): " + seedStr);
+      System.out.println("seed (" + seedLength + " bytes): " + seedStr);
+      System.out.println("privateKey (" + priv.length + " bytes): " + privKeyStr);
       System.out.println("publicKey (" + signer.getPublicKey().length + " bytes): " + pubKeyStr);
-      System.out.println("privateKey (f||g||F, " + priv.length + " bytes): " + privKeyStr);
-      System.out.println("privateKey extended (f||g||F||h, " + extPriv.length + " bytes): "
-          + extPrivStr);
-      System.out.println("WARNING: store either the seed or the extended private key securely. "
-          + "The seed alone is sufficient to re-derive the full keypair; "
-          + "the bare private key f||g||F is NOT sufficient because the public key "
-          + "cannot be re-derived from it.");
-      java.util.Arrays.fill(seed, (byte) 0);
-      java.util.Arrays.fill(priv, (byte) 0);
-      java.util.Arrays.fill(extPriv, (byte) 0);
+      System.out.println("address: " + addressStr);
+      System.out.println("privateKey persisted form (" + persisted.length + " bytes): "
+          + persistedStr);
+      System.out.println("WARNING: store the seed and the persisted private key securely.");
     } catch (Exception e) {
       System.out.println("GeneratePQKey " + failedHighlight() + " !!! " + e.getMessage());
+    } finally {
+      java.util.Arrays.fill(seed, (byte) 0);
+      if (priv != null) {
+        java.util.Arrays.fill(priv, (byte) 0);
+      }
+      if (persisted != null) {
+        java.util.Arrays.fill(persisted, (byte) 0);
+      }
     }
+  }
+
+  private static String supportedPQSchemes() {
+    StringBuilder sb = new StringBuilder();
+    boolean first = true;
+    for (PQScheme s : PQScheme.values()) {
+      if (s == PQScheme.UNKNOWN_PQ_SCHEME || s == PQScheme.UNRECOGNIZED) {
+        continue;
+      }
+      if (PQSchemeRegistry.contains(s)) {
+        if (!first) {
+          sb.append(", ");
+        }
+        sb.append(s.name());
+        first = false;
+      }
+    }
+    return sb.toString();
   }
 
   private void registerWalletPQ(String[] parameters) throws CipherException, IOException {
     PQScheme scheme = parsePQScheme(parameters);
     if (scheme == null) {
-      System.out.println("Unsupported PQ scheme. Supported: FN_DSA_512");
+      System.out.println("Unsupported PQ scheme. Supported: " + supportedPQSchemes());
       return;
     }
     char[] password = Utils.inputPassword2Twice(false);
@@ -3277,23 +3301,23 @@ public class Client {
         scheme = PQScheme.FN_DSA_512;
     }
     if (scheme == null) {
-      System.out.println("Unsupported PQ scheme. Supported: FN_DSA_512");
+      System.out.println("Unsupported PQ scheme. Supported: " + supportedPQSchemes());
       return;
     }
-    int expected = PQSchemeRegistry.getPrivateKeyLength(scheme)
-        + PQSchemeRegistry.getPublicKeyLength(scheme);
+    int expected = PQSchemeRegistry.getPersistedPrivateKeyLength(scheme);
+    int seedLen = PQSchemeRegistry.getSeedLength(scheme);
     if (hexOrPathArg == null) {
       System.out.println("ImportWalletPQ requires the key material as an argument: either a "
-          + FNDSA512.SEED_LENGTH + "-byte / " + (FNDSA512.SEED_LENGTH * 2)
+          + seedLen + "-byte / " + (seedLen * 2)
           + "-hex-char seed, or the " + expected + "-byte / " + (expected * 2)
-          + "-hex-char extended private key (priv||pub).");
+          + "-hex-char persisted private key.");
       System.out.println("Usage:");
       System.out.println("  ImportWalletPQ " + scheme.name() + " <hex>");
       System.out.println("  ImportWalletPQ " + scheme.name() + " <path-to-file-containing-hex>");
       return;
     }
     System.out.println("(Note: This operation will overwrite the old keystore file of the same address)");
-    PQKeyMaterial material = readPQKeyMaterialFromArg(hexOrPathArg, expected);
+    PQKeyMaterial material = readPQKeyMaterialFromArg(scheme, hexOrPathArg, expected);
     if (material == null) {
       System.out.println("ImportWalletPQ " + failedHighlight() + " !!");
       return;
@@ -3356,14 +3380,14 @@ public class Client {
   }
 
   /**
-   * Reads Falcon-512 key material from a CLI argument: either the hex string itself
-   * or a path to a file containing the hex. Auto-detects format by length:
-   * a {@link FNDSA512#SEED_LENGTH}-byte seed is expanded into the full extended
-   * private key (priv||pub); an {@code expectedLen}-byte extended private key is
-   * returned verbatim. Returns {@code null} (and prints a user-facing error) on
-   * any I/O failure, hex-decode failure, or length mismatch.
+   * Reads PQ key material from a CLI argument: either the hex string itself or
+   * a path to a file containing the hex. Auto-detects format by length: a
+   * scheme-specific seed is validated; a persisted private key is returned
+   * verbatim. Returns {@code null} (and prints a user-facing error) on any I/O
+   * failure, hex-decode failure, or length mismatch.
    */
-  private static PQKeyMaterial readPQKeyMaterialFromArg(String hexOrPath, int expectedLen) {
+  private static PQKeyMaterial readPQKeyMaterialFromArg(
+      PQScheme scheme, String hexOrPath, int expectedLen) {
     String hex = hexOrPath;
     java.io.File file = new java.io.File(hexOrPath);
     if (file.isFile()) {
@@ -3376,11 +3400,12 @@ public class Client {
       }
     }
     hex = hex.replaceAll("\\s+", "");
-    int seedHexLen = FNDSA512.SEED_LENGTH * 2;
+    int seedLen = PQSchemeRegistry.getSeedLength(scheme);
+    int seedHexLen = seedLen * 2;
     int extHexLen = expectedLen * 2;
     if (hex.length() != seedHexLen && hex.length() != extHexLen) {
       System.out.println("Invalid PQ key length: got " + hex.length() + " hex chars, expected "
-          + seedHexLen + " (seed) or " + extHexLen + " (extended private key priv||pub).");
+          + seedHexLen + " (seed) or " + extHexLen + " (persisted private key).");
       return null;
     }
     byte[] decoded = StringUtils.hexs2Bytes(
@@ -3389,15 +3414,13 @@ public class Client {
       System.out.println("Invalid PQ key hex (not a valid hex string).");
       return null;
     }
-    if (decoded.length == FNDSA512.SEED_LENGTH) {
-      // Validate the seed produces a usable keypair, but pass the seed itself
-      // through so the keystore can persist BOTH segments (and so the bare
-      // seed remains available for future export / re-derivation).
+    if (decoded.length == seedLen) {
       try {
-        new FNDSA512(decoded);
+        PQSchemeRegistry.fromSeed(scheme, decoded);
       } catch (RuntimeException e) {
         java.util.Arrays.fill(decoded, (byte) 0);
-        System.out.println("Failed to derive Falcon-512 keypair from seed: " + e.getMessage());
+        System.out.println("Failed to derive " + scheme.name() + " keypair from seed: "
+            + e.getMessage());
         return null;
       }
       return new PQKeyMaterial(decoded, null);

--- a/src/main/java/org/tron/walletcli/Client.java
+++ b/src/main/java/org/tron/walletcli/Client.java
@@ -93,6 +93,8 @@ import org.tron.api.GrpcAPI.AddressPrKeyPairMessage;
 import org.tron.common.crypto.Hash;
 import org.tron.common.crypto.SignInterface;
 import org.tron.common.crypto.SignUtils;
+import org.tron.common.crypto.pqc.FNDSA512;
+import org.tron.common.crypto.pqc.PQSchemeRegistry;
 import org.tron.common.enums.NetType;
 import org.tron.common.utils.AbiUtil;
 import org.tron.common.utils.ByteArray;
@@ -114,6 +116,7 @@ import org.tron.ledger.listener.TransactionSignManager;
 import org.tron.ledger.wrapper.LedgerUserHelper;
 import org.tron.mnemonic.MnemonicUtils;
 import org.tron.protos.Protocol;
+import org.tron.protos.Protocol.PQScheme;
 import org.tron.protos.contract.Common.ResourceCode;
 import org.tron.trident.api.GrpcAPI;
 import org.tron.trident.core.exceptions.IllegalException;
@@ -163,6 +166,7 @@ public class Client {
       "GasFreeTrace",
       "GasFreeTransfer",
       "GenerateAddress",
+      "GeneratePQKey",
       "GenerateSubAccount",
       "GetAccount",
       "GetAccountById",
@@ -218,6 +222,7 @@ public class Client {
       "ImportWalletByMnemonic",
       "ImportWalletByLedger",
       "ImportWalletByBase64",
+      "ImportWalletPQ",
       "ListAssetIssue",
       "ListAssetIssuePaginated",
       "ListExchanges",
@@ -236,6 +241,7 @@ public class Client {
       "TronlinkMultiSign",
       "ParticipateAssetIssue",
       "RegisterWallet",
+      "RegisterWalletPQ",
       "ResetWallet",
       "SendCoin",
       "SetAccountId",
@@ -3190,6 +3196,114 @@ public class Client {
     }
   }
 
+  private static PQScheme parsePQScheme(String[] parameters) {
+    if (parameters == null || parameters.length == 0 || parameters[0] == null
+        || parameters[0].isEmpty()) {
+      return PQScheme.FN_DSA_512;
+    }
+    try {
+      PQScheme scheme = PQScheme.valueOf(parameters[0]);
+      if (!PQSchemeRegistry.contains(scheme)) {
+        return null;
+      }
+      return scheme;
+    } catch (IllegalArgumentException e) {
+      return null;
+    }
+  }
+
+  private void generatePQKey(String[] parameters) {
+    PQScheme scheme = parsePQScheme(parameters);
+    if (scheme == null) {
+      System.out.println("Unsupported PQ scheme. Supported: FN_DSA_512");
+      return;
+    }
+    try {
+      FNDSA512 signer = new FNDSA512();
+      byte[] address = signer.getAddress();
+      String addressStr = WalletApi.encode58Check(address);
+      String pubKeyStr = ByteArray.toHexString(signer.getPublicKey());
+      String extPrivStr = ByteArray.toHexString(signer.getPrivateKeyWithPublicKey());
+      System.out.println("scheme: " + scheme.name());
+      System.out.println("address: " + addressStr);
+      System.out.println("publicKey: " + pubKeyStr);
+      System.out.println("privateKey (extended f||g||F||h): " + extPrivStr);
+      System.out.println("WARNING: store the extended private key securely; "
+          + "the public key cannot be re-derived from f||g||F alone.");
+    } catch (Exception e) {
+      System.out.println("GeneratePQKey " + failedHighlight() + " !!! " + e.getMessage());
+    }
+  }
+
+  private void registerWalletPQ(String[] parameters) throws CipherException, IOException {
+    PQScheme scheme = parsePQScheme(parameters);
+    if (scheme == null) {
+      System.out.println("Unsupported PQ scheme. Supported: FN_DSA_512");
+      return;
+    }
+    char[] password = Utils.inputPassword2Twice(false);
+    String fileName = walletApiWrapper.registerWalletPQ(password, scheme);
+    StringUtils.clear(password);
+    if (fileName == null) {
+      System.out.println("RegisterWalletPQ " + failedHighlight() + " !!");
+      return;
+    }
+    System.out.println("Register a PQ wallet " + successfulHighlight() + ", keystore file : ."
+        + File.separator + "Wallet" + File.separator + fileName);
+  }
+
+  private void importWalletPQ(String[] parameters) throws CipherException, IOException {
+    PQScheme scheme = parsePQScheme(parameters);
+    if (scheme == null) {
+      System.out.println("Unsupported PQ scheme. Supported: FN_DSA_512");
+      return;
+    }
+    System.out.println("(Note: This operation will overwrite the old keystore file of the same address)");
+    char[] password = walletApiWrapper.isUnifiedExist() ?
+        byte2Char(walletApiWrapper.getWallet().getUnifiedPassword()) : Utils.inputPassword2Twice(false);
+    int expected = PQSchemeRegistry.getPrivateKeyLength(scheme)
+        + PQSchemeRegistry.getPublicKeyLength(scheme);
+    System.out.println("Please input the extended private key hex (f||g||F||h, "
+        + expected + " bytes / " + (expected * 2) + " hex chars):");
+    byte[] extPriv = inputPQExtendedPrivateKey(expected);
+    if (extPriv == null) {
+      System.out.println("ImportWalletPQ " + failedHighlight() + " !!");
+      StringUtils.clear(password);
+      return;
+    }
+    String fileName = walletApiWrapper.importWalletPQ(password, scheme, extPriv);
+    StringUtils.clear(password);
+    java.util.Arrays.fill(extPriv, (byte) 0);
+    if (fileName == null) {
+      System.out.println("ImportWalletPQ " + failedHighlight() + " !!");
+      return;
+    }
+    System.out.println("Import a PQ wallet " + successfulHighlight() + ", keystore file : ."
+        + File.separator + "Wallet" + File.separator + fileName);
+  }
+
+  private byte[] inputPQExtendedPrivateKey(int expectedLen) throws IOException {
+    int hexLen = expectedLen * 2;
+    byte[] temp = new byte[hexLen + 16];
+    int nTime = 0;
+    while (nTime < retryTime) {
+      int len = System.in.read(temp, 0, temp.length);
+      if (len >= hexLen) {
+        byte[] hex = Arrays.copyOfRange(temp, 0, hexLen);
+        byte[] result = StringUtils.hexs2Bytes(hex);
+        StringUtils.clear(hex);
+        if (result != null && result.length == expectedLen) {
+          StringUtils.clear(temp);
+          return result;
+        }
+      }
+      System.out.println("Invalid extended private key hex, please try again.");
+      ++nTime;
+    }
+    StringUtils.clear(temp);
+    return null;
+  }
+
   private void updateAccountPermission(String[] parameters)
       throws CipherException, IOException, CancelException, IllegalException {
     boolean multi = isMulti(parameters);
@@ -3698,6 +3812,18 @@ public class Client {
             }
             case "registerwallet": {
               registerWallet();
+              break;
+            }
+            case "registerwalletpq": {
+              registerWalletPQ(parameters);
+              break;
+            }
+            case "generatepqkey": {
+              generatePQKey(parameters);
+              break;
+            }
+            case "importwalletpq": {
+              importWalletPQ(parameters);
               break;
             }
             case "modifywalletname": {

--- a/src/main/java/org/tron/walletcli/WalletApiWrapper.java
+++ b/src/main/java/org/tron/walletcli/WalletApiWrapper.java
@@ -98,6 +98,9 @@ import org.tron.gasfree.request.GasFreeSubmitRequest;
 import org.tron.gasfree.response.GasFreeAddressResponse;
 import org.tron.keystore.ClearWalletUtils;
 import org.tron.keystore.Credentials;
+import org.tron.common.crypto.pqc.FNDSA512;
+import org.tron.common.crypto.pqc.PQSchemeRegistry;
+import org.tron.protos.Protocol.PQScheme;
 import org.tron.keystore.WalletFile;
 import org.tron.keystore.WalletUtils;
 import org.tron.ledger.LedgerAddressUtil;
@@ -241,6 +244,110 @@ public class WalletApiWrapper {
         logout();
       }
       return keystoreName;
+    } finally {
+      clear(passwd);
+    }
+  }
+
+  public String registerWalletPQ(char[] password, PQScheme scheme)
+      throws CipherException, IOException {
+    if (!WalletApi.passwordValid(password)) {
+      return null;
+    }
+    byte[] passwd = char2Byte(password);
+    try {
+      FNDSA512 signer = new FNDSA512();
+      WalletFile walletFile = WalletApi.CreatePQWalletFile(
+          passwd, scheme, signer.getPrivateKeyWithPublicKey(), signer.getPublicKey());
+      String keystoreName = WalletApi.store2Keystore(walletFile);
+      logout();
+      return keystoreName;
+    } finally {
+      clear(passwd);
+    }
+  }
+
+  public String importWalletPQ(char[] password, PQScheme scheme, byte[] extendedPrivateKey)
+      throws CipherException, IOException {
+    if (!WalletApi.passwordValid(password)) {
+      return null;
+    }
+    int expected = PQSchemeRegistry.getPrivateKeyLength(scheme)
+        + PQSchemeRegistry.getPublicKeyLength(scheme);
+    if (extendedPrivateKey == null || extendedPrivateKey.length != expected) {
+      System.out.println("Invalid extended private key length: expected " + expected
+          + " bytes for " + scheme.name());
+      return null;
+    }
+    byte[] passwd = char2Byte(password);
+    try {
+      FNDSA512 signer = FNDSA512.fromPrivateKeyWithPublicKey(extendedPrivateKey);
+      WalletFile walletFile = WalletApi.CreatePQWalletFile(
+          passwd, scheme, signer.getPrivateKeyWithPublicKey(), signer.getPublicKey());
+      String keystoreName = WalletApi.store2Keystore(walletFile);
+      if (isUnifiedExist()) {
+        wallet.getWalletList().add(walletFile);
+      } else {
+        logout();
+      }
+      return keystoreName;
+    } finally {
+      clear(passwd);
+    }
+  }
+
+  public CliWalletCreationResult registerWalletPQForCli(
+      char[] password, PQScheme scheme, String walletName)
+      throws CipherException, IOException {
+    validateCliWalletName(walletName);
+    if (!WalletApi.passwordValidQuiet(password)) {
+      throw new CommandErrorException("usage_error",
+          "MASTER_PASSWORD does not meet password requirements.");
+    }
+    byte[] passwd = char2Byte(password);
+    try {
+      FNDSA512 signer = new FNDSA512();
+      WalletFile walletFile = WalletApi.CreatePQWalletFile(
+          passwd, scheme, signer.getPrivateKeyWithPublicKey(), signer.getPublicKey());
+      walletFile.setName(walletName);
+      String keystoreName = WalletApi.store2Keystore(walletFile);
+      logout();
+      return new CliWalletCreationResult(
+          keystoreName, null, walletFile.getAddress(), walletName, null);
+    } finally {
+      clear(passwd);
+    }
+  }
+
+  public CliWalletCreationResult importWalletPQForCli(
+      char[] password, PQScheme scheme, byte[] extendedPrivateKey, String walletName)
+      throws CipherException, IOException {
+    validateCliWalletName(walletName);
+    if (!WalletApi.passwordValidQuiet(password)) {
+      throw new CommandErrorException("usage_error",
+          "MASTER_PASSWORD does not meet password requirements.");
+    }
+    int expected = PQSchemeRegistry.getPrivateKeyLength(scheme)
+        + PQSchemeRegistry.getPublicKeyLength(scheme);
+    if (extendedPrivateKey == null || extendedPrivateKey.length != expected) {
+      throw new CommandErrorException("usage_error",
+          "Invalid extended private key length: expected " + expected
+              + " bytes for " + scheme.name());
+    }
+    byte[] passwd = char2Byte(password);
+    try {
+      FNDSA512 signer = FNDSA512.fromPrivateKeyWithPublicKey(extendedPrivateKey);
+      WalletFile walletFile = WalletApi.CreatePQWalletFile(
+          passwd, scheme, signer.getPrivateKeyWithPublicKey(), signer.getPublicKey());
+      walletFile.setName(walletName);
+      String keystoreName = WalletApi.store2Keystore(walletFile);
+      if (isUnifiedExist()) {
+        wallet.getWalletList().add(walletFile);
+      } else {
+        logout();
+      }
+      return new CliWalletCreationResult(
+          keystoreName, null, walletFile.getAddress(), walletName, null);
     } finally {
       clear(passwd);
     }

--- a/src/main/java/org/tron/walletcli/WalletApiWrapper.java
+++ b/src/main/java/org/tron/walletcli/WalletApiWrapper.java
@@ -260,7 +260,8 @@ public class WalletApiWrapper {
       new java.security.SecureRandom().nextBytes(seed);
       FNDSA512 signer = new FNDSA512(seed);
       WalletFile walletFile = WalletApi.CreatePQWalletFile(
-          passwd, scheme, signer.getPrivateKeyWithPublicKey(), seed, signer.getPublicKey());
+          passwd, PQSchemeRegistry.resolve(scheme), signer.getPrivateKeyWithPublicKey(), seed, signer.getPublicKey());
+      nameWallet(walletFile, false);
       String keystoreName = WalletApi.store2Keystore(walletFile);
       logout();
       return keystoreName;
@@ -301,8 +302,18 @@ public class WalletApiWrapper {
       FNDSA512 signer = (extendedPrivateKey != null)
           ? FNDSA512.fromPrivateKeyWithPublicKey(extendedPrivateKey)
           : new FNDSA512(seed);
+      if (extendedPrivateKey != null && seed != null) {
+        byte[] derivedExt = new FNDSA512(seed).getPrivateKeyWithPublicKey();
+        if (!java.util.Arrays.equals(derivedExt, extendedPrivateKey)) {
+          java.util.Arrays.fill(derivedExt, (byte) 0);
+          System.out.println("Provided seed and extended private key describe different keypairs.");
+          return null;
+        }
+        java.util.Arrays.fill(derivedExt, (byte) 0);
+      }
       WalletFile walletFile = WalletApi.CreatePQWalletFile(
-          passwd, scheme, signer.getPrivateKeyWithPublicKey(), seed, signer.getPublicKey());
+          passwd, PQSchemeRegistry.resolve(scheme), signer.getPrivateKeyWithPublicKey(), seed, signer.getPublicKey());
+      nameWallet(walletFile, false);
       String keystoreName = WalletApi.store2Keystore(walletFile);
       if (isUnifiedExist()) {
         wallet.getWalletList().add(walletFile);
@@ -370,6 +381,15 @@ public class WalletApiWrapper {
       FNDSA512 signer = (extendedPrivateKey != null)
           ? FNDSA512.fromPrivateKeyWithPublicKey(extendedPrivateKey)
           : new FNDSA512(seed);
+      if (extendedPrivateKey != null && seed != null) {
+        byte[] derivedExt = new FNDSA512(seed).getPrivateKeyWithPublicKey();
+        if (!java.util.Arrays.equals(derivedExt, extendedPrivateKey)) {
+          java.util.Arrays.fill(derivedExt, (byte) 0);
+          throw new CommandErrorException("usage_error",
+              "Provided seed and extended private key describe different keypairs.");
+        }
+        java.util.Arrays.fill(derivedExt, (byte) 0);
+      }
       WalletFile walletFile = WalletApi.CreatePQWalletFile(
           passwd, scheme, signer.getPrivateKeyWithPublicKey(), seed, signer.getPublicKey());
       walletFile.setName(walletName);

--- a/src/main/java/org/tron/walletcli/WalletApiWrapper.java
+++ b/src/main/java/org/tron/walletcli/WalletApiWrapper.java
@@ -55,6 +55,7 @@ import java.math.BigInteger;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -98,8 +99,8 @@ import org.tron.gasfree.request.GasFreeSubmitRequest;
 import org.tron.gasfree.response.GasFreeAddressResponse;
 import org.tron.keystore.ClearWalletUtils;
 import org.tron.keystore.Credentials;
-import org.tron.common.crypto.pqc.FNDSA512;
 import org.tron.common.crypto.pqc.PQSchemeRegistry;
+import org.tron.common.crypto.pqc.PQSignature;
 import org.tron.protos.Protocol.PQScheme;
 import org.tron.keystore.WalletFile;
 import org.tron.keystore.WalletUtils;
@@ -255,12 +256,13 @@ public class WalletApiWrapper {
       return null;
     }
     byte[] passwd = char2Byte(password);
-    byte[] seed = new byte[FNDSA512.SEED_LENGTH];
+    int seedLen = PQSchemeRegistry.getSeedLength(scheme);
+    byte[] seed = new byte[seedLen];
     try {
-      new java.security.SecureRandom().nextBytes(seed);
-      FNDSA512 signer = new FNDSA512(seed);
+      new SecureRandom().nextBytes(seed);
+      PQSignature signer = PQSchemeRegistry.fromSeed(scheme, seed);
       WalletFile walletFile = WalletApi.CreatePQWalletFile(
-          passwd, PQSchemeRegistry.resolve(scheme), signer.getPrivateKeyWithPublicKey(), seed, signer.getPublicKey());
+          passwd, scheme, signer.getPersistedPrivateKey(), seed, signer.getPublicKey());
       nameWallet(walletFile, false);
       String keystoreName = WalletApi.store2Keystore(walletFile);
       logout();
@@ -271,11 +273,11 @@ public class WalletApiWrapper {
     }
   }
 
-  // Imports a PQ wallet. Callers supply either the 48-byte seed, the
-  // 2176-byte extended private key, or both (when both are present they must
-  // describe the same keypair). When the seed is available the keystore
-  // persists BOTH segments so that future tooling can re-derive a fresh
-  // extended form from the seed alone.
+  // Imports a PQ wallet. Callers supply either the scheme-specific keygen seed,
+  // the scheme-specific persisted private key, or both (when both are present
+  // they must describe the same keypair). When the seed is available the
+  // keystore persists BOTH segments so that future tooling can re-derive a
+  // fresh persisted form from the seed alone.
   public String importWalletPQ(char[] password, PQScheme scheme,
       byte[] extendedPrivateKey, byte[] seed)
       throws CipherException, IOException {
@@ -286,24 +288,25 @@ public class WalletApiWrapper {
       System.out.println("ImportWalletPQ requires either a seed or an extended private key.");
       return null;
     }
-    int expectedExtLen = PQSchemeRegistry.getPrivateKeyLength(scheme)
-        + PQSchemeRegistry.getPublicKeyLength(scheme);
+    int expectedExtLen = PQSchemeRegistry.getPersistedPrivateKeyLength(scheme);
     if (extendedPrivateKey != null && extendedPrivateKey.length != expectedExtLen) {
       System.out.println("Invalid extended private key length: expected " + expectedExtLen
           + " bytes for " + scheme.name());
       return null;
     }
-    if (seed != null && seed.length != FNDSA512.SEED_LENGTH) {
-      System.out.println("Invalid seed length: expected " + FNDSA512.SEED_LENGTH + " bytes");
+    int expectedSeedLen = PQSchemeRegistry.getSeedLength(scheme);
+    if (seed != null && seed.length != expectedSeedLen) {
+      System.out.println("Invalid seed length: expected " + expectedSeedLen
+          + " bytes for " + scheme.name());
       return null;
     }
     byte[] passwd = char2Byte(password);
     try {
-      FNDSA512 signer = (extendedPrivateKey != null)
-          ? FNDSA512.fromPrivateKeyWithPublicKey(extendedPrivateKey)
-          : new FNDSA512(seed);
+      PQSignature signer = (extendedPrivateKey != null)
+          ? PQSchemeRegistry.fromPersistedPrivateKey(scheme, extendedPrivateKey)
+          : PQSchemeRegistry.fromSeed(scheme, seed);
       if (extendedPrivateKey != null && seed != null) {
-        byte[] derivedExt = new FNDSA512(seed).getPrivateKeyWithPublicKey();
+        byte[] derivedExt = PQSchemeRegistry.fromSeed(scheme, seed).getPersistedPrivateKey();
         if (!java.util.Arrays.equals(derivedExt, extendedPrivateKey)) {
           java.util.Arrays.fill(derivedExt, (byte) 0);
           System.out.println("Provided seed and extended private key describe different keypairs.");
@@ -312,7 +315,7 @@ public class WalletApiWrapper {
         java.util.Arrays.fill(derivedExt, (byte) 0);
       }
       WalletFile walletFile = WalletApi.CreatePQWalletFile(
-          passwd, PQSchemeRegistry.resolve(scheme), signer.getPrivateKeyWithPublicKey(), seed, signer.getPublicKey());
+          passwd, scheme, signer.getPersistedPrivateKey(), seed, signer.getPublicKey());
       nameWallet(walletFile, false);
       String keystoreName = WalletApi.store2Keystore(walletFile);
       if (isUnifiedExist()) {
@@ -335,12 +338,13 @@ public class WalletApiWrapper {
           "MASTER_PASSWORD does not meet password requirements.");
     }
     byte[] passwd = char2Byte(password);
-    byte[] seed = new byte[FNDSA512.SEED_LENGTH];
+    int seedLen = PQSchemeRegistry.getSeedLength(scheme);
+    byte[] seed = new byte[seedLen];
     try {
       new java.security.SecureRandom().nextBytes(seed);
-      FNDSA512 signer = new FNDSA512(seed);
+      PQSignature signer = PQSchemeRegistry.fromSeed(scheme, seed);
       WalletFile walletFile = WalletApi.CreatePQWalletFile(
-          passwd, scheme, signer.getPrivateKeyWithPublicKey(), seed, signer.getPublicKey());
+          passwd, scheme, signer.getPersistedPrivateKey(), seed, signer.getPublicKey());
       walletFile.setName(walletName);
       String keystoreName = WalletApi.store2Keystore(walletFile);
       logout();
@@ -365,24 +369,25 @@ public class WalletApiWrapper {
       throw new CommandErrorException("usage_error",
           "import-wallet-pq requires either a seed or an extended private key.");
     }
-    int expectedExtLen = PQSchemeRegistry.getPrivateKeyLength(scheme)
-        + PQSchemeRegistry.getPublicKeyLength(scheme);
+    int expectedExtLen = PQSchemeRegistry.getPersistedPrivateKeyLength(scheme);
     if (extendedPrivateKey != null && extendedPrivateKey.length != expectedExtLen) {
       throw new CommandErrorException("usage_error",
           "Invalid extended private key length: expected " + expectedExtLen
               + " bytes for " + scheme.name());
     }
-    if (seed != null && seed.length != FNDSA512.SEED_LENGTH) {
+    int expectedSeedLen = PQSchemeRegistry.getSeedLength(scheme);
+    if (seed != null && seed.length != expectedSeedLen) {
       throw new CommandErrorException("usage_error",
-          "Invalid seed length: expected " + FNDSA512.SEED_LENGTH + " bytes");
+          "Invalid seed length: expected " + expectedSeedLen
+              + " bytes for " + scheme.name());
     }
     byte[] passwd = char2Byte(password);
     try {
-      FNDSA512 signer = (extendedPrivateKey != null)
-          ? FNDSA512.fromPrivateKeyWithPublicKey(extendedPrivateKey)
-          : new FNDSA512(seed);
+      PQSignature signer = (extendedPrivateKey != null)
+          ? PQSchemeRegistry.fromPersistedPrivateKey(scheme, extendedPrivateKey)
+          : PQSchemeRegistry.fromSeed(scheme, seed);
       if (extendedPrivateKey != null && seed != null) {
-        byte[] derivedExt = new FNDSA512(seed).getPrivateKeyWithPublicKey();
+        byte[] derivedExt = PQSchemeRegistry.fromSeed(scheme, seed).getPersistedPrivateKey();
         if (!java.util.Arrays.equals(derivedExt, extendedPrivateKey)) {
           java.util.Arrays.fill(derivedExt, (byte) 0);
           throw new CommandErrorException("usage_error",
@@ -391,7 +396,7 @@ public class WalletApiWrapper {
         java.util.Arrays.fill(derivedExt, (byte) 0);
       }
       WalletFile walletFile = WalletApi.CreatePQWalletFile(
-          passwd, scheme, signer.getPrivateKeyWithPublicKey(), seed, signer.getPublicKey());
+          passwd, scheme, signer.getPersistedPrivateKey(), seed, signer.getPublicKey());
       walletFile.setName(walletName);
       String keystoreName = WalletApi.store2Keystore(walletFile);
       if (isUnifiedExist()) {
@@ -3365,6 +3370,18 @@ public class WalletApiWrapper {
         throw new CommandErrorException("invalid_input", "The receiverAddress you entered is invalid.");
       }
       System.out.println("The receiverAddress you entered is invalid.");
+      return false;
+    }
+    WalletFile activeWalletFile = wallet.getWalletFile();
+    if (activeWalletFile != null
+        && activeWalletFile.getScheme() != null
+        && !activeWalletFile.getScheme().isEmpty()) {
+      String msg = "GasFreeTransfer is not supported for post-quantum wallets ("
+          + activeWalletFile.getScheme() + "); requires an ECDSA wallet.";
+      if (standardCli) {
+        throw new CommandErrorException("unsupported_wallet_type", msg);
+      }
+      System.out.println(msg);
       return false;
     }
     String address = getAddress();

--- a/src/main/java/org/tron/walletcli/WalletApiWrapper.java
+++ b/src/main/java/org/tron/walletcli/WalletApiWrapper.java
@@ -255,35 +255,54 @@ public class WalletApiWrapper {
       return null;
     }
     byte[] passwd = char2Byte(password);
+    byte[] seed = new byte[FNDSA512.SEED_LENGTH];
     try {
-      FNDSA512 signer = new FNDSA512();
+      new java.security.SecureRandom().nextBytes(seed);
+      FNDSA512 signer = new FNDSA512(seed);
       WalletFile walletFile = WalletApi.CreatePQWalletFile(
-          passwd, scheme, signer.getPrivateKeyWithPublicKey(), signer.getPublicKey());
+          passwd, scheme, signer.getPrivateKeyWithPublicKey(), seed, signer.getPublicKey());
       String keystoreName = WalletApi.store2Keystore(walletFile);
       logout();
       return keystoreName;
     } finally {
       clear(passwd);
+      java.util.Arrays.fill(seed, (byte) 0);
     }
   }
 
-  public String importWalletPQ(char[] password, PQScheme scheme, byte[] extendedPrivateKey)
+  // Imports a PQ wallet. Callers supply either the 48-byte seed, the
+  // 2176-byte extended private key, or both (when both are present they must
+  // describe the same keypair). When the seed is available the keystore
+  // persists BOTH segments so that future tooling can re-derive a fresh
+  // extended form from the seed alone.
+  public String importWalletPQ(char[] password, PQScheme scheme,
+      byte[] extendedPrivateKey, byte[] seed)
       throws CipherException, IOException {
     if (!WalletApi.passwordValid(password)) {
       return null;
     }
-    int expected = PQSchemeRegistry.getPrivateKeyLength(scheme)
+    if (extendedPrivateKey == null && seed == null) {
+      System.out.println("ImportWalletPQ requires either a seed or an extended private key.");
+      return null;
+    }
+    int expectedExtLen = PQSchemeRegistry.getPrivateKeyLength(scheme)
         + PQSchemeRegistry.getPublicKeyLength(scheme);
-    if (extendedPrivateKey == null || extendedPrivateKey.length != expected) {
-      System.out.println("Invalid extended private key length: expected " + expected
+    if (extendedPrivateKey != null && extendedPrivateKey.length != expectedExtLen) {
+      System.out.println("Invalid extended private key length: expected " + expectedExtLen
           + " bytes for " + scheme.name());
+      return null;
+    }
+    if (seed != null && seed.length != FNDSA512.SEED_LENGTH) {
+      System.out.println("Invalid seed length: expected " + FNDSA512.SEED_LENGTH + " bytes");
       return null;
     }
     byte[] passwd = char2Byte(password);
     try {
-      FNDSA512 signer = FNDSA512.fromPrivateKeyWithPublicKey(extendedPrivateKey);
+      FNDSA512 signer = (extendedPrivateKey != null)
+          ? FNDSA512.fromPrivateKeyWithPublicKey(extendedPrivateKey)
+          : new FNDSA512(seed);
       WalletFile walletFile = WalletApi.CreatePQWalletFile(
-          passwd, scheme, signer.getPrivateKeyWithPublicKey(), signer.getPublicKey());
+          passwd, scheme, signer.getPrivateKeyWithPublicKey(), seed, signer.getPublicKey());
       String keystoreName = WalletApi.store2Keystore(walletFile);
       if (isUnifiedExist()) {
         wallet.getWalletList().add(walletFile);
@@ -305,10 +324,12 @@ public class WalletApiWrapper {
           "MASTER_PASSWORD does not meet password requirements.");
     }
     byte[] passwd = char2Byte(password);
+    byte[] seed = new byte[FNDSA512.SEED_LENGTH];
     try {
-      FNDSA512 signer = new FNDSA512();
+      new java.security.SecureRandom().nextBytes(seed);
+      FNDSA512 signer = new FNDSA512(seed);
       WalletFile walletFile = WalletApi.CreatePQWalletFile(
-          passwd, scheme, signer.getPrivateKeyWithPublicKey(), signer.getPublicKey());
+          passwd, scheme, signer.getPrivateKeyWithPublicKey(), seed, signer.getPublicKey());
       walletFile.setName(walletName);
       String keystoreName = WalletApi.store2Keystore(walletFile);
       logout();
@@ -316,29 +337,41 @@ public class WalletApiWrapper {
           keystoreName, null, walletFile.getAddress(), walletName, null);
     } finally {
       clear(passwd);
+      java.util.Arrays.fill(seed, (byte) 0);
     }
   }
 
   public CliWalletCreationResult importWalletPQForCli(
-      char[] password, PQScheme scheme, byte[] extendedPrivateKey, String walletName)
+      char[] password, PQScheme scheme,
+      byte[] extendedPrivateKey, byte[] seed, String walletName)
       throws CipherException, IOException {
     validateCliWalletName(walletName);
     if (!WalletApi.passwordValidQuiet(password)) {
       throw new CommandErrorException("usage_error",
           "MASTER_PASSWORD does not meet password requirements.");
     }
-    int expected = PQSchemeRegistry.getPrivateKeyLength(scheme)
-        + PQSchemeRegistry.getPublicKeyLength(scheme);
-    if (extendedPrivateKey == null || extendedPrivateKey.length != expected) {
+    if (extendedPrivateKey == null && seed == null) {
       throw new CommandErrorException("usage_error",
-          "Invalid extended private key length: expected " + expected
+          "import-wallet-pq requires either a seed or an extended private key.");
+    }
+    int expectedExtLen = PQSchemeRegistry.getPrivateKeyLength(scheme)
+        + PQSchemeRegistry.getPublicKeyLength(scheme);
+    if (extendedPrivateKey != null && extendedPrivateKey.length != expectedExtLen) {
+      throw new CommandErrorException("usage_error",
+          "Invalid extended private key length: expected " + expectedExtLen
               + " bytes for " + scheme.name());
+    }
+    if (seed != null && seed.length != FNDSA512.SEED_LENGTH) {
+      throw new CommandErrorException("usage_error",
+          "Invalid seed length: expected " + FNDSA512.SEED_LENGTH + " bytes");
     }
     byte[] passwd = char2Byte(password);
     try {
-      FNDSA512 signer = FNDSA512.fromPrivateKeyWithPublicKey(extendedPrivateKey);
+      FNDSA512 signer = (extendedPrivateKey != null)
+          ? FNDSA512.fromPrivateKeyWithPublicKey(extendedPrivateKey)
+          : new FNDSA512(seed);
       WalletFile walletFile = WalletApi.CreatePQWalletFile(
-          passwd, scheme, signer.getPrivateKeyWithPublicKey(), signer.getPublicKey());
+          passwd, scheme, signer.getPrivateKeyWithPublicKey(), seed, signer.getPublicKey());
       walletFile.setName(walletName);
       String keystoreName = WalletApi.store2Keystore(walletFile);
       if (isUnifiedExist()) {

--- a/src/main/java/org/tron/walletcli/cli/commands/WalletCommands.java
+++ b/src/main/java/org/tron/walletcli/cli/commands/WalletCommands.java
@@ -123,32 +123,51 @@ public class WalletCommands {
         registry.add(noAuthCommand()
                 .name("import-wallet-pq")
                 .aliases("importwalletpq")
-                .description("Import a post-quantum wallet from an extended private key (priv||pub hex)")
+                .description("Import a post-quantum wallet from a seed or extended private key")
                 .option("name", "Wallet name", true)
                 .option("scheme", "PQ signature scheme (default: FN_DSA_512)", false)
                 .option("extended-private-key-hex",
-                        "Hex-encoded extended private key (private||public bytes)", true)
+                        "Hex-encoded key material (either the 48-byte seed or the full extended private||public bytes)", true)
                 .handler((ctx, opts, wrapper, out) -> {
                     PQScheme scheme = parsePQSchemeOption(out, opts);
                     if (scheme == null) {
                         return;
                     }
                     String hex = opts.getString("extended-private-key-hex");
-                    byte[] extendedPriv;
+                    byte[] decoded;
                     try {
-                        extendedPriv = Hex.decode(hex);
+                        decoded = Hex.decode(hex);
                     } catch (Exception e) {
                         out.usageError("Invalid hex for --extended-private-key-hex", null);
                         return;
                     }
-                    int expected = PQSchemeRegistry.getPrivateKeyLength(scheme)
+                    int expectedExtLen = PQSchemeRegistry.getPrivateKeyLength(scheme)
                             + PQSchemeRegistry.getPublicKeyLength(scheme);
-                    if (extendedPriv.length != expected) {
-                        out.usageError("extended-private-key-hex must decode to " + expected
-                                + " bytes for " + scheme.name() + " (got "
-                                + extendedPriv.length + ")", null);
+                    int expectedSeedLen = FNDSA512.SEED_LENGTH;
+
+                    byte[] seed = null;
+                    byte[] extendedPriv = null;
+
+                    if (decoded.length == expectedSeedLen) {
+                        seed = decoded;
+                        // Verify the seed derives successfully, but pass the seed verbatim
+                        // to the keystore layer so BOTH segments can be persisted.
+                        try {
+                            new FNDSA512(seed);
+                        } catch (RuntimeException e) {
+                            java.util.Arrays.fill(seed, (byte) 0);
+                            out.error("execution_error", "Failed to derive Falcon-512 keypair from seed: " + e.getMessage());
+                            return;
+                        }
+                    } else if (decoded.length == expectedExtLen) {
+                        extendedPriv = decoded;
+                    } else {
+                        out.usageError("extended-private-key-hex must decode to " + expectedSeedLen
+                                + " bytes (seed) or " + expectedExtLen + " bytes (extended private key) for "
+                                + scheme.name() + " (got " + decoded.length + ")", null);
                         return;
                     }
+
                     String envPassword = ctx.getMasterPassword();
                     if (envPassword == null || envPassword.isEmpty()) {
                         out.error("execution_error",
@@ -158,7 +177,7 @@ public class WalletCommands {
                     char[] password = envPassword.toCharArray();
                     try {
                         CliWalletCreationResult result = wrapper.importWalletPQForCli(
-                                password, scheme, extendedPriv, opts.getString("name"));
+                                password, scheme, extendedPriv, seed, opts.getString("name"));
                         ActiveWalletConfig.setActiveAddress(result.getAddress());
                         Map<String, Object> json = new LinkedHashMap<String, Object>();
                         json.put("keystore", result.getKeystoreName());
@@ -169,6 +188,12 @@ public class WalletCommands {
                                 + result.getKeystoreName(), json);
                     } finally {
                         org.tron.keystore.StringUtils.clear(password);
+                        if (extendedPriv != null) {
+                            java.util.Arrays.fill(extendedPriv, (byte) 0);
+                        }
+                        if (seed != null) {
+                            java.util.Arrays.fill(seed, (byte) 0);
+                        }
                     }
                 })
                 .build());

--- a/src/main/java/org/tron/walletcli/cli/commands/WalletCommands.java
+++ b/src/main/java/org/tron/walletcli/cli/commands/WalletCommands.java
@@ -48,11 +48,11 @@ public class WalletCommands {
         String schemeName = opts.has("scheme") ? opts.getString("scheme") : "FN_DSA_512";
         try {
             PQScheme scheme = PQScheme.valueOf(schemeName);
-            if (scheme == PQScheme.UNKNOWN_PQ_SCHEME) {
+            if (scheme == PQScheme.UNKNOWN_PQ_SCHEME || !PQSchemeRegistry.contains(scheme)) {
                 out.usageError("Unsupported scheme: " + schemeName, null);
                 return null;
             }
-            return scheme;
+            return PQSchemeRegistry.resolve(scheme);
         } catch (IllegalArgumentException e) {
             out.usageError("Unsupported scheme: " + schemeName, null);
             return null;
@@ -172,6 +172,7 @@ public class WalletCommands {
                     if (envPassword == null || envPassword.isEmpty()) {
                         out.error("execution_error",
                                 "Set MASTER_PASSWORD environment variable for non-interactive wallet import");
+                        java.util.Arrays.fill(decoded, (byte) 0);
                         return;
                     }
                     char[] password = envPassword.toCharArray();

--- a/src/main/java/org/tron/walletcli/cli/commands/WalletCommands.java
+++ b/src/main/java/org/tron/walletcli/cli/commands/WalletCommands.java
@@ -1,8 +1,9 @@
 package org.tron.walletcli.cli.commands;
 
+import java.util.Arrays;
 import org.bouncycastle.util.encoders.Hex;
-import org.tron.common.crypto.pqc.FNDSA512;
 import org.tron.common.crypto.pqc.PQSchemeRegistry;
+import org.tron.common.crypto.pqc.PQSignature;
 import org.tron.keystore.WalletFile;
 import org.tron.mnemonic.MnemonicUtils;
 import org.tron.keystore.WalletUtils;
@@ -13,6 +14,8 @@ import org.tron.walletcli.cli.ActiveWalletConfig;
 import org.tron.walletcli.cli.CommandDefinition;
 import org.tron.walletcli.cli.CommandRegistry;
 import org.tron.walletcli.cli.OptionDef;
+import org.tron.walletcli.cli.OutputFormatter;
+import org.tron.walletcli.cli.ParsedOptions;
 import org.tron.walletserver.WalletApi;
 
 
@@ -43,16 +46,15 @@ public class WalletCommands {
         registerImportWalletPQ(registry);
     }
 
-    private static PQScheme parsePQSchemeOption(org.tron.walletcli.cli.OutputFormatter out,
-                                                org.tron.walletcli.cli.ParsedOptions opts) {
+    private static PQScheme parsePQSchemeOption(OutputFormatter out, ParsedOptions opts) {
         String schemeName = opts.has("scheme") ? opts.getString("scheme") : "FN_DSA_512";
         try {
             PQScheme scheme = PQScheme.valueOf(schemeName);
-            if (scheme == PQScheme.UNKNOWN_PQ_SCHEME || !PQSchemeRegistry.contains(scheme)) {
+            if (!PQSchemeRegistry.contains(scheme)) {
                 out.usageError("Unsupported scheme: " + schemeName, null);
                 return null;
             }
-            return PQSchemeRegistry.resolve(scheme);
+            return scheme;
         } catch (IllegalArgumentException e) {
             out.usageError("Unsupported scheme: " + schemeName, null);
             return null;
@@ -70,14 +72,35 @@ public class WalletCommands {
                     if (scheme == null) {
                         return;
                     }
-                    FNDSA512 signer = new FNDSA512();
-                    String address = WalletApi.encode58Check(signer.getAddress());
-                    Map<String, Object> json = new LinkedHashMap<String, Object>();
-                    json.put("scheme", scheme.name());
-                    json.put("address", address);
-                    json.put("public_key_hex", Hex.toHexString(signer.getPublicKey()));
-                    json.put("private_key_hex", Hex.toHexString(signer.getPrivateKeyWithPublicKey()));
-                    out.success("Generated PQ key for address: " + address, json);
+                    int seedLen = PQSchemeRegistry.getSeedLength(scheme);
+                    byte[] seed = new byte[seedLen];
+                    new java.security.SecureRandom().nextBytes(seed);
+                    byte[] priv = null;
+                    byte[] persisted = null;
+                    try {
+                        PQSignature signer = PQSchemeRegistry.fromSeed(scheme, seed);
+                        String address = WalletApi.encode58Check(signer.getAddress());
+                        priv = signer.getPrivateKey();
+                        persisted = signer.getPersistedPrivateKey();
+                        Map<String, Object> json = new LinkedHashMap<String, Object>();
+                        json.put("scheme", scheme.name());
+                        json.put("seed", Hex.toHexString(seed));
+                        json.put("private_key", Hex.toHexString(priv));
+                        json.put("public_key", Hex.toHexString(signer.getPublicKey()));
+                        json.put("address", address);
+                        json.put("private_key_persisted_form", Hex.toHexString(persisted));
+                        json.put("warning",
+                                "store the seed and the persisted private key securely.");
+                        out.success("Generated PQ key for address: " + address, json);
+                    } finally {
+                        java.util.Arrays.fill(seed, (byte) 0);
+                        if (priv != null) {
+                            java.util.Arrays.fill(priv, (byte) 0);
+                        }
+                        if (persisted != null) {
+                            java.util.Arrays.fill(persisted, (byte) 0);
+                        }
+                    }
                 })
                 .build());
     }
@@ -141,29 +164,28 @@ public class WalletCommands {
                         out.usageError("Invalid hex for --extended-private-key-hex", null);
                         return;
                     }
-                    int expectedExtLen = PQSchemeRegistry.getPrivateKeyLength(scheme)
-                            + PQSchemeRegistry.getPublicKeyLength(scheme);
-                    int expectedSeedLen = FNDSA512.SEED_LENGTH;
+                    int expectedExtLen = PQSchemeRegistry.getPersistedPrivateKeyLength(scheme);
+                    int expectedSeedLen = PQSchemeRegistry.getSeedLength(scheme);
 
                     byte[] seed = null;
                     byte[] extendedPriv = null;
 
                     if (decoded.length == expectedSeedLen) {
                         seed = decoded;
-                        // Verify the seed derives successfully, but pass the seed verbatim
-                        // to the keystore layer so BOTH segments can be persisted.
                         try {
-                            new FNDSA512(seed);
+                            PQSchemeRegistry.fromSeed(scheme, seed);
                         } catch (RuntimeException e) {
                             java.util.Arrays.fill(seed, (byte) 0);
-                            out.error("execution_error", "Failed to derive Falcon-512 keypair from seed: " + e.getMessage());
+                            out.error("execution_error", "Failed to derive " + scheme.name()
+                                    + " keypair from seed: " + e.getMessage());
                             return;
                         }
                     } else if (decoded.length == expectedExtLen) {
                         extendedPriv = decoded;
                     } else {
+                        Arrays.fill(decoded, (byte) 0);
                         out.usageError("extended-private-key-hex must decode to " + expectedSeedLen
-                                + " bytes (seed) or " + expectedExtLen + " bytes (extended private key) for "
+                                + " bytes (seed) or " + expectedExtLen + " bytes (persisted private key) for "
                                 + scheme.name() + " (got " + decoded.length + ")", null);
                         return;
                     }
@@ -172,7 +194,7 @@ public class WalletCommands {
                     if (envPassword == null || envPassword.isEmpty()) {
                         out.error("execution_error",
                                 "Set MASTER_PASSWORD environment variable for non-interactive wallet import");
-                        java.util.Arrays.fill(decoded, (byte) 0);
+                        Arrays.fill(decoded, (byte) 0);
                         return;
                     }
                     char[] password = envPassword.toCharArray();

--- a/src/main/java/org/tron/walletcli/cli/commands/WalletCommands.java
+++ b/src/main/java/org/tron/walletcli/cli/commands/WalletCommands.java
@@ -1,9 +1,13 @@
 package org.tron.walletcli.cli.commands;
 
+import org.bouncycastle.util.encoders.Hex;
+import org.tron.common.crypto.pqc.FNDSA512;
+import org.tron.common.crypto.pqc.PQSchemeRegistry;
 import org.tron.keystore.WalletFile;
 import org.tron.mnemonic.MnemonicUtils;
 import org.tron.keystore.WalletUtils;
 import org.tron.ledger.LedgerFileUtil;
+import org.tron.protos.Protocol.PQScheme;
 import org.tron.walletcli.WalletApiWrapper.CliWalletCreationResult;
 import org.tron.walletcli.cli.ActiveWalletConfig;
 import org.tron.walletcli.cli.CommandDefinition;
@@ -34,6 +38,140 @@ public class WalletCommands {
         registerResetWallet(registry);
         registerModifyWalletName(registry);
         registerGenerateSubAccount(registry);
+        registerGeneratePQKey(registry);
+        registerRegisterWalletPQ(registry);
+        registerImportWalletPQ(registry);
+    }
+
+    private static PQScheme parsePQSchemeOption(org.tron.walletcli.cli.OutputFormatter out,
+                                                org.tron.walletcli.cli.ParsedOptions opts) {
+        String schemeName = opts.has("scheme") ? opts.getString("scheme") : "FN_DSA_512";
+        try {
+            PQScheme scheme = PQScheme.valueOf(schemeName);
+            if (scheme == PQScheme.UNKNOWN_PQ_SCHEME) {
+                out.usageError("Unsupported scheme: " + schemeName, null);
+                return null;
+            }
+            return scheme;
+        } catch (IllegalArgumentException e) {
+            out.usageError("Unsupported scheme: " + schemeName, null);
+            return null;
+        }
+    }
+
+    private static void registerGeneratePQKey(CommandRegistry registry) {
+        registry.add(noAuthCommand()
+                .name("generate-pq-key")
+                .aliases("generatepqkey")
+                .description("Generate a new post-quantum keypair (no keystore written)")
+                .option("scheme", "PQ signature scheme (default: FN_DSA_512)", false)
+                .handler((ctx, opts, wrapper, out) -> {
+                    PQScheme scheme = parsePQSchemeOption(out, opts);
+                    if (scheme == null) {
+                        return;
+                    }
+                    FNDSA512 signer = new FNDSA512();
+                    String address = WalletApi.encode58Check(signer.getAddress());
+                    Map<String, Object> json = new LinkedHashMap<String, Object>();
+                    json.put("scheme", scheme.name());
+                    json.put("address", address);
+                    json.put("public_key_hex", Hex.toHexString(signer.getPublicKey()));
+                    json.put("private_key_hex", Hex.toHexString(signer.getPrivateKeyWithPublicKey()));
+                    out.success("Generated PQ key for address: " + address, json);
+                })
+                .build());
+    }
+
+    private static void registerRegisterWalletPQ(CommandRegistry registry) {
+        registry.add(noAuthCommand()
+                .name("register-wallet-pq")
+                .aliases("registerwalletpq")
+                .description("Create a new post-quantum wallet")
+                .option("name", "Wallet name", true)
+                .option("scheme", "PQ signature scheme (default: FN_DSA_512)", false)
+                .handler((ctx, opts, wrapper, out) -> {
+                    PQScheme scheme = parsePQSchemeOption(out, opts);
+                    if (scheme == null) {
+                        return;
+                    }
+                    String envPassword = ctx.getMasterPassword();
+                    if (envPassword == null || envPassword.isEmpty()) {
+                        out.error("execution_error",
+                                "Set MASTER_PASSWORD environment variable for non-interactive wallet creation");
+                        return;
+                    }
+                    char[] password = envPassword.toCharArray();
+                    try {
+                        CliWalletCreationResult result = wrapper.registerWalletPQForCli(
+                                password, scheme, opts.getString("name"));
+                        ActiveWalletConfig.setActiveAddress(result.getAddress());
+                        Map<String, Object> json = new LinkedHashMap<String, Object>();
+                        json.put("keystore", result.getKeystoreName());
+                        json.put("address", result.getAddress());
+                        json.put("wallet_name", result.getWalletName());
+                        json.put("scheme", scheme.name());
+                        out.success("Register a PQ wallet successful, keystore file name is "
+                                + result.getKeystoreName(), json);
+                    } finally {
+                        org.tron.keystore.StringUtils.clear(password);
+                    }
+                })
+                .build());
+    }
+
+    private static void registerImportWalletPQ(CommandRegistry registry) {
+        registry.add(noAuthCommand()
+                .name("import-wallet-pq")
+                .aliases("importwalletpq")
+                .description("Import a post-quantum wallet from an extended private key (priv||pub hex)")
+                .option("name", "Wallet name", true)
+                .option("scheme", "PQ signature scheme (default: FN_DSA_512)", false)
+                .option("extended-private-key-hex",
+                        "Hex-encoded extended private key (private||public bytes)", true)
+                .handler((ctx, opts, wrapper, out) -> {
+                    PQScheme scheme = parsePQSchemeOption(out, opts);
+                    if (scheme == null) {
+                        return;
+                    }
+                    String hex = opts.getString("extended-private-key-hex");
+                    byte[] extendedPriv;
+                    try {
+                        extendedPriv = Hex.decode(hex);
+                    } catch (Exception e) {
+                        out.usageError("Invalid hex for --extended-private-key-hex", null);
+                        return;
+                    }
+                    int expected = PQSchemeRegistry.getPrivateKeyLength(scheme)
+                            + PQSchemeRegistry.getPublicKeyLength(scheme);
+                    if (extendedPriv.length != expected) {
+                        out.usageError("extended-private-key-hex must decode to " + expected
+                                + " bytes for " + scheme.name() + " (got "
+                                + extendedPriv.length + ")", null);
+                        return;
+                    }
+                    String envPassword = ctx.getMasterPassword();
+                    if (envPassword == null || envPassword.isEmpty()) {
+                        out.error("execution_error",
+                                "Set MASTER_PASSWORD environment variable for non-interactive wallet import");
+                        return;
+                    }
+                    char[] password = envPassword.toCharArray();
+                    try {
+                        CliWalletCreationResult result = wrapper.importWalletPQForCli(
+                                password, scheme, extendedPriv, opts.getString("name"));
+                        ActiveWalletConfig.setActiveAddress(result.getAddress());
+                        Map<String, Object> json = new LinkedHashMap<String, Object>();
+                        json.put("keystore", result.getKeystoreName());
+                        json.put("address", result.getAddress());
+                        json.put("wallet_name", result.getWalletName());
+                        json.put("scheme", scheme.name());
+                        out.success("Import a PQ wallet successful, keystore file name is "
+                                + result.getKeystoreName(), json);
+                    } finally {
+                        org.tron.keystore.StringUtils.clear(password);
+                    }
+                })
+                .build());
     }
 
     private static void registerRegisterWallet(CommandRegistry registry) {

--- a/src/main/java/org/tron/walletserver/WalletApi.java
+++ b/src/main/java/org/tron/walletserver/WalletApi.java
@@ -395,8 +395,8 @@ public class WalletApi {
   }
 
   public static WalletFile CreatePQWalletFile(byte[] password, PQScheme scheme,
-      byte[] extendedPrivateKey, byte[] publicKey) throws CipherException {
-    return Wallet.createStandardPQ(password, scheme, extendedPrivateKey, publicKey);
+      byte[] extendedPrivateKey, byte[] seed, byte[] publicKey) throws CipherException {
+    return Wallet.createStandardPQ(password, scheme, extendedPrivateKey, seed, publicKey);
   }
 
   public static void storeMnemonicWords(byte[] password, SignInterface ecKeySm2Pair, List<String> mnemonicWords) throws CipherException, IOException {

--- a/src/main/java/org/tron/walletserver/WalletApi.java
+++ b/src/main/java/org/tron/walletserver/WalletApi.java
@@ -82,7 +82,9 @@ import org.tron.common.crypto.Hash;
 import org.tron.common.crypto.Sha256Sm3Hash;
 import org.tron.common.crypto.SignInterface;
 import org.tron.common.crypto.SignatureInterface;
+import org.tron.common.crypto.pqc.FNDSA512;
 import org.tron.common.crypto.sm2.SM2;
+import org.tron.protos.Protocol.PQScheme;
 import org.tron.common.enums.NetType;
 import org.tron.common.utils.Base58;
 import org.tron.common.utils.ByteArray;
@@ -392,6 +394,11 @@ public class WalletApi {
     return Wallet.createStandardLedger(password, address, path);
   }
 
+  public static WalletFile CreatePQWalletFile(byte[] password, PQScheme scheme,
+      byte[] extendedPrivateKey, byte[] publicKey) throws CipherException {
+    return Wallet.createStandardPQ(password, scheme, extendedPrivateKey, publicKey);
+  }
+
   public static void storeMnemonicWords(byte[] password, SignInterface ecKeySm2Pair, List<String> mnemonicWords) throws CipherException, IOException {
     storeMnemonicWords(password, ecKeySm2Pair, mnemonicWords, true);
   }
@@ -530,6 +537,14 @@ public class WalletApi {
 
   public SM2 getSM2(WalletFile walletFile, byte[] password) throws CipherException {
     return Wallet.decryptSM2(password, walletFile);
+  }
+
+  public FNDSA512 getFNDSA512(WalletFile walletFile, byte[] password) throws CipherException {
+    return Wallet.decryptPQ(password, walletFile);
+  }
+
+  public static boolean isPQWallet(WalletFile walletFile) {
+    return walletFile != null && "FN_DSA_512".equals(walletFile.getScheme());
   }
 
   public byte[] getPrivateBytes(byte[] password) throws CipherException, IOException {
@@ -944,7 +959,9 @@ public class WalletApi {
         return null;
       }
     } else {
-      if (isEckey) {
+      if (isPQWallet(wf)) {
+        transaction = TransactionUtils.signPQ(transaction, this.getFNDSA512(wf, passwd), PQScheme.FN_DSA_512);
+      } else if (isEckey) {
         transaction = TransactionUtils.sign(transaction, this.getEcKey(wf, passwd));
       } else {
         transaction = TransactionUtils.sign(transaction, this.getSM2(wf, passwd));
@@ -1017,7 +1034,9 @@ public class WalletApi {
           return null;
         }
       } else {
-        if (isEckey) {
+        if (isPQWallet(wf)) {
+          transaction = TransactionUtils.signPQ(transaction, this.getFNDSA512(wf, passwd), PQScheme.FN_DSA_512);
+        } else if (isEckey) {
           transaction = TransactionUtils.sign(transaction, this.getEcKey(wf, passwd));
         } else {
           transaction = TransactionUtils.sign(transaction, this.getSM2(wf, passwd));
@@ -1092,7 +1111,9 @@ public class WalletApi {
         TransactionSignManager.getInstance().setTransaction(null);
         throw new CancelException(weight.getResult().getMessage());
       }
-      if (isEckey) {
+      if (isPQWallet(wf)) {
+        transaction = TransactionUtils.signPQ(transaction, this.getFNDSA512(wf, passwd), PQScheme.FN_DSA_512);
+      } else if (isEckey) {
         transaction = TransactionUtils.sign(transaction, this.getEcKey(wf, passwd));
       } else {
         transaction = TransactionUtils.sign(transaction, this.getSM2(wf, passwd));
@@ -4424,7 +4445,9 @@ public class WalletApi {
       System.out.println("Please input your password.");
       passwd = char2Byte(inputPassword(false));
     }
-    if (isEckey) {
+    if (isPQWallet(wf)) {
+      transaction = TransactionUtils.signPQ(transaction, this.getFNDSA512(wf, passwd), PQScheme.FN_DSA_512);
+    } else if (isEckey) {
       transaction = TransactionUtils.sign(transaction, this.getEcKey(wf, passwd));
     } else {
       transaction = TransactionUtils.sign(transaction, this.getSM2(wf, passwd));

--- a/src/main/java/org/tron/walletserver/WalletApi.java
+++ b/src/main/java/org/tron/walletserver/WalletApi.java
@@ -543,8 +543,19 @@ public class WalletApi {
     return Wallet.decryptPQ(password, walletFile);
   }
 
+  public static PQScheme getWalletPQScheme(WalletFile walletFile) {
+    if (walletFile == null || StringUtils.isBlank(walletFile.getScheme())) {
+      return null;
+    }
+    try {
+      return PQScheme.valueOf(walletFile.getScheme());
+    } catch (IllegalArgumentException e) {
+      throw new IllegalStateException("Unsupported PQ scheme: " + walletFile.getScheme(), e);
+    }
+  }
+
   public static boolean isPQWallet(WalletFile walletFile) {
-    return walletFile != null && "FN_DSA_512".equals(walletFile.getScheme());
+    return getWalletPQScheme(walletFile) != null;
   }
 
   public byte[] getPrivateBytes(byte[] password) throws CipherException, IOException {
@@ -959,8 +970,9 @@ public class WalletApi {
         return null;
       }
     } else {
-      if (isPQWallet(wf)) {
-        transaction = TransactionUtils.signPQ(transaction, this.getFNDSA512(wf, passwd), PQScheme.FN_DSA_512);
+      PQScheme pqScheme = getWalletPQScheme(wf);
+      if (pqScheme != null) {
+        transaction = TransactionUtils.signPQ(transaction, this.getFNDSA512(wf, passwd), pqScheme);
       } else if (isEckey) {
         transaction = TransactionUtils.sign(transaction, this.getEcKey(wf, passwd));
       } else {
@@ -1111,8 +1123,9 @@ public class WalletApi {
         TransactionSignManager.getInstance().setTransaction(null);
         throw new CancelException(weight.getResult().getMessage());
       }
-      if (isPQWallet(wf)) {
-        transaction = TransactionUtils.signPQ(transaction, this.getFNDSA512(wf, passwd), PQScheme.FN_DSA_512);
+      PQScheme pqScheme = getWalletPQScheme(wf);
+      if (pqScheme != null) {
+        transaction = TransactionUtils.signPQ(transaction, this.getFNDSA512(wf, passwd), pqScheme);
       } else if (isEckey) {
         transaction = TransactionUtils.sign(transaction, this.getEcKey(wf, passwd));
       } else {

--- a/src/main/java/org/tron/walletserver/WalletApi.java
+++ b/src/main/java/org/tron/walletserver/WalletApi.java
@@ -44,7 +44,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
-import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.security.SecureRandom;
@@ -81,8 +80,7 @@ import org.tron.common.crypto.ECKey;
 import org.tron.common.crypto.Hash;
 import org.tron.common.crypto.Sha256Sm3Hash;
 import org.tron.common.crypto.SignInterface;
-import org.tron.common.crypto.SignatureInterface;
-import org.tron.common.crypto.pqc.FNDSA512;
+import org.tron.common.crypto.pqc.PQSignature;
 import org.tron.common.crypto.sm2.SM2;
 import org.tron.protos.Protocol.PQScheme;
 import org.tron.common.enums.NetType;
@@ -272,7 +270,7 @@ public class WalletApi {
       solidityNode = fullNode;
       isSoliditynodeEmpty = true;
     }
-  
+
     WalletApi.setAddressPreFixByte(ADD_PRE_FIX_BYTE_DEFAULT);
 
     if (config.hasPath("crypto.engine")) {
@@ -539,7 +537,8 @@ public class WalletApi {
     return Wallet.decryptSM2(password, walletFile);
   }
 
-  public FNDSA512 getFNDSA512(WalletFile walletFile, byte[] password) throws CipherException {
+  public PQSignature getPQSignature(WalletFile walletFile, byte[] password)
+      throws CipherException {
     return Wallet.decryptPQ(password, walletFile);
   }
 
@@ -552,10 +551,6 @@ public class WalletApi {
     } catch (IllegalArgumentException e) {
       throw new IllegalStateException("Unsupported PQ scheme: " + walletFile.getScheme(), e);
     }
-  }
-
-  public static boolean isPQWallet(WalletFile walletFile) {
-    return getWalletPQScheme(walletFile) != null;
   }
 
   public byte[] getPrivateBytes(byte[] password) throws CipherException, IOException {
@@ -972,7 +967,7 @@ public class WalletApi {
     } else {
       PQScheme pqScheme = getWalletPQScheme(wf);
       if (pqScheme != null) {
-        transaction = TransactionUtils.signPQ(transaction, this.getFNDSA512(wf, passwd), pqScheme);
+        transaction = TransactionUtils.signPQ(transaction, this.getPQSignature(wf, passwd), pqScheme);
       } else if (isEckey) {
         transaction = TransactionUtils.sign(transaction, this.getEcKey(wf, passwd));
       } else {
@@ -1046,8 +1041,9 @@ public class WalletApi {
           return null;
         }
       } else {
-        if (isPQWallet(wf)) {
-          transaction = TransactionUtils.signPQ(transaction, this.getFNDSA512(wf, passwd), PQScheme.FN_DSA_512);
+        PQScheme pqScheme = getWalletPQScheme(wf);
+        if (pqScheme != null) {
+          transaction = TransactionUtils.signPQ(transaction, this.getPQSignature(wf, passwd), pqScheme);
         } else if (isEckey) {
           transaction = TransactionUtils.sign(transaction, this.getEcKey(wf, passwd));
         } else {
@@ -1125,7 +1121,7 @@ public class WalletApi {
       }
       PQScheme pqScheme = getWalletPQScheme(wf);
       if (pqScheme != null) {
-        transaction = TransactionUtils.signPQ(transaction, this.getFNDSA512(wf, passwd), pqScheme);
+        transaction = TransactionUtils.signPQ(transaction, this.getPQSignature(wf, passwd), pqScheme);
       } else if (isEckey) {
         transaction = TransactionUtils.sign(transaction, this.getEcKey(wf, passwd));
       } else {
@@ -4458,8 +4454,9 @@ public class WalletApi {
       System.out.println("Please input your password.");
       passwd = char2Byte(inputPassword(false));
     }
-    if (isPQWallet(wf)) {
-      transaction = TransactionUtils.signPQ(transaction, this.getFNDSA512(wf, passwd), PQScheme.FN_DSA_512);
+    PQScheme pqScheme = getWalletPQScheme(wf);
+    if (pqScheme != null) {
+      transaction = TransactionUtils.signPQ(transaction, this.getPQSignature(wf, passwd), pqScheme);
     } else if (isEckey) {
       transaction = TransactionUtils.sign(transaction, this.getEcKey(wf, passwd));
     } else {

--- a/src/main/java/org/tron/walletserver/WalletApi.java
+++ b/src/main/java/org/tron/walletserver/WalletApi.java
@@ -3787,6 +3787,8 @@ public class WalletApi {
     }
     Response.TransactionExtention transactionExtention;
     try {
+      // TODO: add PQ support — switch to the deployContract overload that takes an explicit
+      //  owner address.
       transactionExtention = tmpApiCli.deployContract(contractName, ABI,
           code, Collections.emptyList(), feeLimit, consumeUserResourcePercent, originEnergyLimit,
           value, tokenId, tokenValue);
@@ -3870,6 +3872,8 @@ public class WalletApi {
     }
     Response.TransactionExtention transactionExtention;
     try {
+      // TODO: add PQ support — switch to the deployContract overload that takes an explicit
+      //  owner address.
       transactionExtention = tmpApiCli.deployContract(contractName, ABI,
           code, Collections.emptyList(), feeLimit, consumeUserResourcePercent, originEnergyLimit,
           value, tokenId, tokenValue);

--- a/src/main/java/org/tron/walletserver/WalletApi.java
+++ b/src/main/java/org/tron/walletserver/WalletApi.java
@@ -553,6 +553,22 @@ public class WalletApi {
     }
   }
 
+  // The Trident SDK ApiClient takes a hex string private key and assumes it is
+  // a 32-byte ECDSA secp256k1 / SM2 key. A PQ persisted private key (2176 or
+  // 2560 bytes) cannot be used there — silently passing it would produce
+  // invalid signatures or runtime errors deep inside Trident. Operations that
+  // must construct an ApiClient directly should call this before reading the
+  // key out of the keystore, mirroring the pre-flight check in
+  // {@code WalletApiWrapper.gasFreeTransferInternal}.
+  private void rejectPQForEcdsaSigning(String operation) {
+    WalletFile wf = getWalletFile();
+    if (wf != null && wf.getScheme() != null && !wf.getScheme().isEmpty()) {
+      throw new UnsupportedOperationException(
+          operation + " is not supported for post-quantum wallets ("
+              + wf.getScheme() + "); requires an ECDSA wallet.");
+    }
+  }
+
   public byte[] getPrivateBytes(byte[] password) throws CipherException, IOException {
     return decrypt2PrivateBytes(password, loadWalletFile());
   }
@@ -848,7 +864,17 @@ public class WalletApi {
       throw new IOException(
           "No keystore file found, please use " + greenBoldHighlight("RegisterWallet") + " or " + greenBoldHighlight("ImportWallet") + " first!");
     }
-    Credentials credentials = WalletUtils.loadCredentials(oldPassword, wallet);
+    WalletFile existing = WalletUtils.loadWalletFile(wallet);
+    // PQ wallets use a different keystore shape (scheme + ext/seed segments).
+    // The legacy ECDSA/SM2 re-encrypt path would silently rewrite a PQ keystore
+    // as an EC keystore, losing the scheme tag and seed segment.
+    if (existing.getScheme() != null && !existing.getScheme().isEmpty()) {
+      WalletFile reEncrypted = Wallet.reEncryptPQ(oldPassword, newPassowrd, existing);
+      WalletUtils.writeWalletFile(reEncrypted, wallet);
+      // PQ wallets do not currently persist a BIP-39 mnemonic file.
+      return true;
+    }
+    Credentials credentials = WalletUtils.loadCredentials(oldPassword, existing);
     WalletUtils.updateWalletFile(newPassowrd, credentials.getPair(), wallet, true);
 
     // update the password of mnemonicFile
@@ -3734,6 +3760,7 @@ public class WalletApi {
     if (!isUnlocked()) {
       throw new IllegalStateException(LOCK_WARNING);
     }
+    rejectPQForEcdsaSigning("DeployContract");
     if (owner == null) {
       owner = getAddress();
     }
@@ -3816,6 +3843,7 @@ public class WalletApi {
     if (!isUnlocked()) {
       throw new IllegalStateException(LOCK_WARNING);
     }
+    rejectPQForEcdsaSigning("DeployContract");
     if (owner == null) {
       owner = getAddress();
     }

--- a/src/main/protos/core/Tron.proto
+++ b/src/main/protos/core/Tron.proto
@@ -17,6 +17,18 @@ enum AccountType {
   Contract = 2;
 }
 
+// Post-quantum signature scheme identifier used by PQAuthSig.
+// UNKNOWN_PQ_SCHEME = 0 is the proto3 default and is reserved per the
+// java-tron API evolution standard (issue #6515) so unset / unrecognized
+// values are detectable by JSON consumers; it MUST never be registered
+// in PQSchemeRegistry. FN_DSA_512 = 1 is the V2 launch scheme.
+// New schemes are reserved for future activation (see PQSchemeRegistry).
+enum PQScheme {
+  UNKNOWN_PQ_SCHEME = 0;
+  FN_DSA_512 = 1;
+  reserved 2 to 15;
+}
+
 // AccountId, (name, address) use name, (null, address) use address, (name, null) use name,
 message AccountId {
   bytes name = 1;
@@ -245,6 +257,16 @@ message Key {
   int64 weight = 2;
 }
 
+// Per-signer post-quantum authentication witness for a transaction or block.
+// The signing public key is carried in-band; node verifies binding via
+//   derived_addr = 0x41 ‖ deriveHash(scheme, public_key)[12..32]
+// and matches against Permission.keys[].address.
+message PQAuthSig {
+  PQScheme scheme     = 1;
+  bytes    public_key = 2;
+  bytes    signature  = 3;
+}
+
 message DelegatedResource {
   bytes from = 1;
   bytes to = 2;
@@ -448,6 +470,10 @@ message Transaction {
   // only support size = 1,  repeated list here for muti-sig extension
   repeated bytes signature = 2;
   repeated Result ret = 5;
+  // Post-quantum authentication entries. ECDSA signatures (`signature` above)
+  // and PQAuthSig entries may co-exist on a multi-sig transaction; the node
+  // matches each entry's derived address against Permission.keys[].address.
+  repeated PQAuthSig pq_auth_sig = 6;
 }
 
 message TransactionInfo {
@@ -514,6 +540,11 @@ message BlockHeader {
   }
   raw raw_data = 1;
   bytes witness_signature = 2;
+  // Exactly one of {witness_signature, pq_auth_sig} SHALL be present per block:
+  // SRs with an ECDSA-only Witness Key produce witness_signature; SRs with a
+  // PQ-derived Key set pq_auth_sig instead. The verifier dispatches by which
+  // field is populated.
+  PQAuthSig pq_auth_sig = 3;
 }
 
 // block
@@ -627,6 +658,9 @@ message HelloMessage {
   int32 nodeType = 9;
   int64 lowestBlockNum = 10;
   bytes codeVersion = 11;
+  // Post-quantum handshake signature. Mutually exclusive with `signature` —
+  // exactly one of the two must be set by an active SR / peer.
+  PQAuthSig pq_auth_sig = 12;
 }
 
 message InternalTransaction {

--- a/src/main/protos/core/Tron.proto
+++ b/src/main/protos/core/Tron.proto
@@ -19,14 +19,12 @@ enum AccountType {
 
 // Post-quantum signature scheme identifier used by PQAuthSig.
 // UNKNOWN_PQ_SCHEME = 0 is the proto3 default and is reserved per the
-// java-tron API evolution standard (issue #6515) so unset / unrecognized
-// values are detectable by JSON consumers; it MUST never be registered
-// in PQSchemeRegistry. FN_DSA_512 = 1 is the V2 launch scheme.
-// New schemes are reserved for future activation (see PQSchemeRegistry).
+// java-tron API evolution standard so unset / unrecognized values are
+// detectable by JSON consumers; it MUST never be registered in PQSchemeRegistry.
 enum PQScheme {
   UNKNOWN_PQ_SCHEME = 0;
   FN_DSA_512 = 1;
-  reserved 2 to 15;
+  ML_DSA_44 = 2;
 }
 
 // AccountId, (name, address) use name, (null, address) use address, (name, null) use name,

--- a/src/main/resources/commands.txt
+++ b/src/main/resources/commands.txt
@@ -853,3 +853,26 @@ Summary:
 Get witnesses voting information in pages.
 Usage example:
 wallet> GetPaginatedNowWitnessList 0 10
+Syntax:
+GeneratePQKey [scheme]
+Summary:
+Generate a post-quantum keypair (default scheme: FN_DSA_512) and print the address, public key, and extended private key. The key is NOT persisted to a keystore; use RegisterWalletPQ if you want it saved.
+Usage example:
+wallet> GeneratePQKey
+wallet> GeneratePQKey FN_DSA_512
+Syntax:
+RegisterWalletPQ [scheme]
+Summary:
+Register a new post-quantum wallet (default scheme: FN_DSA_512). Generates a fresh Falcon-512 keypair, prompts for a password, and writes an encrypted keystore under Wallet/.
+Usage example:
+wallet> RegisterWalletPQ
+wallet> RegisterWalletPQ FN_DSA_512
+Syntax:
+ImportWalletPQ [scheme] <seed_or_extended_private_key_hex_or_file>
+Summary:
+Import a post-quantum wallet from key material. The argument is required and may be either the hex string itself or a path to a file containing it. The format is auto-detected by length: a 48-byte / 96-hex-char Falcon-512 seed is expanded into the full keypair; a 2176-byte / 4352-hex-char extended private key (priv||pub) is used verbatim. Interactive paste is not supported because most terminals truncate lines longer than ~1024 chars.
+Usage example:
+wallet> ImportWalletPQ FN_DSA_512 0102030405060708...   (96 hex chars = seed)
+wallet> ImportWalletPQ FN_DSA_512 /tmp/my-falcon-seed.hex
+wallet> ImportWalletPQ FN_DSA_512 /tmp/my-falcon-extpriv.hex
+wallet> ImportWalletPQ /tmp/my-falcon-seed.hex

--- a/src/main/resources/commands.txt
+++ b/src/main/resources/commands.txt
@@ -856,23 +856,29 @@ wallet> GetPaginatedNowWitnessList 0 10
 Syntax:
 GeneratePQKey [scheme]
 Summary:
-Generate a post-quantum keypair (default scheme: FN_DSA_512) and print the address, public key, and extended private key. The key is NOT persisted to a keystore; use RegisterWalletPQ if you want it saved.
+Generate a post-quantum keypair and print the address, public key, and persisted private key. Supported schemes: FN_DSA_512 (Falcon-512, default), ML_DSA_44 (CRYSTALS-Dilithium-2 / FIPS-204). The key is NOT persisted to a keystore; use RegisterWalletPQ if you want it saved.
 Usage example:
 wallet> GeneratePQKey
 wallet> GeneratePQKey FN_DSA_512
+wallet> GeneratePQKey ML_DSA_44
 Syntax:
 RegisterWalletPQ [scheme]
 Summary:
-Register a new post-quantum wallet (default scheme: FN_DSA_512). Generates a fresh Falcon-512 keypair, prompts for a password, and writes an encrypted keystore under Wallet/.
+Register a new post-quantum wallet. Generates a fresh keypair for the given scheme, prompts for a password, and writes an encrypted keystore under Wallet/. Supported schemes: FN_DSA_512 (default), ML_DSA_44.
 Usage example:
 wallet> RegisterWalletPQ
 wallet> RegisterWalletPQ FN_DSA_512
+wallet> RegisterWalletPQ ML_DSA_44
 Syntax:
-ImportWalletPQ [scheme] <seed_or_extended_private_key_hex_or_file>
+ImportWalletPQ [scheme] <seed_or_persisted_private_key_hex_or_file>
 Summary:
-Import a post-quantum wallet from key material. The argument is required and may be either the hex string itself or a path to a file containing it. The format is auto-detected by length: a 48-byte / 96-hex-char Falcon-512 seed is expanded into the full keypair; a 2176-byte / 4352-hex-char extended private key (priv||pub) is used verbatim. Interactive paste is not supported because most terminals truncate lines longer than ~1024 chars.
+Import a post-quantum wallet from key material. Supported schemes: FN_DSA_512 (default), ML_DSA_44. The argument is required and may be either the hex string itself or a path to a file containing it. Format is auto-detected by length against the scheme:
+  - FN_DSA_512: 48-byte / 96-hex-char seed, or 2176-byte / 4352-hex-char extended private key (f||g||F||h).
+  - ML_DSA_44:  32-byte / 64-hex-char seed, or 2560-byte / 5120-hex-char encoded private key (rho||K||tr||s1||s2||t0).
+Interactive paste is not supported because most terminals truncate lines longer than ~1024 chars.
 Usage example:
-wallet> ImportWalletPQ FN_DSA_512 0102030405060708...   (96 hex chars = seed)
+wallet> ImportWalletPQ FN_DSA_512 0102030405060708...   (96 hex chars = Falcon seed)
 wallet> ImportWalletPQ FN_DSA_512 /tmp/my-falcon-seed.hex
 wallet> ImportWalletPQ FN_DSA_512 /tmp/my-falcon-extpriv.hex
+wallet> ImportWalletPQ ML_DSA_44 /tmp/my-mldsa-seed.hex
 wallet> ImportWalletPQ /tmp/my-falcon-seed.hex

--- a/src/main/resources/help_summary.txt
+++ b/src/main/resources/help_summary.txt
@@ -133,7 +133,7 @@
 | GetMemoFee                                        | Get memo fee                                                            |
 | ListNodes                                         | Query the list of nodes connected to the API node                       |
 |---------------------------------------------------+-------------------------------------------------------------------------+
-|                WALLET OPERATIONS (25)             |                                                                         |
+|                WALLET OPERATIONS (28)             |                                                                         |
 +---------------------------------------------------+-------------------------------------------------------------------------+
 | Lock                                              | Lock the current wallet account                                         |
 | Unlock                                            | Unlock the current wallet account                                       |
@@ -148,6 +148,9 @@
 | ImportWalletByLedger                              | Import wallet through Ledger                                            |
 | ImportWalletByKeystore                            | Import wallet through Keystore file                                     |
 | ImportWalletByBase64                              | Import wallet through base64                                            |
+| GeneratePQKey                                     | Generate a post-quantum (Falcon-512) keypair without saving a keystore  |
+| RegisterWalletPQ                                  | Register a new post-quantum wallet (Falcon-512 / FN-DSA-512)            |
+| ImportWalletPQ                                    | Import a post-quantum wallet from an extended private key               |
 | GenerateSubAccount                                | Generate sub accounts through mnemonic words                            |
 | ExportWalletKeystore                              | Export the Keystore file                                                |
 | ExportWalletMnemonic                              | Export wallet mnemonic words                                            |

--- a/src/main/resources/help_summary.txt
+++ b/src/main/resources/help_summary.txt
@@ -150,7 +150,7 @@
 | ImportWalletByBase64                              | Import wallet through base64                                            |
 | GeneratePQKey                                     | Generate a post-quantum (Falcon-512) keypair without saving a keystore  |
 | RegisterWalletPQ                                  | Register a new post-quantum wallet (Falcon-512 / FN-DSA-512)            |
-| ImportWalletPQ                                    | Import a post-quantum wallet from an extended private key               |
+| ImportWalletPQ                                    | Import a post-quantum wallet from a seed or extended private key        |
 | GenerateSubAccount                                | Generate sub accounts through mnemonic words                            |
 | ExportWalletKeystore                              | Export the Keystore file                                                |
 | ExportWalletMnemonic                              | Export wallet mnemonic words                                            |

--- a/src/test/java/org/tron/common/crypto/pqc/FNDSA512Test.java
+++ b/src/test/java/org/tron/common/crypto/pqc/FNDSA512Test.java
@@ -39,7 +39,8 @@ public class FNDSA512Test {
         .getBytes(StandardCharsets.UTF_8);
     byte[] signature = signer.sign(message);
     assertNotNull(signature);
-    assertTrue(signature.length > 0 && signature.length <= FNDSA512.SIGNATURE_LENGTH);
+    assertTrue(signature.length >= FNDSA512.SIGNATURE_MIN_LENGTH
+        && signature.length <= FNDSA512.SIGNATURE_LENGTH);
     assertTrue(signer.verify(message, signature));
     assertTrue(FNDSA512.verify(signer.getPublicKey(), message, signature));
   }

--- a/src/test/java/org/tron/common/crypto/pqc/FNDSA512Test.java
+++ b/src/test/java/org/tron/common/crypto/pqc/FNDSA512Test.java
@@ -1,0 +1,138 @@
+package org.tron.common.crypto.pqc;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import org.junit.Test;
+import org.tron.protos.Protocol.PQScheme;
+
+public class FNDSA512Test {
+
+  private static byte[] fixedSeed() {
+    byte[] seed = new byte[FNDSA512.SEED_LENGTH];
+    for (int i = 0; i < seed.length; i++) {
+      seed[i] = (byte) i;
+    }
+    return seed;
+  }
+
+  @Test
+  public void deterministicKeygenFromSeed() {
+    FNDSA512 a = new FNDSA512(fixedSeed());
+    FNDSA512 b = new FNDSA512(fixedSeed());
+    assertArrayEquals(a.getPublicKey(), b.getPublicKey());
+    assertArrayEquals(a.getPrivateKey(), b.getPrivateKey());
+    assertEquals(FNDSA512.PUBLIC_KEY_LENGTH, a.getPublicKey().length);
+    assertEquals(FNDSA512.PRIVATE_KEY_LENGTH, a.getPrivateKey().length);
+  }
+
+  @Test
+  public void signVerifyRoundtrip() {
+    FNDSA512 signer = new FNDSA512(fixedSeed());
+    byte[] message = "wallet-cli FN-DSA-512 round-trip"
+        .getBytes(StandardCharsets.UTF_8);
+    byte[] signature = signer.sign(message);
+    assertNotNull(signature);
+    assertTrue(signature.length > 0 && signature.length <= FNDSA512.SIGNATURE_LENGTH);
+    assertTrue(signer.verify(message, signature));
+    assertTrue(FNDSA512.verify(signer.getPublicKey(), message, signature));
+  }
+
+  @Test
+  public void verifyRejectsTamperedMessage() {
+    FNDSA512 signer = new FNDSA512(fixedSeed());
+    byte[] message = "original".getBytes(StandardCharsets.UTF_8);
+    byte[] signature = signer.sign(message);
+    byte[] tampered = "OrIgInAl".getBytes(StandardCharsets.UTF_8);
+    assertFalse(FNDSA512.verify(signer.getPublicKey(), tampered, signature));
+  }
+
+  @Test
+  public void extendedPrivateKeyRoundtrip() {
+    FNDSA512 original = new FNDSA512(fixedSeed());
+    byte[] extended = original.getPrivateKeyWithPublicKey();
+    assertEquals(FNDSA512.PRIVATE_KEY_WITH_PUBLIC_KEY_LENGTH, extended.length);
+
+    FNDSA512 rebuilt = FNDSA512.fromPrivateKeyWithPublicKey(extended);
+    assertArrayEquals(original.getPublicKey(), rebuilt.getPublicKey());
+    assertArrayEquals(original.getPrivateKey(), rebuilt.getPrivateKey());
+
+    byte[] msg = "extended-roundtrip".getBytes(StandardCharsets.UTF_8);
+    byte[] sig = rebuilt.sign(msg);
+    assertTrue(original.verify(msg, sig));
+  }
+
+  @Test
+  public void derivePublicKeyFromExtendedPrivate() {
+    FNDSA512 signer = new FNDSA512(fixedSeed());
+    byte[] extended = signer.getPrivateKeyWithPublicKey();
+    byte[] derivedPub = FNDSA512.derivePublicKey(extended);
+    assertArrayEquals(signer.getPublicKey(), derivedPub);
+  }
+
+  @Test
+  public void derivePublicKeyFromBarePrivateThrows() {
+    FNDSA512 signer = new FNDSA512(fixedSeed());
+    try {
+      FNDSA512.derivePublicKey(signer.getPrivateKey());
+      fail("expected UnsupportedOperationException for bare private key");
+    } catch (UnsupportedOperationException expected) {
+      // pass
+    }
+  }
+
+  @Test
+  public void getSchemeReturnsFnDsa512() {
+    FNDSA512 signer = new FNDSA512(fixedSeed());
+    assertEquals(PQScheme.FN_DSA_512, signer.getScheme());
+  }
+
+  @Test
+  public void addressIs21BytesWithTronPrefix() {
+    FNDSA512 signer = new FNDSA512(fixedSeed());
+    byte[] address = signer.getAddress();
+    assertEquals(21, address.length);
+    assertEquals((byte) 0x41, address[0]);
+  }
+
+  @Test
+  public void invalidSeedLengthRejected() {
+    try {
+      new FNDSA512(new byte[FNDSA512.SEED_LENGTH - 1]);
+      fail("expected IllegalArgumentException for short seed");
+    } catch (IllegalArgumentException expected) {
+      // pass
+    }
+  }
+
+  @Test
+  public void mismatchedKeypairRejected() {
+    FNDSA512 a = new FNDSA512(fixedSeed());
+    // Different seed → different keypair
+    byte[] otherSeed = new byte[FNDSA512.SEED_LENGTH];
+    new SecureRandom(new byte[]{1, 2, 3}).nextBytes(otherSeed);
+    FNDSA512 b = new FNDSA512(otherSeed);
+    try {
+      new FNDSA512(a.getPrivateKey(), b.getPublicKey());
+      fail("expected IllegalArgumentException for mismatched keypair");
+    } catch (IllegalArgumentException expected) {
+      // pass
+    }
+  }
+
+  @Test
+  public void fromExtendedRejectsWrongLength() {
+    try {
+      FNDSA512.fromPrivateKeyWithPublicKey(new byte[10]);
+      fail("expected IllegalArgumentException for wrong-length extended key");
+    } catch (IllegalArgumentException expected) {
+      // pass
+    }
+  }
+}

--- a/src/test/java/org/tron/common/crypto/pqc/MLDSA44Test.java
+++ b/src/test/java/org/tron/common/crypto/pqc/MLDSA44Test.java
@@ -1,0 +1,124 @@
+package org.tron.common.crypto.pqc;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import org.junit.Test;
+import org.tron.protos.Protocol.PQScheme;
+
+public class MLDSA44Test {
+
+  private static byte[] fixedSeed() {
+    byte[] seed = new byte[MLDSA44.SEED_LENGTH];
+    for (int i = 0; i < seed.length; i++) {
+      seed[i] = (byte) i;
+    }
+    return seed;
+  }
+
+  @Test
+  public void deterministicKeygenFromSeed() {
+    MLDSA44 a = new MLDSA44(fixedSeed());
+    MLDSA44 b = new MLDSA44(fixedSeed());
+    assertArrayEquals(a.getPublicKey(), b.getPublicKey());
+    assertArrayEquals(a.getPrivateKey(), b.getPrivateKey());
+    assertEquals(MLDSA44.PUBLIC_KEY_LENGTH, a.getPublicKey().length);
+    assertEquals(MLDSA44.PRIVATE_KEY_LENGTH, a.getPrivateKey().length);
+  }
+
+  @Test
+  public void signVerifyRoundtrip() {
+    MLDSA44 signer = new MLDSA44(fixedSeed());
+    byte[] message = "wallet-cli ML-DSA-44 round-trip"
+        .getBytes(StandardCharsets.UTF_8);
+    byte[] signature = signer.sign(message);
+    assertNotNull(signature);
+    assertEquals(MLDSA44.SIGNATURE_LENGTH, signature.length);
+    assertTrue(signer.verify(message, signature));
+    assertTrue(MLDSA44.verify(signer.getPublicKey(), message, signature));
+  }
+
+  @Test
+  public void verifyRejectsTamperedMessage() {
+    MLDSA44 signer = new MLDSA44(fixedSeed());
+    byte[] message = "original".getBytes(StandardCharsets.UTF_8);
+    byte[] signature = signer.sign(message);
+    byte[] tampered = "OrIgInAl".getBytes(StandardCharsets.UTF_8);
+    assertFalse(MLDSA44.verify(signer.getPublicKey(), tampered, signature));
+  }
+
+  @Test
+  public void derivePublicKeyFromPrivate() {
+    MLDSA44 signer = new MLDSA44(fixedSeed());
+    byte[] derivedPub = MLDSA44.derivePublicKey(signer.getPrivateKey());
+    assertArrayEquals(signer.getPublicKey(), derivedPub);
+  }
+
+  @Test
+  public void persistedPrivateKeyIsEncodedPrivate() {
+    MLDSA44 signer = new MLDSA44(fixedSeed());
+    assertArrayEquals(signer.getPrivateKey(), signer.getPersistedPrivateKey());
+    assertEquals(MLDSA44.PRIVATE_KEY_LENGTH, signer.getPersistedPrivateKey().length);
+  }
+
+  @Test
+  public void getSchemeReturnsMlDsa44() {
+    MLDSA44 signer = new MLDSA44(fixedSeed());
+    assertEquals(PQScheme.ML_DSA_44, signer.getScheme());
+  }
+
+  @Test
+  public void addressIs21BytesWithTronPrefix() {
+    MLDSA44 signer = new MLDSA44(fixedSeed());
+    byte[] address = signer.getAddress();
+    assertEquals(21, address.length);
+    assertEquals((byte) 0x41, address[0]);
+  }
+
+  @Test
+  public void invalidSeedLengthRejected() {
+    try {
+      new MLDSA44(new byte[MLDSA44.SEED_LENGTH - 1]);
+      fail("expected IllegalArgumentException for short seed");
+    } catch (IllegalArgumentException expected) {
+      // pass
+    }
+  }
+
+  @Test
+  public void mismatchedKeypairRejected() {
+    MLDSA44 a = new MLDSA44(fixedSeed());
+    byte[] otherSeed = new byte[MLDSA44.SEED_LENGTH];
+    new SecureRandom(new byte[]{1, 2, 3}).nextBytes(otherSeed);
+    MLDSA44 b = new MLDSA44(otherSeed);
+    try {
+      new MLDSA44(a.getPrivateKey(), b.getPublicKey());
+      fail("expected IllegalArgumentException for mismatched keypair");
+    } catch (IllegalArgumentException expected) {
+      // pass
+    }
+  }
+
+  @Test
+  public void validateSignatureRejectsWrongLength() {
+    MLDSA44 signer = new MLDSA44(fixedSeed());
+    try {
+      signer.validateSignature(new byte[MLDSA44.SIGNATURE_LENGTH - 1]);
+      fail("expected IllegalArgumentException for short signature");
+    } catch (IllegalArgumentException expected) {
+      // pass
+    }
+    try {
+      signer.validateSignature(new byte[MLDSA44.SIGNATURE_LENGTH + 1]);
+      fail("expected IllegalArgumentException for long signature");
+    } catch (IllegalArgumentException expected) {
+      // pass
+    }
+  }
+}

--- a/src/test/java/org/tron/common/crypto/pqc/PQSchemeRegistryTest.java
+++ b/src/test/java/org/tron/common/crypto/pqc/PQSchemeRegistryTest.java
@@ -1,0 +1,95 @@
+package org.tron.common.crypto.pqc;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.Test;
+import org.tron.protos.Protocol.PQScheme;
+
+public class PQSchemeRegistryTest {
+
+  private static byte[] fixedSeed() {
+    byte[] seed = new byte[FNDSA512.SEED_LENGTH];
+    for (int i = 0; i < seed.length; i++) {
+      seed[i] = (byte) (i + 1);
+    }
+    return seed;
+  }
+
+  @Test
+  public void resolveUnknownMapsToFnDsa512() {
+    assertEquals(PQScheme.FN_DSA_512, PQSchemeRegistry.resolve(PQScheme.UNKNOWN_PQ_SCHEME));
+    assertEquals(PQScheme.FN_DSA_512, PQSchemeRegistry.resolve(PQScheme.FN_DSA_512));
+  }
+
+  @Test
+  public void containsAndLengthQueries() {
+    assertTrue(PQSchemeRegistry.contains(PQScheme.FN_DSA_512));
+    assertTrue(PQSchemeRegistry.contains(PQScheme.UNKNOWN_PQ_SCHEME));
+    assertEquals(FNDSA512.PRIVATE_KEY_LENGTH,
+        PQSchemeRegistry.getPrivateKeyLength(PQScheme.FN_DSA_512));
+    assertEquals(FNDSA512.PUBLIC_KEY_LENGTH,
+        PQSchemeRegistry.getPublicKeyLength(PQScheme.FN_DSA_512));
+    assertEquals(FNDSA512.SIGNATURE_LENGTH,
+        PQSchemeRegistry.getSignatureLength(PQScheme.FN_DSA_512));
+    assertEquals(FNDSA512.SEED_LENGTH,
+        PQSchemeRegistry.getSeedLength(PQScheme.FN_DSA_512));
+  }
+
+  @Test
+  public void signVerifyDispatch() {
+    FNDSA512 signer = new FNDSA512(fixedSeed());
+    byte[] msg = "registry-dispatch".getBytes(StandardCharsets.UTF_8);
+    byte[] sig = PQSchemeRegistry.sign(PQScheme.FN_DSA_512, signer.getPrivateKey(), msg);
+    assertTrue(PQSchemeRegistry.verify(PQScheme.FN_DSA_512, signer.getPublicKey(), msg, sig));
+  }
+
+  @Test
+  public void signatureLengthValidator() {
+    assertFalse(PQSchemeRegistry.isValidSignatureLength(PQScheme.FN_DSA_512, 0));
+    assertTrue(PQSchemeRegistry.isValidSignatureLength(PQScheme.FN_DSA_512, 1));
+    assertTrue(PQSchemeRegistry.isValidSignatureLength(
+        PQScheme.FN_DSA_512, FNDSA512.SIGNATURE_LENGTH));
+    assertFalse(PQSchemeRegistry.isValidSignatureLength(
+        PQScheme.FN_DSA_512, FNDSA512.SIGNATURE_LENGTH + 1));
+  }
+
+  @Test
+  public void computeAddressMatchesEcdsaShape() {
+    FNDSA512 signer = new FNDSA512(fixedSeed());
+    byte[] addr = PQSchemeRegistry.computeAddress(PQScheme.FN_DSA_512, signer.getPublicKey());
+    assertEquals(21, addr.length);
+    assertEquals((byte) 0x41, addr[0]);
+    // FNDSA512.getAddress delegates to this method — must match.
+    assertArrayEquals(signer.getAddress(), addr);
+  }
+
+  @Test
+  public void deriveHashLengthIs32() {
+    FNDSA512 signer = new FNDSA512(fixedSeed());
+    byte[] digest = PQSchemeRegistry.deriveHash(PQScheme.FN_DSA_512, signer.getPublicKey());
+    assertEquals(32, digest.length);
+  }
+
+  @Test
+  public void deriveHashRejectsWrongPubLength() {
+    try {
+      PQSchemeRegistry.deriveHash(PQScheme.FN_DSA_512, new byte[10]);
+      fail("expected IllegalArgumentException for short public key");
+    } catch (IllegalArgumentException expected) {
+      // pass
+    }
+  }
+
+  @Test
+  public void fromSeedAndFromKeypair() {
+    PQSignature fromSeed = PQSchemeRegistry.fromSeed(PQScheme.FN_DSA_512, fixedSeed());
+    PQSignature fromKeypair = PQSchemeRegistry.fromKeypair(
+        PQScheme.FN_DSA_512, fromSeed.getPrivateKey(), fromSeed.getPublicKey());
+    assertArrayEquals(fromSeed.getPublicKey(), fromKeypair.getPublicKey());
+  }
+}

--- a/src/test/java/org/tron/common/crypto/pqc/PQSchemeRegistryTest.java
+++ b/src/test/java/org/tron/common/crypto/pqc/PQSchemeRegistryTest.java
@@ -21,15 +21,10 @@ public class PQSchemeRegistryTest {
   }
 
   @Test
-  public void resolveUnknownMapsToFnDsa512() {
-    assertEquals(PQScheme.FN_DSA_512, PQSchemeRegistry.resolve(PQScheme.UNKNOWN_PQ_SCHEME));
-    assertEquals(PQScheme.FN_DSA_512, PQSchemeRegistry.resolve(PQScheme.FN_DSA_512));
-  }
-
-  @Test
   public void containsAndLengthQueries() {
     assertTrue(PQSchemeRegistry.contains(PQScheme.FN_DSA_512));
-    assertTrue(PQSchemeRegistry.contains(PQScheme.UNKNOWN_PQ_SCHEME));
+    assertFalse(PQSchemeRegistry.contains(PQScheme.UNKNOWN_PQ_SCHEME));
+    assertFalse(PQSchemeRegistry.contains(null));
     assertEquals(FNDSA512.PRIVATE_KEY_LENGTH,
         PQSchemeRegistry.getPrivateKeyLength(PQScheme.FN_DSA_512));
     assertEquals(FNDSA512.PUBLIC_KEY_LENGTH,
@@ -51,7 +46,10 @@ public class PQSchemeRegistryTest {
   @Test
   public void signatureLengthValidator() {
     assertFalse(PQSchemeRegistry.isValidSignatureLength(PQScheme.FN_DSA_512, 0));
-    assertTrue(PQSchemeRegistry.isValidSignatureLength(PQScheme.FN_DSA_512, 1));
+    assertFalse(PQSchemeRegistry.isValidSignatureLength(
+        PQScheme.FN_DSA_512, FNDSA512.SIGNATURE_MIN_LENGTH - 1));
+    assertTrue(PQSchemeRegistry.isValidSignatureLength(
+        PQScheme.FN_DSA_512, FNDSA512.SIGNATURE_MIN_LENGTH));
     assertTrue(PQSchemeRegistry.isValidSignatureLength(
         PQScheme.FN_DSA_512, FNDSA512.SIGNATURE_LENGTH));
     assertFalse(PQSchemeRegistry.isValidSignatureLength(
@@ -91,5 +89,68 @@ public class PQSchemeRegistryTest {
     PQSignature fromKeypair = PQSchemeRegistry.fromKeypair(
         PQScheme.FN_DSA_512, fromSeed.getPrivateKey(), fromSeed.getPublicKey());
     assertArrayEquals(fromSeed.getPublicKey(), fromKeypair.getPublicKey());
+  }
+
+  @Test
+  public void mlDsa44Registered() {
+    assertTrue(PQSchemeRegistry.contains(PQScheme.ML_DSA_44));
+    assertEquals(MLDSA44.PRIVATE_KEY_LENGTH,
+        PQSchemeRegistry.getPrivateKeyLength(PQScheme.ML_DSA_44));
+    assertEquals(MLDSA44.PUBLIC_KEY_LENGTH,
+        PQSchemeRegistry.getPublicKeyLength(PQScheme.ML_DSA_44));
+    assertEquals(MLDSA44.SIGNATURE_LENGTH,
+        PQSchemeRegistry.getSignatureLength(PQScheme.ML_DSA_44));
+    assertEquals(MLDSA44.SEED_LENGTH,
+        PQSchemeRegistry.getSeedLength(PQScheme.ML_DSA_44));
+    assertEquals(MLDSA44.PRIVATE_KEY_LENGTH,
+        PQSchemeRegistry.getPersistedPrivateKeyLength(PQScheme.ML_DSA_44));
+  }
+
+  @Test
+  public void mlDsa44SignVerifyDispatch() {
+    byte[] seed = new byte[MLDSA44.SEED_LENGTH];
+    for (int i = 0; i < seed.length; i++) {
+      seed[i] = (byte) (i + 3);
+    }
+    MLDSA44 signer = new MLDSA44(seed);
+    byte[] msg = "ml-dsa-44 registry dispatch".getBytes(StandardCharsets.UTF_8);
+    byte[] sig = PQSchemeRegistry.sign(PQScheme.ML_DSA_44, signer.getPrivateKey(), msg);
+    assertTrue(PQSchemeRegistry.verify(PQScheme.ML_DSA_44, signer.getPublicKey(), msg, sig));
+  }
+
+  @Test
+  public void mlDsa44SignatureLengthIsFixed() {
+    assertFalse(PQSchemeRegistry.isValidSignatureLength(
+        PQScheme.ML_DSA_44, MLDSA44.SIGNATURE_LENGTH - 1));
+    assertTrue(PQSchemeRegistry.isValidSignatureLength(
+        PQScheme.ML_DSA_44, MLDSA44.SIGNATURE_LENGTH));
+    assertFalse(PQSchemeRegistry.isValidSignatureLength(
+        PQScheme.ML_DSA_44, MLDSA44.SIGNATURE_LENGTH + 1));
+  }
+
+  @Test
+  public void mlDsa44ComputeAddressShape() {
+    byte[] seed = new byte[MLDSA44.SEED_LENGTH];
+    for (int i = 0; i < seed.length; i++) {
+      seed[i] = (byte) (i + 5);
+    }
+    MLDSA44 signer = new MLDSA44(seed);
+    byte[] addr = PQSchemeRegistry.computeAddress(PQScheme.ML_DSA_44, signer.getPublicKey());
+    assertEquals(21, addr.length);
+    assertEquals((byte) 0x41, addr[0]);
+    assertArrayEquals(signer.getAddress(), addr);
+  }
+
+  @Test
+  public void mlDsa44FromPersistedPrivateKey() {
+    byte[] seed = new byte[MLDSA44.SEED_LENGTH];
+    for (int i = 0; i < seed.length; i++) {
+      seed[i] = (byte) (i + 9);
+    }
+    MLDSA44 original = new MLDSA44(seed);
+    PQSignature rebuilt = PQSchemeRegistry.fromPersistedPrivateKey(
+        PQScheme.ML_DSA_44, original.getPersistedPrivateKey());
+    assertArrayEquals(original.getPublicKey(), rebuilt.getPublicKey());
+    assertArrayEquals(original.getPrivateKey(), rebuilt.getPrivateKey());
   }
 }

--- a/src/test/java/org/tron/common/crypto/pqc/PQSignatureDefaultsTest.java
+++ b/src/test/java/org/tron/common/crypto/pqc/PQSignatureDefaultsTest.java
@@ -1,0 +1,81 @@
+package org.tron.common.crypto.pqc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+/**
+ * Default-method contract tests for {@link PQSignature}. The defaults validate
+ * key and signature lengths so that registered schemes do not need to
+ * re-implement that boilerplate.
+ */
+public class PQSignatureDefaultsTest {
+
+  @Test
+  public void validatePrivateKeyRejectsWrongLength() {
+    FNDSA512 signer = new FNDSA512();
+    try {
+      signer.validatePrivateKey(new byte[1]);
+      fail("expected IllegalArgumentException for wrong private key length");
+    } catch (IllegalArgumentException expected) {
+      // pass — FNDSA512 overrides default to also accept extended form,
+      // but length=1 fails both branches.
+    }
+  }
+
+  @Test
+  public void validatePrivateKeyAcceptsExtendedForm() {
+    FNDSA512 signer = new FNDSA512();
+    // Extended form is allowed for FN-DSA (overridden default).
+    signer.validatePrivateKey(signer.getPrivateKeyWithPublicKey());
+    signer.validatePrivateKey(signer.getPrivateKey());
+  }
+
+  @Test
+  public void validatePublicKeyRejectsWrongLength() {
+    FNDSA512 signer = new FNDSA512();
+    try {
+      signer.validatePublicKey(new byte[1]);
+      fail("expected IllegalArgumentException for wrong public key length");
+    } catch (IllegalArgumentException expected) {
+      // pass
+    }
+  }
+
+  @Test
+  public void validatePublicKeyAcceptsCorrectLength() {
+    FNDSA512 signer = new FNDSA512();
+    signer.validatePublicKey(signer.getPublicKey());
+  }
+
+  @Test
+  public void validateSignatureRejectsEmpty() {
+    FNDSA512 signer = new FNDSA512();
+    try {
+      signer.validateSignature(new byte[0]);
+      fail("expected IllegalArgumentException for empty signature");
+    } catch (IllegalArgumentException expected) {
+      // pass
+    }
+  }
+
+  @Test
+  public void validateSignatureRejectsTooLong() {
+    FNDSA512 signer = new FNDSA512();
+    try {
+      signer.validateSignature(new byte[FNDSA512.SIGNATURE_LENGTH + 1]);
+      fail("expected IllegalArgumentException for oversized signature");
+    } catch (IllegalArgumentException expected) {
+      // pass
+    }
+  }
+
+  @Test
+  public void lengthGettersMatchConstants() {
+    FNDSA512 signer = new FNDSA512();
+    assertEquals(FNDSA512.PRIVATE_KEY_LENGTH, signer.getPrivateKeyLength());
+    assertEquals(FNDSA512.PUBLIC_KEY_LENGTH, signer.getPublicKeyLength());
+    assertEquals(FNDSA512.SIGNATURE_LENGTH, signer.getSignatureLength());
+  }
+}

--- a/src/test/java/org/tron/keystore/WalletPQAddressTest.java
+++ b/src/test/java/org/tron/keystore/WalletPQAddressTest.java
@@ -1,0 +1,41 @@
+package org.tron.keystore;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.tron.common.crypto.Hash;
+import org.tron.common.crypto.pqc.FNDSA512;
+import org.tron.common.crypto.pqc.PQSchemeRegistry;
+import org.tron.protos.Protocol.PQScheme;
+
+/**
+ * Parity test: confirm that PQ address derivation matches the documented
+ * formula {@code 0x41 ‖ Keccak-256(public_key)[12..32]}, the same shape as
+ * the ECDSA address derivation. The vector is computed at test time from a
+ * fixed seed (no hard-coded magic bytes — the test guards the formula, not
+ * a snapshot of the BC implementation).
+ */
+public class WalletPQAddressTest {
+
+  @Test
+  public void addressMatchesKeccak256Slice() {
+    byte[] seed = new byte[FNDSA512.SEED_LENGTH];
+    for (int i = 0; i < seed.length; i++) {
+      seed[i] = (byte) (i * 3 + 1);
+    }
+    FNDSA512 signer = new FNDSA512(seed);
+    byte[] publicKey = signer.getPublicKey();
+
+    byte[] digest = Hash.sha3(publicKey);
+    assertEquals(32, digest.length);
+
+    byte[] expected = new byte[21];
+    expected[0] = 0x41;
+    System.arraycopy(digest, digest.length - 20, expected, 1, 20);
+
+    byte[] actual = PQSchemeRegistry.computeAddress(PQScheme.FN_DSA_512, publicKey);
+    assertArrayEquals(expected, actual);
+    assertArrayEquals(expected, signer.getAddress());
+  }
+}

--- a/src/test/java/org/tron/keystore/WalletPQKeystoreTest.java
+++ b/src/test/java/org/tron/keystore/WalletPQKeystoreTest.java
@@ -115,7 +115,8 @@ public class WalletPQKeystoreTest {
         original.getPrivateKeyWithPublicKey(), seed, original.getPublicKey());
 
     String mac = walletFile.getCrypto().getMac();
-    walletFile.getCrypto().setMac(mac.replace('a', 'b').replace('0', '1'));
+    char flipped = mac.charAt(0) == '0' ? '1' : '0';
+    walletFile.getCrypto().setMac(flipped + mac.substring(1));
 
     try {
       Wallet.decryptPQ(password, walletFile);
@@ -135,7 +136,8 @@ public class WalletPQKeystoreTest {
         original.getPrivateKeyWithPublicKey(), seed, original.getPublicKey());
 
     String seedMac = walletFile.getCrypto().getSeedmac();
-    walletFile.getCrypto().setSeedmac(seedMac.replace('a', 'b').replace('0', '1'));
+    char seedFlipped = seedMac.charAt(0) == '0' ? '1' : '0';
+    walletFile.getCrypto().setSeedmac(seedFlipped + seedMac.substring(1));
 
     try {
       Wallet.decryptPQ(password, walletFile);

--- a/src/test/java/org/tron/keystore/WalletPQKeystoreTest.java
+++ b/src/test/java/org/tron/keystore/WalletPQKeystoreTest.java
@@ -51,7 +51,7 @@ public class WalletPQKeystoreTest {
     String seedIv = walletFile.getCrypto().getSeedcipherparams().getIv();
     assertFalse("IVs must be independent", extIv.equals(seedIv));
 
-    FNDSA512 decrypted = Wallet.decryptPQ(password, walletFile);
+    FNDSA512 decrypted = (FNDSA512) Wallet.decryptPQ(password, walletFile);
     assertNotNull(decrypted);
     assertArrayEquals(original.getPublicKey(), decrypted.getPublicKey());
     assertArrayEquals(original.getPrivateKey(), decrypted.getPrivateKey());
@@ -73,7 +73,7 @@ public class WalletPQKeystoreTest {
     assertNotNull(walletFile.getCrypto().getCiphertext());
     assertNull(walletFile.getCrypto().getSeedciphertext());
 
-    FNDSA512 decrypted = Wallet.decryptPQ(password, walletFile);
+    FNDSA512 decrypted = (FNDSA512) Wallet.decryptPQ(password, walletFile);
     assertArrayEquals(original.getPublicKey(), decrypted.getPublicKey());
   }
 
@@ -90,7 +90,7 @@ public class WalletPQKeystoreTest {
     assertNull(walletFile.getCrypto().getCiphertext());
     assertNotNull(walletFile.getCrypto().getSeedciphertext());
 
-    FNDSA512 decrypted = Wallet.decryptPQ(password, walletFile);
+    FNDSA512 decrypted = (FNDSA512) Wallet.decryptPQ(password, walletFile);
     assertArrayEquals(original.getPublicKey(), decrypted.getPublicKey());
   }
 
@@ -198,7 +198,7 @@ public class WalletPQKeystoreTest {
     WalletFile reloaded = mapper.readValue(json, WalletFile.class);
     assertEquals("FN_DSA_512", reloaded.getScheme());
 
-    FNDSA512 decrypted = Wallet.decryptPQ(password, reloaded);
+    FNDSA512 decrypted = (FNDSA512) Wallet.decryptPQ(password, reloaded);
     assertArrayEquals(original.getPublicKey(), decrypted.getPublicKey());
   }
 

--- a/src/test/java/org/tron/keystore/WalletPQKeystoreTest.java
+++ b/src/test/java/org/tron/keystore/WalletPQKeystoreTest.java
@@ -1,0 +1,80 @@
+package org.tron.keystore;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import org.junit.Test;
+import org.tron.common.crypto.pqc.FNDSA512;
+import org.tron.common.crypto.pqc.PQSchemeRegistry;
+import org.tron.protos.Protocol.PQScheme;
+import org.tron.walletserver.WalletApi;
+
+public class WalletPQKeystoreTest {
+
+  private static byte[] fixedSeed() {
+    byte[] seed = new byte[FNDSA512.SEED_LENGTH];
+    for (int i = 0; i < seed.length; i++) {
+      seed[i] = (byte) (i + 7);
+    }
+    return seed;
+  }
+
+  @Test
+  public void encryptDecryptRoundtrip() throws Exception {
+    FNDSA512 original = new FNDSA512(fixedSeed());
+    byte[] password = "testpassword123A".getBytes(StandardCharsets.UTF_8);
+
+    WalletFile walletFile = Wallet.createStandardPQ(
+        password, PQScheme.FN_DSA_512,
+        original.getPrivateKeyWithPublicKey(), original.getPublicKey());
+
+    assertEquals("FN_DSA_512", walletFile.getScheme());
+    String expectedAddress = WalletApi.encode58Check(
+        PQSchemeRegistry.computeAddress(PQScheme.FN_DSA_512, original.getPublicKey()));
+    assertEquals(expectedAddress, walletFile.getAddress());
+
+    FNDSA512 decrypted = Wallet.decryptPQ(password, walletFile);
+    assertNotNull(decrypted);
+    assertArrayEquals(original.getPublicKey(), decrypted.getPublicKey());
+    assertArrayEquals(original.getPrivateKey(), decrypted.getPrivateKey());
+
+    byte[] msg = "keystore-roundtrip".getBytes(StandardCharsets.UTF_8);
+    byte[] sig = decrypted.sign(msg);
+    assertTrue(FNDSA512.verify(original.getPublicKey(), msg, sig));
+  }
+
+  @Test
+  public void jacksonSerializationPreservesSchemeField() throws Exception {
+    FNDSA512 original = new FNDSA512(fixedSeed());
+    byte[] password = "testpassword123A".getBytes(StandardCharsets.UTF_8);
+    WalletFile walletFile = Wallet.createStandardPQ(
+        password, PQScheme.FN_DSA_512,
+        original.getPrivateKeyWithPublicKey(), original.getPublicKey());
+
+    ObjectMapper mapper = new ObjectMapper();
+    String json = mapper.writeValueAsString(walletFile);
+    assertTrue("JSON should contain scheme field: " + json,
+        json.contains("\"scheme\":\"FN_DSA_512\""));
+
+    WalletFile reloaded = mapper.readValue(json, WalletFile.class);
+    assertEquals("FN_DSA_512", reloaded.getScheme());
+    assertEquals(walletFile.getAddress(), reloaded.getAddress());
+
+    FNDSA512 decrypted = Wallet.decryptPQ(password, reloaded);
+    assertArrayEquals(original.getPublicKey(), decrypted.getPublicKey());
+  }
+
+  @Test
+  public void legacyWalletFileHasNoSchemeField() throws Exception {
+    // A WalletFile with no scheme (legacy ECKey/SM2) must not emit a scheme key.
+    WalletFile legacy = new WalletFile();
+    legacy.setAddress("Tabcdefg");
+    ObjectMapper mapper = new ObjectMapper();
+    String json = mapper.writeValueAsString(legacy);
+    assertTrue("Legacy JSON should omit scheme: " + json, !json.contains("\"scheme\""));
+  }
+}

--- a/src/test/java/org/tron/keystore/WalletPQKeystoreTest.java
+++ b/src/test/java/org/tron/keystore/WalletPQKeystoreTest.java
@@ -2,14 +2,18 @@ package org.tron.keystore;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.charset.StandardCharsets;
 import org.junit.Test;
 import org.tron.common.crypto.pqc.FNDSA512;
 import org.tron.common.crypto.pqc.PQSchemeRegistry;
+import org.tron.core.exception.CipherException;
 import org.tron.protos.Protocol.PQScheme;
 import org.tron.walletserver.WalletApi;
 
@@ -24,57 +28,185 @@ public class WalletPQKeystoreTest {
   }
 
   @Test
-  public void encryptDecryptRoundtrip() throws Exception {
-    FNDSA512 original = new FNDSA512(fixedSeed());
+  public void encryptDecryptRoundtripDualCiphertext() throws Exception {
+    byte[] seed = fixedSeed();
+    FNDSA512 original = new FNDSA512(seed);
     byte[] password = "testpassword123A".getBytes(StandardCharsets.UTF_8);
 
     WalletFile walletFile = Wallet.createStandardPQ(
         password, PQScheme.FN_DSA_512,
-        original.getPrivateKeyWithPublicKey(), original.getPublicKey());
+        original.getPrivateKeyWithPublicKey(), seed, original.getPublicKey());
 
     assertEquals("FN_DSA_512", walletFile.getScheme());
     String expectedAddress = WalletApi.encode58Check(
         PQSchemeRegistry.computeAddress(PQScheme.FN_DSA_512, original.getPublicKey()));
     assertEquals(expectedAddress, walletFile.getAddress());
 
+    // Both segments must be present
+    assertNotNull(walletFile.getCrypto().getCiphertext());
+    assertNotNull(walletFile.getCrypto().getSeedciphertext());
+
+    // IVs must be independent
+    String extIv = walletFile.getCrypto().getCipherparams().getIv();
+    String seedIv = walletFile.getCrypto().getSeedcipherparams().getIv();
+    assertFalse("IVs must be independent", extIv.equals(seedIv));
+
     FNDSA512 decrypted = Wallet.decryptPQ(password, walletFile);
     assertNotNull(decrypted);
     assertArrayEquals(original.getPublicKey(), decrypted.getPublicKey());
     assertArrayEquals(original.getPrivateKey(), decrypted.getPrivateKey());
 
-    byte[] msg = "keystore-roundtrip".getBytes(StandardCharsets.UTF_8);
+    byte[] msg = "keystore-roundtrip-dual".getBytes(StandardCharsets.UTF_8);
     byte[] sig = decrypted.sign(msg);
     assertTrue(FNDSA512.verify(original.getPublicKey(), msg, sig));
   }
 
   @Test
-  public void jacksonSerializationPreservesSchemeField() throws Exception {
+  public void encryptDecryptRoundtripExtOnly() throws Exception {
     FNDSA512 original = new FNDSA512(fixedSeed());
+    byte[] password = "testpassword123A".getBytes(StandardCharsets.UTF_8);
+
+    WalletFile walletFile = Wallet.createStandardPQ(
+        password, PQScheme.FN_DSA_512,
+        original.getPrivateKeyWithPublicKey(), null, original.getPublicKey());
+
+    assertNotNull(walletFile.getCrypto().getCiphertext());
+    assertNull(walletFile.getCrypto().getSeedciphertext());
+
+    FNDSA512 decrypted = Wallet.decryptPQ(password, walletFile);
+    assertArrayEquals(original.getPublicKey(), decrypted.getPublicKey());
+  }
+
+  @Test
+  public void encryptDecryptRoundtripSeedOnly() throws Exception {
+    byte[] seed = fixedSeed();
+    FNDSA512 original = new FNDSA512(seed);
+    byte[] password = "testpassword123A".getBytes(StandardCharsets.UTF_8);
+
+    WalletFile walletFile = Wallet.createStandardPQ(
+        password, PQScheme.FN_DSA_512,
+        null, seed, original.getPublicKey());
+
+    assertNull(walletFile.getCrypto().getCiphertext());
+    assertNotNull(walletFile.getCrypto().getSeedciphertext());
+
+    FNDSA512 decrypted = Wallet.decryptPQ(password, walletFile);
+    assertArrayEquals(original.getPublicKey(), decrypted.getPublicKey());
+  }
+
+  @Test
+  public void createFailsWithoutKeyMaterial() {
+    byte[] password = "test".getBytes(StandardCharsets.UTF_8);
+    try {
+      Wallet.createStandardPQ(password, PQScheme.FN_DSA_512, null, null, new byte[896]);
+      fail("Should reject null key material");
+    } catch (CipherException e) {
+      assertTrue(e.getMessage().contains("requires at least one"));
+    }
+  }
+
+  @Test
+  public void extMacTamperRejectsDecryption() throws Exception {
+    byte[] seed = fixedSeed();
+    FNDSA512 original = new FNDSA512(seed);
+    byte[] password = "test".getBytes(StandardCharsets.UTF_8);
+    WalletFile walletFile = Wallet.createStandardPQ(
+        password, PQScheme.FN_DSA_512,
+        original.getPrivateKeyWithPublicKey(), seed, original.getPublicKey());
+
+    String mac = walletFile.getCrypto().getMac();
+    walletFile.getCrypto().setMac(mac.replace('a', 'b').replace('0', '1'));
+
+    try {
+      Wallet.decryptPQ(password, walletFile);
+      fail("Should reject tampered ext MAC");
+    } catch (CipherException e) {
+      assertEquals("Invalid password provided", e.getMessage());
+    }
+  }
+
+  @Test
+  public void seedMacTamperRejectsDecryption() throws Exception {
+    byte[] seed = fixedSeed();
+    FNDSA512 original = new FNDSA512(seed);
+    byte[] password = "test".getBytes(StandardCharsets.UTF_8);
+    WalletFile walletFile = Wallet.createStandardPQ(
+        password, PQScheme.FN_DSA_512,
+        original.getPrivateKeyWithPublicKey(), seed, original.getPublicKey());
+
+    String seedMac = walletFile.getCrypto().getSeedmac();
+    walletFile.getCrypto().setSeedmac(seedMac.replace('a', 'b').replace('0', '1'));
+
+    try {
+      Wallet.decryptPQ(password, walletFile);
+      fail("Should reject tampered seed MAC");
+    } catch (CipherException e) {
+      assertEquals("Invalid password provided", e.getMessage());
+    }
+  }
+
+  @Test
+  public void mismatchBetweenSeedAndExtRejectsDecryption() throws Exception {
+    byte[] seed = fixedSeed();
+    FNDSA512 original = new FNDSA512(seed);
+    byte[] password = "test".getBytes(StandardCharsets.UTF_8);
+
+    WalletFile walletFile = Wallet.createStandardPQ(
+        password, PQScheme.FN_DSA_512,
+        original.getPrivateKeyWithPublicKey(), seed, original.getPublicKey());
+
+    // Create a second wallet with a different key, steal its seed ciphertext + mac + iv
+    byte[] seed2 = seed.clone();
+    seed2[0] ^= 1;
+    FNDSA512 other = new FNDSA512(seed2);
+    WalletFile otherWallet = Wallet.createStandardPQ(
+        password, PQScheme.FN_DSA_512,
+        other.getPrivateKeyWithPublicKey(), seed2, other.getPublicKey());
+
+    // Graft the other wallet's seed segment into the first wallet (an insider
+    // with the password could do this to try to desync the wallet).
+    walletFile.getCrypto().setSeedciphertext(otherWallet.getCrypto().getSeedciphertext());
+    walletFile.getCrypto().setSeedmac(otherWallet.getCrypto().getSeedmac());
+    walletFile.getCrypto().setSeedcipherparams(otherWallet.getCrypto().getSeedcipherparams());
+
+    try {
+      Wallet.decryptPQ(password, walletFile);
+      fail("Should reject mismatched seed/ext");
+    } catch (CipherException e) {
+      assertTrue("Expected 'Invalid password provided' (due to mismatched MAC since scrypt key doesn't match graft), got: " + e.getMessage(),
+          e.getMessage().contains("Invalid password provided") || e.getMessage().contains("disagree"));
+    }
+  }
+
+  @Test
+  public void jacksonSerializationPreservesDualCiphertext() throws Exception {
+    byte[] seed = fixedSeed();
+    FNDSA512 original = new FNDSA512(seed);
     byte[] password = "testpassword123A".getBytes(StandardCharsets.UTF_8);
     WalletFile walletFile = Wallet.createStandardPQ(
         password, PQScheme.FN_DSA_512,
-        original.getPrivateKeyWithPublicKey(), original.getPublicKey());
+        original.getPrivateKeyWithPublicKey(), seed, original.getPublicKey());
 
     ObjectMapper mapper = new ObjectMapper();
     String json = mapper.writeValueAsString(walletFile);
-    assertTrue("JSON should contain scheme field: " + json,
-        json.contains("\"scheme\":\"FN_DSA_512\""));
+    assertTrue(json.contains("\"scheme\":\"FN_DSA_512\""));
+    assertTrue(json.contains("\"seedciphertext\""));
+    assertTrue(json.contains("\"seedmac\""));
 
     WalletFile reloaded = mapper.readValue(json, WalletFile.class);
     assertEquals("FN_DSA_512", reloaded.getScheme());
-    assertEquals(walletFile.getAddress(), reloaded.getAddress());
 
     FNDSA512 decrypted = Wallet.decryptPQ(password, reloaded);
     assertArrayEquals(original.getPublicKey(), decrypted.getPublicKey());
   }
 
   @Test
-  public void legacyWalletFileHasNoSchemeField() throws Exception {
-    // A WalletFile with no scheme (legacy ECKey/SM2) must not emit a scheme key.
+  public void legacyWalletFileHasNoSeedFields() throws Exception {
     WalletFile legacy = new WalletFile();
     legacy.setAddress("Tabcdefg");
     ObjectMapper mapper = new ObjectMapper();
     String json = mapper.writeValueAsString(legacy);
-    assertTrue("Legacy JSON should omit scheme: " + json, !json.contains("\"scheme\""));
+    assertFalse(json.contains("\"scheme\""));
+    assertFalse(json.contains("\"seedciphertext\""));
   }
 }

--- a/src/test/java/org/tron/keystore/WalletPQMlDsa44KeystoreTest.java
+++ b/src/test/java/org/tron/keystore/WalletPQMlDsa44KeystoreTest.java
@@ -1,0 +1,110 @@
+package org.tron.keystore;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import org.junit.Test;
+import org.tron.common.crypto.pqc.MLDSA44;
+import org.tron.common.crypto.pqc.PQSchemeRegistry;
+import org.tron.common.crypto.pqc.PQSignature;
+import org.tron.protos.Protocol.PQScheme;
+import org.tron.walletserver.WalletApi;
+
+public class WalletPQMlDsa44KeystoreTest {
+
+  private static byte[] fixedSeed() {
+    byte[] seed = new byte[MLDSA44.SEED_LENGTH];
+    for (int i = 0; i < seed.length; i++) {
+      seed[i] = (byte) (i + 11);
+    }
+    return seed;
+  }
+
+  @Test
+  public void encryptDecryptRoundtripDualCiphertext() throws Exception {
+    byte[] seed = fixedSeed();
+    MLDSA44 original = new MLDSA44(seed);
+    byte[] password = "testpassword123A".getBytes(StandardCharsets.UTF_8);
+
+    WalletFile walletFile = Wallet.createStandardPQ(
+        password, PQScheme.ML_DSA_44,
+        original.getPersistedPrivateKey(), seed, original.getPublicKey());
+
+    assertEquals("ML_DSA_44", walletFile.getScheme());
+    String expectedAddress = WalletApi.encode58Check(
+        PQSchemeRegistry.computeAddress(PQScheme.ML_DSA_44, original.getPublicKey()));
+    assertEquals(expectedAddress, walletFile.getAddress());
+
+    assertNotNull(walletFile.getCrypto().getCiphertext());
+    assertNotNull(walletFile.getCrypto().getSeedciphertext());
+
+    PQSignature decrypted = Wallet.decryptPQ(password, walletFile);
+    assertNotNull(decrypted);
+    assertEquals(PQScheme.ML_DSA_44, decrypted.getScheme());
+    assertArrayEquals(original.getPublicKey(), decrypted.getPublicKey());
+    assertArrayEquals(original.getPrivateKey(), decrypted.getPrivateKey());
+
+    byte[] msg = "ml-dsa-44-keystore-roundtrip".getBytes(StandardCharsets.UTF_8);
+    byte[] sig = decrypted.sign(msg);
+    assertTrue(MLDSA44.verify(original.getPublicKey(), msg, sig));
+  }
+
+  @Test
+  public void encryptDecryptRoundtripExtOnly() throws Exception {
+    MLDSA44 original = new MLDSA44(fixedSeed());
+    byte[] password = "testpassword123A".getBytes(StandardCharsets.UTF_8);
+
+    WalletFile walletFile = Wallet.createStandardPQ(
+        password, PQScheme.ML_DSA_44,
+        original.getPersistedPrivateKey(), null, original.getPublicKey());
+
+    assertNotNull(walletFile.getCrypto().getCiphertext());
+    assertNull(walletFile.getCrypto().getSeedciphertext());
+
+    PQSignature decrypted = Wallet.decryptPQ(password, walletFile);
+    assertArrayEquals(original.getPublicKey(), decrypted.getPublicKey());
+    assertArrayEquals(original.getPrivateKey(), decrypted.getPrivateKey());
+  }
+
+  @Test
+  public void encryptDecryptRoundtripSeedOnly() throws Exception {
+    byte[] seed = fixedSeed();
+    MLDSA44 original = new MLDSA44(seed);
+    byte[] password = "testpassword123A".getBytes(StandardCharsets.UTF_8);
+
+    WalletFile walletFile = Wallet.createStandardPQ(
+        password, PQScheme.ML_DSA_44,
+        null, seed, original.getPublicKey());
+
+    assertNull(walletFile.getCrypto().getCiphertext());
+    assertNotNull(walletFile.getCrypto().getSeedciphertext());
+
+    PQSignature decrypted = Wallet.decryptPQ(password, walletFile);
+    assertArrayEquals(original.getPublicKey(), decrypted.getPublicKey());
+  }
+
+  @Test
+  public void jacksonSerializationPreservesMlDsaScheme() throws Exception {
+    byte[] seed = fixedSeed();
+    MLDSA44 original = new MLDSA44(seed);
+    byte[] password = "testpassword123A".getBytes(StandardCharsets.UTF_8);
+    WalletFile walletFile = Wallet.createStandardPQ(
+        password, PQScheme.ML_DSA_44,
+        original.getPersistedPrivateKey(), seed, original.getPublicKey());
+
+    ObjectMapper mapper = new ObjectMapper();
+    String json = mapper.writeValueAsString(walletFile);
+    assertTrue(json.contains("\"scheme\":\"ML_DSA_44\""));
+
+    WalletFile reloaded = mapper.readValue(json, WalletFile.class);
+    assertEquals("ML_DSA_44", reloaded.getScheme());
+
+    PQSignature decrypted = Wallet.decryptPQ(password, reloaded);
+    assertArrayEquals(original.getPublicKey(), decrypted.getPublicKey());
+  }
+}

--- a/src/test/java/org/tron/keystore/WalletPQReEncryptTest.java
+++ b/src/test/java/org/tron/keystore/WalletPQReEncryptTest.java
@@ -1,0 +1,130 @@
+package org.tron.keystore;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.Test;
+import org.tron.common.crypto.pqc.FNDSA512;
+import org.tron.core.exception.CipherException;
+import org.tron.protos.Protocol.PQScheme;
+
+public class WalletPQReEncryptTest {
+
+  private static byte[] fixedSeed() {
+    byte[] seed = new byte[FNDSA512.SEED_LENGTH];
+    for (int i = 0; i < seed.length; i++) {
+      seed[i] = (byte) (i + 11);
+    }
+    return seed;
+  }
+
+  @Test
+  public void reEncryptPreservesSchemeAndBothSegments() throws Exception {
+    byte[] seed = fixedSeed();
+    FNDSA512 signer = new FNDSA512(seed);
+    byte[] oldPwd = "testpassword123A".getBytes(StandardCharsets.UTF_8);
+    byte[] newPwd = "rotatedPassword99B".getBytes(StandardCharsets.UTF_8);
+
+    WalletFile original = Wallet.createStandardPQ(
+        oldPwd, PQScheme.FN_DSA_512,
+        signer.getPersistedPrivateKey(), seed, signer.getPublicKey());
+    String originalId = original.getId();
+    String originalAddress = original.getAddress();
+    original.setName("pq-wallet-rotate");
+
+    WalletFile rotated = Wallet.reEncryptPQ(oldPwd, newPwd, original);
+
+    assertEquals("FN_DSA_512", rotated.getScheme());
+    assertEquals(originalId, rotated.getId());
+    assertEquals(originalAddress, rotated.getAddress());
+    assertEquals("pq-wallet-rotate", rotated.getName());
+    assertNotNull(rotated.getCrypto().getCiphertext());
+    assertNotNull(rotated.getCrypto().getSeedciphertext());
+    assertNotEquals(original.getCrypto().getCiphertext(),
+        rotated.getCrypto().getCiphertext());
+    assertNotEquals(original.getCrypto().getSeedciphertext(),
+        rotated.getCrypto().getSeedciphertext());
+
+    FNDSA512 decrypted = (FNDSA512) Wallet.decryptPQ(newPwd, rotated);
+    assertArrayEquals(signer.getPublicKey(), decrypted.getPublicKey());
+    assertArrayEquals(signer.getPrivateKey(), decrypted.getPrivateKey());
+
+    try {
+      Wallet.decryptPQ(oldPwd, rotated);
+      fail("Old password should no longer decrypt the rotated keystore");
+    } catch (CipherException e) {
+      assertEquals("Invalid password provided", e.getMessage());
+    }
+  }
+
+  @Test
+  public void reEncryptPreservesExtOnlyShape() throws Exception {
+    byte[] seed = fixedSeed();
+    FNDSA512 signer = new FNDSA512(seed);
+    byte[] oldPwd = "testpassword123A".getBytes(StandardCharsets.UTF_8);
+    byte[] newPwd = "rotatedPassword99B".getBytes(StandardCharsets.UTF_8);
+
+    WalletFile original = Wallet.createStandardPQ(
+        oldPwd, PQScheme.FN_DSA_512,
+        signer.getPersistedPrivateKey(), null, signer.getPublicKey());
+    assertNull(original.getCrypto().getSeedciphertext());
+
+    WalletFile rotated = Wallet.reEncryptPQ(oldPwd, newPwd, original);
+
+    assertEquals("FN_DSA_512", rotated.getScheme());
+    assertNotNull(rotated.getCrypto().getCiphertext());
+    assertNull("ext-only shape must survive rotation",
+        rotated.getCrypto().getSeedciphertext());
+
+    FNDSA512 decrypted = (FNDSA512) Wallet.decryptPQ(newPwd, rotated);
+    assertArrayEquals(signer.getPublicKey(), decrypted.getPublicKey());
+  }
+
+  @Test
+  public void reEncryptPreservesSeedOnlyShape() throws Exception {
+    byte[] seed = fixedSeed();
+    FNDSA512 signer = new FNDSA512(seed);
+    byte[] oldPwd = "testpassword123A".getBytes(StandardCharsets.UTF_8);
+    byte[] newPwd = "rotatedPassword99B".getBytes(StandardCharsets.UTF_8);
+
+    WalletFile original = Wallet.createStandardPQ(
+        oldPwd, PQScheme.FN_DSA_512,
+        null, seed, signer.getPublicKey());
+    assertNull(original.getCrypto().getCiphertext());
+
+    WalletFile rotated = Wallet.reEncryptPQ(oldPwd, newPwd, original);
+
+    assertEquals("FN_DSA_512", rotated.getScheme());
+    assertNull("seed-only shape must survive rotation",
+        rotated.getCrypto().getCiphertext());
+    assertNotNull(rotated.getCrypto().getSeedciphertext());
+
+    FNDSA512 decrypted = (FNDSA512) Wallet.decryptPQ(newPwd, rotated);
+    assertArrayEquals(signer.getPublicKey(), decrypted.getPublicKey());
+  }
+
+  @Test
+  public void reEncryptRejectsWrongOldPassword() throws Exception {
+    byte[] seed = fixedSeed();
+    FNDSA512 signer = new FNDSA512(seed);
+    byte[] oldPwd = "testpassword123A".getBytes(StandardCharsets.UTF_8);
+    byte[] wrongPwd = "wrongPassword456Z".getBytes(StandardCharsets.UTF_8);
+    byte[] newPwd = "rotatedPassword99B".getBytes(StandardCharsets.UTF_8);
+
+    WalletFile original = Wallet.createStandardPQ(
+        oldPwd, PQScheme.FN_DSA_512,
+        signer.getPersistedPrivateKey(), seed, signer.getPublicKey());
+
+    try {
+      Wallet.reEncryptPQ(wrongPwd, newPwd, original);
+      fail("Wrong old password must not allow rotation");
+    } catch (CipherException e) {
+      assertEquals("Invalid password provided", e.getMessage());
+    }
+  }
+}


### PR DESCRIPTION
**What does this PR do?**
Adds post-quantum signature support to wallet-cli, mirroring the protocol changes introduced by the `ALLOW_FN_DSA_512` and `ALLOW_ML_DSA_44` proposals in java-tron. Users can generate, store, import, and transact with PQ keypairs in either scheme.

Two PQ schemes are now supported:
- **Falcon-512 / FN-DSA-512** (FIPS-206 draft) — 48-byte seed, 896-byte public key, 2176-byte persisted private key (`f‖g‖F‖h`), ≤752-byte signature.
- **ML-DSA-44 / Dilithium-2** (FIPS-204) — 32-byte seed, 1312-byte public key, 2560-byte encoded private key (`rho‖K‖tr‖s1‖s2‖t0`), fixed 2420-byte signature.

Key changes:
- **Proto Sync**: Added `PQScheme` (with `FN_DSA_512`, `ML_DSA_44`), `PQAuthSig`, and `pq_auth_sig` fields on `Transaction`, `BlockHeader`, and `HelloMessage` (additive, backward-compatible).
- **Crypto Layer**: Added `FNDSA512`, `MLDSA44`, `PQSchemeRegistry`, and the `PQSignature` abstraction. Dispatch is per-wallet via `WalletFile.scheme`, not process-wide. Address derivation uses `0x41 || Keccak-256(pubkey)[12..32]` for both schemes.
- **Keystore (TIP-101 Extension)**: Implements the v5 dual-ciphertext specification for the post-quantum keystore.
  - `WalletFile.scheme` acts as a discriminator (`FN_DSA_512`, `ML_DSA_44`).
  - The keygen seed and the persisted private key (scheme-specific length) are encrypted independently within the same file.
  - `Wallet.createPQ` uses a single scrypt KDF run to generate `DK`, where `DK[0..16]` keys AES-CTR for both segments using independent IVs, and `DK[16..32]` generates independent Keccak-256 MACs.
  - `Wallet.decryptPQ` validates all present MACs before decryption and performs consistency checks.
- **PQ surface is scheme-generic**: `PQSchemeRegistry` is the single dispatch point; per-scheme seed/persisted-key lengths come from the registry and the `getPersistedPrivateKey()` default abstracts the on-disk encoding asymmetry between Falcon (must append `h`) and ML-DSA (private encoding is self-contained).
- **Commands**: Added `generatePQKey`, `registerWalletPQ`, and `importWalletPQ` to the REPL, and `generate-pq-key`, `register-wallet-pq`, and `import-wallet-pq` to the standard CLI. All three commands accept a `--scheme` / positional `scheme` argument (default `FN_DSA_512`).

**Why are these changes required?**
To provide a reference user-facing tool for interacting with the upcoming post-quantum signature features in TRON. Supporting both Falcon-512 and ML-DSA-44 from day one mirrors the dual-scheme rollout on the node side and lets users compare the two schemes for their own use cases. The dual-ciphertext keystore design ensures the wallet can securely store the (longer) persisted private key alongside the original seed, allowing full key recovery while preventing keystream reuse.

**This PR has been tested by:**
- Unit Tests: `FNDSA512Test`, `MLDSA44Test`, `PQSchemeRegistryTest` (covers dispatch for both schemes), `PQSignatureDefaultsTest`, `WalletPQAddressTest`, `WalletPQKeystoreTest`, `WalletPQMlDsa44KeystoreTest`. Coverage includes dual-ciphertext roundtrips, ext-only and seed-only paths, missing material, IV independence, segment-specific MAC tamper rejection, and signature-length validation.
- Manual Testing: REPL and standard CLI flows for PQ key generation, keystore encryption/decryption, and signing, exercised under both schemes.

**Follow up**
- PQ support for hardware wallets (Ledger) when available.
- Mnemonic derivation for PQ keys.

**Extra details**
- BouncyCastle has been bumped from 1.78.1 to 1.84 to access `org.bouncycastle.pqc.crypto.falcon.*` and `org.bouncycastle.pqc.crypto.crystals.dilithium.*`.