### PR TITLE
refactor(pqc): resolve Trident PQ TODOs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ dependencies {
     implementation group: 'org.hid4java', name: 'hid4java', version: '0.8.0'
     //implementation 'javax.annotation:javax.annotation-api:1.3.2'
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
-    implementation("com.github.federico2014:trident:0.11.pq1") {
+    implementation("com.github.tronprotocol:trident:post_quantum-SNAPSHOT") {
         exclude group: "com.google.guava", module: "guava"
     }
     implementation 'javax.annotation:javax.annotation-api:1.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ dependencies {
     implementation group: 'org.hid4java', name: 'hid4java', version: '0.8.0'
     //implementation 'javax.annotation:javax.annotation-api:1.3.2'
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
-    implementation("io.github.tronprotocol:trident:0.11.0") {
+    implementation("com.github.federico2014:trident:0.11.pq1") {
         exclude group: "com.google.guava", module: "guava"
     }
     implementation 'javax.annotation:javax.annotation-api:1.3.2'

--- a/src/main/java/org/tron/common/utils/TransactionUtils.java
+++ b/src/main/java/org/tron/common/utils/TransactionUtils.java
@@ -53,20 +53,8 @@ import org.tron.trident.proto.Chain;
 public class TransactionUtils {
   private static final ThreadLocal<Integer> PERMISSION_ID_OVERRIDE = new ThreadLocal<>();
 
-  // Protobuf field number of Transaction.pq_auth_sig (Tron.proto). The Trident
-  // SDK's Chain.Transaction does not define this field, so on those objects PQ
-  // auth signatures are preserved only as unknown field 6. Shared so the
-  // bandwidth estimate in WalletApi reads the same field number.
-  // TODO(trident-pq): once the Trident SDK models pq_auth_sig on
-  // Chain.Transaction, drop this constant and use the generated accessors.
-  public static final int PQ_AUTH_SIG_FIELD_NUMBER = 6;
-
-  /** True if the (possibly Trident-typed) transaction carries any PQ auth signature. */
-  // TODO(trident-pq): replace the unknown-field probe with
-  // transaction.getPqAuthSigCount() > 0 when Trident's Chain.Transaction
-  // exposes pq_auth_sig natively.
   private static boolean hasPqAuthSig(Chain.Transaction transaction) {
-    return transaction.getUnknownFields().hasField(PQ_AUTH_SIG_FIELD_NUMBER);
+    return transaction.getPqAuthSigCount() > 0;
   }
 
   /**
@@ -322,17 +310,8 @@ public class TransactionUtils {
     return transaction;
   }
 
-  // TODO(trident-pq): this Chain<->Protocol byte round-trip only exists because
-  // Trident's Chain.Transaction cannot carry pq_auth_sig. Drop the conversion
-  // and add the PQAuthSig directly once Trident models the field.
   public static Chain.Transaction signPQ(
-      Chain.Transaction transaction, PQSignature signer, PQScheme scheme)
-      throws InvalidProtocolBufferException {
-    return Chain.Transaction.parseFrom(
-        signPQ(Transaction.parseFrom(transaction.toByteArray()), signer, scheme).toByteArray());
-  }
-
-  public static Transaction signPQ(Transaction transaction, PQSignature signer, PQScheme scheme) {
+      Chain.Transaction transaction, PQSignature signer, PQScheme scheme) {
     if (!PQSchemeRegistry.contains(scheme)) {
       throw new IllegalArgumentException("Unsupported or unknown PQScheme: " + scheme);
     }
@@ -340,10 +319,15 @@ public class TransactionUtils {
       throw new IllegalArgumentException("Signer scheme " + signer.getScheme()
           + " does not match requested scheme " + scheme);
     }
+    Chain.PQScheme tridentScheme = Chain.PQScheme.forNumber(scheme.getNumber());
+    if (tridentScheme == null
+        || tridentScheme == Chain.PQScheme.UNKNOWN_PQ_SCHEME) {
+      throw new IllegalArgumentException("Unsupported or unknown Trident PQScheme: " + scheme);
+    }
     byte[] hash = Sha256Sm3Hash.hash(transaction.getRawData().toByteArray());
     byte[] sig = signer.sign(hash);
-    PQAuthSig pqSig = PQAuthSig.newBuilder()
-        .setScheme(scheme)
+    Chain.PQAuthSig pqSig = Chain.PQAuthSig.newBuilder()
+        .setScheme(tridentScheme)
         .setPublicKey(ByteString.copyFrom(signer.getPublicKey()))
         .setSignature(ByteString.copyFrom(sig))
         .build();
@@ -388,10 +372,6 @@ public class TransactionUtils {
     return transaction;
   }
 
-  // TODO(trident-pq): the Chain<->Protocol byte round-trip is only needed to
-  // preserve pq_auth_sig (and read getPqAuthSigCount() in the Protocol overload)
-  // because Trident's Chain.Transaction lacks the field. Simplify once Trident
-  // models pq_auth_sig.
   public static Chain.Transaction setPermissionId(Chain.Transaction transaction, String tipString)
       throws CancelException, InvalidProtocolBufferException {
     return Chain.Transaction.parseFrom(

--- a/src/main/java/org/tron/walletserver/ApiClient.java
+++ b/src/main/java/org/tron/walletserver/ApiClient.java
@@ -473,14 +473,21 @@ public class ApiClient {
    * @return max delegatable size
    */
   public long getCanDelegatedMaxSize(byte[] ownerAddress, int type, PQScheme pqScheme) {
-    int pqSchemeValue = pqScheme == null ? PQScheme.UNKNOWN_PQ_SCHEME_VALUE : pqScheme.getNumber();
+    Chain.PQScheme tridentPQScheme = toTridentPQScheme(pqScheme);
     if (!emptySolidityNode) {
       return client.getCanDelegatedMaxSize(encode58Check(ownerAddress), type,
-          pqSchemeValue, SOLIDITY_NODE);
+          tridentPQScheme, SOLIDITY_NODE);
     } else {
       return client.getCanDelegatedMaxSize(encode58Check(ownerAddress), type,
-          pqSchemeValue, FULL_NODE);
+          tridentPQScheme, FULL_NODE);
     }
+  }
+
+  private static Chain.PQScheme toTridentPQScheme(PQScheme pqScheme) {
+    if (pqScheme == null || pqScheme == PQScheme.UNKNOWN_PQ_SCHEME) {
+      return Chain.PQScheme.UNKNOWN_PQ_SCHEME;
+    }
+    return Chain.PQScheme.forNumber(pqScheme.getNumber());
   }
 
   public long getAvailableUnfreezeCount(byte[] ownerAddress) {// pass

--- a/src/main/java/org/tron/walletserver/ApiClient.java
+++ b/src/main/java/org/tron/walletserver/ApiClient.java
@@ -473,21 +473,14 @@ public class ApiClient {
    * @return max delegatable size
    */
   public long getCanDelegatedMaxSize(byte[] ownerAddress, int type, PQScheme pqScheme) {
-    // TODO(trident-sdk): Trident's ApiWrapper.getCanDelegatedMaxSize does not yet accept a
-    // PQScheme parameter. Once the Trident SDK is updated (add pq_scheme to its
-    // CanDelegatedMaxSizeRequestMessage proto and regenerate), pass pqScheme to the
-    // ApiWrapper call below. Until then, the scheme hint is silently ignored and the
-    // node returns the ECDSA-sized estimate (backward-compatible default).
-    //
-    // When the SDK is ready, replace this body with:
-    //   if (!emptySolidityNode) {
-    //     return client.getCanDelegatedMaxSize(encode58Check(ownerAddress), type,
-    //         pqScheme, SOLIDITY_NODE);
-    //   } else {
-    //     return client.getCanDelegatedMaxSize(encode58Check(ownerAddress), type,
-    //         pqScheme, FULL_NODE);
-    //   }
-    return getCanDelegatedMaxSize(ownerAddress, type);
+    int pqSchemeValue = pqScheme == null ? PQScheme.UNKNOWN_PQ_SCHEME_VALUE : pqScheme.getNumber();
+    if (!emptySolidityNode) {
+      return client.getCanDelegatedMaxSize(encode58Check(ownerAddress), type,
+          pqSchemeValue, SOLIDITY_NODE);
+    } else {
+      return client.getCanDelegatedMaxSize(encode58Check(ownerAddress), type,
+          pqSchemeValue, FULL_NODE);
+    }
   }
 
   public long getAvailableUnfreezeCount(byte[] ownerAddress) {// pass
@@ -636,6 +629,13 @@ public class ApiClient {
 
   public Response.TransactionExtention deployContract(String contractName, String abi, String code, List<Type<?>> constructorParams, long feeLimit, long consumeUserResourcePercent, long originEnergyLimit, long value, String tokenId, long tokenValue) throws Exception {// pass
     return client.deployContract(contractName, abi, code, constructorParams, feeLimit, consumeUserResourcePercent, originEnergyLimit, value, tokenId, tokenValue);
+  }
+
+  public Response.TransactionExtention deployContract(byte[] owner, String contractName, String abi,
+      String code, List<Type<?>> constructorParams, long feeLimit, long consumeUserResourcePercent,
+      long originEnergyLimit, long value, String tokenId, long tokenValue) throws Exception {
+    return client.deployContract(encode58Check(owner), contractName, abi, code, constructorParams,
+        feeLimit, consumeUserResourcePercent, originEnergyLimit, value, tokenId, tokenValue);
   }
 
   public Response.WitnessList getPaginatedNowWitnessList(int offset, int limit) {

--- a/src/main/java/org/tron/walletserver/WalletApi.java
+++ b/src/main/java/org/tron/walletserver/WalletApi.java
@@ -561,25 +561,6 @@ public class WalletApi {
     }
   }
 
-  // The Trident SDK ApiClient takes a hex string private key and assumes it is
-  // a 32-byte ECDSA secp256k1 / SM2 key. A PQ persisted private key (2176 or
-  // 2560 bytes) cannot be used there — silently passing it would produce
-  // invalid signatures or runtime errors deep inside Trident. Operations that
-  // must construct an ApiClient directly should call this before reading the
-  // key out of the keystore, mirroring the pre-flight check in
-  // {@code WalletApiWrapper.gasFreeTransferInternal}.
-  // TODO(trident-pq): this guard exists only because Trident's ApiClient-based
-  // signing path cannot attach pq_auth_sig. Once Trident supports PQ signing,
-  // route these operations through the PQ signing flow and remove the rejection.
-  private void rejectPQForEcdsaSigning(String operation) {
-    WalletFile wf = getWalletFile();
-    if (wf != null && wf.getScheme() != null && !wf.getScheme().isEmpty()) {
-      throw new UnsupportedOperationException(
-          operation + " is not supported for post-quantum wallets ("
-              + wf.getScheme() + "); requires an ECDSA wallet.");
-    }
-  }
-
   public byte[] getPrivateBytes(byte[] password) throws CipherException, IOException {
     return decrypt2PrivateBytes(password, loadWalletFile());
   }
@@ -2577,13 +2558,8 @@ public class WalletApi {
         System.out.println("delegateBalance must be greater than or equal to 1 TRX");
         return false;
       }
-      // TODO(pq-delegate): When delegating from a PQ wallet, the bandwidth consumed by the
-      // delegate transaction itself is larger (PQAuthSig vs ECDSA sig). Pass the active
-      // wallet's PQ scheme so the node reserves room for the larger signature — without it,
-      // the returned max may be too large and the subsequent delegate transaction could fail
-      // with insufficient bandwidth. Requires the Trident SDK to accept a PQScheme parameter
-      // in its getCanDelegatedMaxSize call (see TODO in ApiClient.java).
-      long canDelegatedMaxSize = apiCli.getCanDelegatedMaxSize(ownerAddress, resourceCode);
+      long canDelegatedMaxSize = apiCli.getCanDelegatedMaxSize(
+          ownerAddress, resourceCode, getWalletPQScheme(getWalletFile()));
       if (balance > canDelegatedMaxSize) {
         System.out.println("delegateBalance must be less than or equal to available FreezeV2 balance");
         return false;
@@ -3812,7 +3788,6 @@ public class WalletApi {
     if (!isUnlocked()) {
       throw new IllegalStateException(LOCK_WARNING);
     }
-    rejectPQForEcdsaSigning("DeployContract");
     if (owner == null) {
       owner = getAddress();
     }
@@ -3820,33 +3795,9 @@ public class WalletApi {
     if (null != libraryAddressPair) {
       code = Hex.toHexString(replaceLibraryAddress(code, libraryAddressPair, compilerVersion));
     }
-    ApiClient tmpApiCli;
-    NetType netType = getCurrentNetwork();
-    byte[] bytes = isUnifiedExist() ? getUnifiedPassword() : getPwdForDeploy();
-    byte[] rawKey = credentials == null ? decrypt2PrivateBytes(bytes, getWalletFile()) : credentials.getPair().getPrivateKey();
-    byte[] privateKeyBytes = Arrays.copyOf(rawKey, rawKey.length);
-    Arrays.fill(rawKey, (byte) 0);
-    // Trident SDK's ApiWrapper only accepts String for private key; immutable String cannot be
-    // zeroed from JVM heap. Byte arrays are cleared above; residual String risk is a platform
-    // limitation that requires upstream SDK changes to eliminate.
-    String privateKey = ByteArray.toHexString(privateKeyBytes);
-    Arrays.fill(privateKeyBytes, (byte) 0);
-    if (netType == CUSTOM) {
-      tmpApiCli = new ApiClient(customNodes.getLeft().getLeft(), customNodes.getRight().getLeft(),
-          customNodes.getLeft().getRight(), customNodes.getRight().getRight(), privateKey);
-    } else {
-      tmpApiCli = new ApiClient(netType, privateKey);
-    }
-    Response.TransactionExtention transactionExtention;
-    try {
-      // TODO: add PQ support — switch to the deployContract overload that takes an explicit
-      //  owner address.
-      transactionExtention = tmpApiCli.deployContract(contractName, ABI,
-          code, Collections.emptyList(), feeLimit, consumeUserResourcePercent, originEnergyLimit,
-          value, tokenId, tokenValue);
-    } finally {
-      tmpApiCli.close();
-    }
+    Response.TransactionExtention transactionExtention = apiCli.deployContract(owner, contractName,
+        ABI, code, Collections.emptyList(), feeLimit, consumeUserResourcePercent,
+        originEnergyLimit, value, tokenId, tokenValue);
     if (transactionExtention == null || !transactionExtention.getResult().getResult()) {
       System.out.println("RPC create trx " + failedHighlight() + "!");
       if (transactionExtention != null) {
@@ -3863,20 +3814,9 @@ public class WalletApi {
         .toBuilder();
     rawBuilder.setFeeLimit(feeLimit);
     transBuilder.setRawData(rawBuilder);
-    // Preserve unknown fields (notably pq_auth_sig / field 6, which Trident's
-    // Chain.Transaction does not model) so a PQ-carrying transaction is not
-    // silently stripped when rebuilt to inject the fee limit.
-    // TODO(trident-pq): once Trident models pq_auth_sig, copy it explicitly
-    // instead of relying on unknown-field preservation.
-    transBuilder.setUnknownFields(transactionExtention.getTransaction().getUnknownFields());
-    for (int i = 0; i < transactionExtention.getTransaction().getSignatureCount(); i++) {
-      ByteString s = transactionExtention.getTransaction().getSignature(i);
-      transBuilder.setSignature(i, s);
-    }
-    for (int i = 0; i < transactionExtention.getTransaction().getRetCount(); i++) {
-      Chain.Transaction.Result r = transactionExtention.getTransaction().getRet(i);
-      transBuilder.setRet(i, r);
-    }
+    transBuilder.addAllSignature(transactionExtention.getTransaction().getSignatureList());
+    transBuilder.addAllRet(transactionExtention.getTransaction().getRetList());
+    transBuilder.addAllPqAuthSig(transactionExtention.getTransaction().getPqAuthSigList());
     texBuilder.setTransaction(transBuilder);
     texBuilder.setResult(transactionExtention.getResult());
     texBuilder.setTxid(transactionExtention.getTxid());
@@ -3903,7 +3843,6 @@ public class WalletApi {
     if (!isUnlocked()) {
       throw new IllegalStateException(LOCK_WARNING);
     }
-    rejectPQForEcdsaSigning("DeployContract");
     if (owner == null) {
       owner = getAddress();
     }
@@ -3911,33 +3850,9 @@ public class WalletApi {
     if (null != libraryAddressPair) {
       code = Hex.toHexString(replaceLibraryAddress(code, libraryAddressPair, compilerVersion));
     }
-    ApiClient tmpApiCli;
-    NetType netType = getCurrentNetwork();
-    byte[] bytes = isUnifiedExist() ? getUnifiedPassword() : getPwdForDeploy();
-    byte[] rawKey = credentials == null
-        ? decrypt2PrivateBytes(bytes, getWalletFile())
-        : credentials.getPair().getPrivateKey();
-    byte[] privateKeyBytes = Arrays.copyOf(rawKey, rawKey.length);
-    Arrays.fill(rawKey, (byte) 0);
-    // Same Trident SDK limitation as deployContract above — see comment there.
-    String privateKey = ByteArray.toHexString(privateKeyBytes);
-    Arrays.fill(privateKeyBytes, (byte) 0);
-    if (netType == CUSTOM) {
-      tmpApiCli = new ApiClient(customNodes.getLeft().getLeft(), customNodes.getRight().getLeft(),
-          customNodes.getLeft().getRight(), customNodes.getRight().getRight(), privateKey);
-    } else {
-      tmpApiCli = new ApiClient(netType, privateKey);
-    }
-    Response.TransactionExtention transactionExtention;
-    try {
-      // TODO: add PQ support — switch to the deployContract overload that takes an explicit
-      //  owner address.
-      transactionExtention = tmpApiCli.deployContract(contractName, ABI,
-          code, Collections.emptyList(), feeLimit, consumeUserResourcePercent, originEnergyLimit,
-          value, tokenId, tokenValue);
-    } finally {
-      tmpApiCli.close();
-    }
+    Response.TransactionExtention transactionExtention = apiCli.deployContract(owner, contractName,
+        ABI, code, Collections.emptyList(), feeLimit, consumeUserResourcePercent,
+        originEnergyLimit, value, tokenId, tokenValue);
     if (transactionExtention == null || !transactionExtention.getResult().getResult()) {
       recordLastCliOperationError(extractTransactionReturnMessage(
           transactionExtention == null ? null : transactionExtention.getResult()));
@@ -3950,20 +3865,9 @@ public class WalletApi {
         .toBuilder();
     rawBuilder.setFeeLimit(feeLimit);
     transBuilder.setRawData(rawBuilder);
-    // Preserve unknown fields (notably pq_auth_sig / field 6, which Trident's
-    // Chain.Transaction does not model) so a PQ-carrying transaction is not
-    // silently stripped when rebuilt to inject the fee limit.
-    // TODO(trident-pq): once Trident models pq_auth_sig, copy it explicitly
-    // instead of relying on unknown-field preservation.
-    transBuilder.setUnknownFields(transactionExtention.getTransaction().getUnknownFields());
-    for (int i = 0; i < transactionExtention.getTransaction().getSignatureCount(); i++) {
-      ByteString s = transactionExtention.getTransaction().getSignature(i);
-      transBuilder.setSignature(i, s);
-    }
-    for (int i = 0; i < transactionExtention.getTransaction().getRetCount(); i++) {
-      Chain.Transaction.Result r = transactionExtention.getTransaction().getRet(i);
-      transBuilder.setRet(i, r);
-    }
+    transBuilder.addAllSignature(transactionExtention.getTransaction().getSignatureList());
+    transBuilder.addAllRet(transactionExtention.getTransaction().getRetList());
+    transBuilder.addAllPqAuthSig(transactionExtention.getTransaction().getPqAuthSigList());
     texBuilder.setTransaction(transBuilder);
     texBuilder.setResult(transactionExtention.getResult());
     texBuilder.setTxid(transactionExtention.getTxid());
@@ -4057,20 +3961,9 @@ public class WalletApi {
         .toBuilder();
     rawBuilder.setFeeLimit(feeLimit);
     transBuilder.setRawData(rawBuilder);
-    // Preserve unknown fields (notably pq_auth_sig / field 6, which Trident's
-    // Chain.Transaction does not model) so a PQ-carrying transaction is not
-    // silently stripped when rebuilt to inject the fee limit.
-    // TODO(trident-pq): once Trident models pq_auth_sig, copy it explicitly
-    // instead of relying on unknown-field preservation.
-    transBuilder.setUnknownFields(transactionExtention.getTransaction().getUnknownFields());
-    for (int i = 0; i < transactionExtention.getTransaction().getSignatureCount(); i++) {
-      ByteString s = transactionExtention.getTransaction().getSignature(i);
-      transBuilder.setSignature(i, s);
-    }
-    for (int i = 0; i < transactionExtention.getTransaction().getRetCount(); i++) {
-      Chain.Transaction.Result r = transactionExtention.getTransaction().getRet(i);
-      transBuilder.setRet(i, r);
-    }
+    transBuilder.addAllSignature(transactionExtention.getTransaction().getSignatureList());
+    transBuilder.addAllRet(transactionExtention.getTransaction().getRetList());
+    transBuilder.addAllPqAuthSig(transactionExtention.getTransaction().getPqAuthSigList());
     texBuilder.setTransaction(transBuilder);
     texBuilder.setResult(transactionExtention.getResult());
     texBuilder.setTxid(transactionExtention.getTxid());
@@ -4149,20 +4042,9 @@ public class WalletApi {
         .toBuilder();
     rawBuilder.setFeeLimit(feeLimit);
     transBuilder.setRawData(rawBuilder);
-    // Preserve unknown fields (notably pq_auth_sig / field 6, which Trident's
-    // Chain.Transaction does not model) so a PQ-carrying transaction is not
-    // silently stripped when rebuilt to inject the fee limit.
-    // TODO(trident-pq): once Trident models pq_auth_sig, copy it explicitly
-    // instead of relying on unknown-field preservation.
-    transBuilder.setUnknownFields(transactionExtention.getTransaction().getUnknownFields());
-    for (int i = 0; i < transactionExtention.getTransaction().getSignatureCount(); i++) {
-      ByteString s = transactionExtention.getTransaction().getSignature(i);
-      transBuilder.setSignature(i, s);
-    }
-    for (int i = 0; i < transactionExtention.getTransaction().getRetCount(); i++) {
-      Chain.Transaction.Result r = transactionExtention.getTransaction().getRet(i);
-      transBuilder.setRet(i, r);
-    }
+    transBuilder.addAllSignature(transactionExtention.getTransaction().getSignatureList());
+    transBuilder.addAllRet(transactionExtention.getTransaction().getRetList());
+    transBuilder.addAllPqAuthSig(transactionExtention.getTransaction().getPqAuthSigList());
     texBuilder.setTransaction(transBuilder);
     texBuilder.setResult(transactionExtention.getResult());
     texBuilder.setTxid(transactionExtention.getTxid());
@@ -4222,18 +4104,10 @@ public class WalletApi {
     final long SIGNATURE_PER_BANDWIDTH = 67;
     final long MAX_RESULT_SIZE_IN_TX = 64;
     long byteLength = (long) Math.ceil(hexString.length() / 2.0);
-    // PQ auth signatures are far larger than an ECDSA signature and do not count
-    // toward getSignatureCount(). Trident's Chain.Transaction does not define
-    // pq_auth_sig (field 6), so it is preserved as unknown field 6; add its
-    // serialized size so the estimate is not biased low for PQ transactions.
-    // TODO(trident-pq): once Trident models pq_auth_sig, sum the serialized
-    // sizes of getPqAuthSigList() instead of reading unknown field 6.
-    long pqAuthSigBytes = 0;
-    com.google.protobuf.UnknownFieldSet unknownFields = transaction.getUnknownFields();
-    if (unknownFields.hasField(TransactionUtils.PQ_AUTH_SIG_FIELD_NUMBER)) {
-      pqAuthSigBytes = unknownFields.getField(TransactionUtils.PQ_AUTH_SIG_FIELD_NUMBER)
-          .getSerializedSize(TransactionUtils.PQ_AUTH_SIG_FIELD_NUMBER);
-    }
+    long pqAuthSigBytes = transaction.getPqAuthSigList().stream()
+        .mapToLong(sig -> com.google.protobuf.CodedOutputStream.computeMessageSize(
+            Chain.Transaction.PQ_AUTH_SIG_FIELD_NUMBER, sig))
+        .sum();
     long bandwidthBuffer = DATA_HEX_PROTOBUF_EXTRA
         + SIGNATURE_PER_BANDWIDTH * (transaction.getSignatureCount() + 1)
         + pqAuthSigBytes


### PR DESCRIPTION
**What does this PR do?**

This PR removes the protobuf unknown-field workarounds for `pq_auth_sig` (field 6) now that the updated Trident SDK models it natively on `Chain.Transaction`. It replaces `Chain`↔`Protocol` byte round-trips with direct `Chain.Transaction` operations, adds a `toTridentPQScheme` helper for proper `PQScheme → Chain.PQScheme` conversion, and switches the Trident dependency to the upstream `tronprotocol/trident:post_quantum-SNAPSHOT`.

**Why are these changes required?**

The new Trident SDK exposes `getPqAuthSigCount()`, `getPqAuthSigList()`, and `Chain.PQAuthSig` natively — the field-6 `getUnknownFields()` probes and byte-codec round-trips are no longer needed. The dependency switch to `tronprotocol/trident` makes these protobuf accessors available, and the helper method provides a clean, null-safe mapping between the CLI's `PQScheme` and Trident's `Chain.PQScheme`. PQ wallets can now deploy contracts and sign through the normal flow without `rejectPQForEcdsaSigning` guards.

**This PR has been tested by:**

- Manual Testing

**Follow up**

**Extra details**
