### PR TITLE
fix(staking): network-aware, fail-open resource-code validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1245,7 +1245,7 @@ frozen_duration
 > frezen duration, 3 days
 
 ResourceCode
-> 0 BANDWIDTH;1 ENERGY
+> 0 BANDWIDTH;1 ENERGY;2 TRON_POWER (only when getAllowNewResourceModel is enabled)
 
 receiverAddress
 > target account address
@@ -1279,7 +1279,7 @@ frozen_balance
 > The amount of frozen, the unit is the smallest unit (Sun), the minimum is 1000000sun.
 
 ResourceCode
-> 0 BANDWIDTH;1 ENERGY
+> 0 BANDWIDTH;1 ENERGY;2 TRON_POWER (only when getAllowNewResourceModel is enabled)
 
 Example:
 ```console
@@ -1327,7 +1327,7 @@ unfreezeBalance
 > The amount of unfreeze, the unit is the smallest unit (Sun)
 
 ResourceCode
-> 0 BANDWIDTH;1 ENERGY
+> 0 BANDWIDTH;1 ENERGY;2 TRON_POWER (only when getAllowNewResourceModel is enabled)
 
 Example:
 ```console

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ After the freezing time expires, funds can be unfroze.
 **Unfreeze operation is as follows:**
 
 ```console
-> unfreezeBalance [OwnerAddress] ResourceCode(0 BANDWIDTH, 1 CPU) [receiverAddress]
+> unfreezeBalance [OwnerAddress] ResourceCode(0 BANDWIDTH, 1 ENERGY) [receiverAddress]
 ```
 
 ## How to vote
@@ -1245,14 +1245,14 @@ frozen_duration
 > frezen duration, 3 days
 
 ResourceCode
-> 0 BANDWIDTH;1 ENERGY;2 TRON_POWER (only when getAllowNewResourceModel is enabled)
+> 0 BANDWIDTH;1 ENERGY (TRON_POWER is not delegatable)
 
 receiverAddress
 > target account address
 
 ### unfreeze delegated resource
 
-    > unfreezeBalance [OwnerAddress] ResourceCode(0 BANDWIDTH, 1 CPU) [receiverAddress]
+    > unfreezeBalance [OwnerAddress] ResourceCode(0 BANDWIDTH, 1 ENERGY) [receiverAddress]
 
 The latter two parameters are optional. If they are not set, the BANDWIDTH resource is unfreeze
 by default; when the receiverAddress is set, the delegate resources are unfreezed.

--- a/docs/standard-cli-contract-spec.md
+++ b/docs/standard-cli-contract-spec.md
@@ -446,6 +446,12 @@ Examples:
 Command-specific validation that runs immediately after parsing may still surface as `usage_error` when the problem
 is malformed user input rather than runtime execution failure.
 
+Staking resource-code validation is **network-aware and fail-open**: for freeze/unfreeze commands the code `2`
+(TRON_POWER) is accepted only when the chain parameter `getAllowNewResourceModel` is enabled, and when that
+parameter cannot be fetched (offline/timeout) the client-side pre-check is skipped so the node's `validate()`
+remains the single source of truth at broadcast. Delegation commands reject `2` unconditionally (BANDWIDTH/ENERGY
+only), matching the node actuator.
+
 ### Rationale
 
 This contract prevents malformed input such as `--contract --method balanceOf(address)` from being treated as

--- a/docs/standard-cli-user-manual.md
+++ b/docs/standard-cli-user-manual.md
@@ -130,6 +130,7 @@ TRON uses two resources to process transactions:
 You obtain these resources by **staking (freezing) TRX**. Resource type codes:
 - `0` = Bandwidth
 - `1` = Energy
+- `2` = TRON_POWER -- accepted by freeze/unfreeze only when the network enables `getAllowNewResourceModel`; not delegatable
 
 ---
 
@@ -748,7 +749,7 @@ Freeze TRX to obtain bandwidth or energy using **Stake 2.0** (the current stakin
 | Option | Required | Type | Description |
 |--------|----------|------|-------------|
 | `--amount` | Yes | number | Amount to freeze in SUN |
-| `--resource` | No | number | Resource type: `0` = Bandwidth, `1` = Energy (default: `0`) |
+| `--resource` | No | number | Resource type: `0` = Bandwidth, `1` = Energy, `2` = TRON_POWER (only when getAllowNewResourceModel enabled; default: `0`) |
 | `--owner` | No | address | Owner address |
 | `--permission-id` | No | number | Permission ID for multi-sig signing (default: 0) |
 | `--multi` | No | boolean | Multi-signature mode |
@@ -775,7 +776,7 @@ Unfreeze previously frozen TRX under **Stake 2.0**. Unfrozen TRX enters a waitin
 | Option | Required | Type | Description |
 |--------|----------|------|-------------|
 | `--amount` | Yes | number | Amount to unfreeze in SUN |
-| `--resource` | No | number | Resource type: `0` = Bandwidth, `1` = Energy (default: `0`) |
+| `--resource` | No | number | Resource type: `0` = Bandwidth, `1` = Energy, `2` = TRON_POWER (only when getAllowNewResourceModel enabled; default: `0`) |
 | `--owner` | No | address | Owner address |
 | `--permission-id` | No | number | Permission ID for multi-sig signing (default: 0) |
 | `--multi` | No | boolean | Multi-signature mode |
@@ -922,7 +923,7 @@ Freeze TRX using the legacy Stake 1.0 system. **Use `freeze-balance-v2` instead.
 |--------|----------|------|-------------|
 | `--amount` | Yes | number | Amount to freeze in SUN |
 | `--duration` | Yes | number | Freeze duration in days |
-| `--resource` | No | number | Resource type: `0` = Bandwidth, `1` = Energy (default: `0`) |
+| `--resource` | No | number | Resource type: `0` = Bandwidth, `1` = Energy, `2` = TRON_POWER (only when getAllowNewResourceModel enabled; default: `0`) |
 | `--receiver` | No | address | Delegate the frozen resources to this address |
 | `--owner` | No | address | Owner address |
 | `--multi` | No | boolean | Multi-signature mode |
@@ -944,7 +945,7 @@ Unfreeze TRX under the legacy Stake 1.0 system. **Use `unfreeze-balance-v2` inst
 
 | Option | Required | Type | Description |
 |--------|----------|------|-------------|
-| `--resource` | No | number | Resource type: `0` = Bandwidth, `1` = Energy (default: `0`) |
+| `--resource` | No | number | Resource type: `0` = Bandwidth, `1` = Energy, `2` = TRON_POWER (only when getAllowNewResourceModel enabled; default: `0`) |
 | `--receiver` | No | address | Receiver address (if resources were delegated) |
 | `--owner` | No | address | Owner address |
 | `--multi` | No | boolean | Multi-signature mode |
@@ -2749,6 +2750,7 @@ Common error codes:
 |------|----------|---------|
 | `0` | Bandwidth | All transactions (data transfer) |
 | `1` | Energy | Smart contract calls |
+| `2` | TRON_POWER | freeze/unfreeze only, when `getAllowNewResourceModel` is enabled (not delegatable) |
 
 ### C. Network Endpoints
 

--- a/src/main/java/org/tron/walletcli/Client.java
+++ b/src/main/java/org/tron/walletcli/Client.java
@@ -1644,7 +1644,8 @@ public class Client {
       receiverAddress = WalletApi.decodeFromBase58Check(parameters[index]);
     }
 
-    if (!checkStakingResource(resourceCode, true)) {
+    // v1 freeze with a receiver is a delegated freeze; TRON_POWER is not delegatable.
+    if (!checkStakingResource(resourceCode, receiverAddress == null)) {
       return;
     }
     boolean result = walletApiWrapper.freezeBalance(ownerAddress, frozen_balance,
@@ -1735,7 +1736,8 @@ public class Client {
       receiverAddress = WalletApi.decodeFromBase58Check(parameters[index++]);
     }
 
-    if (!checkStakingResource(resourceCode, true)) {
+    // v1 unfreeze with a receiver targets a delegated freeze; TRON_POWER is not delegatable.
+    if (!checkStakingResource(resourceCode, receiverAddress == null)) {
       return;
     }
     boolean result = walletApiWrapper.unfreezeBalance(ownerAddress, resourceCode, receiverAddress, multi);

--- a/src/main/java/org/tron/walletcli/Client.java
+++ b/src/main/java/org/tron/walletcli/Client.java
@@ -1582,6 +1582,32 @@ public class Client {
     return ownerAddress;
   }
 
+  // Network-aware staking resource guard (issue #939). Returns false (and prints guidance) when
+  // the code should be rejected. freezeContext=true for freeze/unfreeze (2=TRON_POWER allowed only
+  // when getAllowNewResourceModel is on); false for delegate/undelegate (never delegatable).
+  // Fail-open: when the chain parameter can't be fetched, allow 2 and let the node validate.
+  private boolean checkStakingResource(int resourceCode, boolean freezeContext) {
+    if (resourceCode == 0 || resourceCode == 1) {
+      return true;
+    }
+    if (resourceCode != 2 || !freezeContext) {
+      System.out.println("Invalid ResourceCode: " + resourceCode + ". Use 0 (BANDWIDTH), 1 (ENERGY)"
+          + (freezeContext ? ", or 2 (TRON_POWER, only when getAllowNewResourceModel is enabled)." : "."));
+      return false;
+    }
+    Boolean enabled = walletApiWrapper.isNewResourceModelEnabled();
+    if (Boolean.FALSE.equals(enabled)) {
+      System.out.println("ResourceCode 2 (TRON_POWER) is not enabled on this network "
+          + "(getAllowNewResourceModel is off).");
+      return false;
+    }
+    if (enabled == null) {
+      System.out.println("[WARNING] Could not verify getAllowNewResourceModel; proceeding with "
+          + "TRON_POWER — the node validates at broadcast.");
+    }
+    return true;
+  }
+
   private void freezeBalance(String[] parameters)
       throws IOException, CipherException, CancelException, IllegalException {
     boolean multi = isMulti(parameters);
@@ -1618,6 +1644,9 @@ public class Client {
       receiverAddress = WalletApi.decodeFromBase58Check(parameters[index]);
     }
 
+    if (!checkStakingResource(resourceCode, true)) {
+      return;
+    }
     boolean result = walletApiWrapper.freezeBalance(ownerAddress, frozen_balance,
         frozen_duration, resourceCode, receiverAddress, multi);
     if (result) {
@@ -1659,6 +1688,9 @@ public class Client {
       }
     }
 
+    if (!checkStakingResource(resourceCode, true)) {
+      return;
+    }
     boolean result = walletApiWrapper.freezeBalanceV2(ownerAddress, frozen_balance
         , resourceCode, multi);
     if (multi) {
@@ -1703,6 +1735,9 @@ public class Client {
       receiverAddress = WalletApi.decodeFromBase58Check(parameters[index++]);
     }
 
+    if (!checkStakingResource(resourceCode, true)) {
+      return;
+    }
     boolean result = walletApiWrapper.unfreezeBalance(ownerAddress, resourceCode, receiverAddress, multi);
     if (result) {
       System.out.println("UnfreezeBalance " + successfulHighlight() + " !!!");
@@ -1741,6 +1776,9 @@ public class Client {
       }
     }
 
+    if (!checkStakingResource(resourceCode, true)) {
+      return;
+    }
     boolean result = walletApiWrapper.unfreezeBalanceV2(ownerAddress, unfreezeBalance, resourceCode, multi);
     if (multi) {
       createMultiSignResult(result);
@@ -1834,6 +1872,9 @@ public class Client {
       }
     }
 
+    if (!checkStakingResource(resourceCode, false)) {
+      return;
+    }
     boolean result = walletApiWrapper.delegateresource(
         ownerAddress, balance, resourceCode, receiverAddress, lock, lockPeriod, multi);
     if (multi) {
@@ -1886,6 +1927,9 @@ public class Client {
         System.out.println("unDelegateResource ownerAddress is invalid");
         return;
       }
+    }
+    if (!checkStakingResource(resourceCode, false)) {
+      return;
     }
     boolean result = walletApiWrapper.undelegateresource(ownerAddress, balance, resourceCode, receiverAddress, multi);
     if (multi) {

--- a/src/main/java/org/tron/walletcli/WalletApiWrapper.java
+++ b/src/main/java/org/tron/walletcli/WalletApiWrapper.java
@@ -1923,6 +1923,19 @@ public class WalletApiWrapper {
     }
   }
 
+  /** TRUE = new resource model active, FALSE = off, null = couldn't determine (fail-open). */
+  public Boolean isNewResourceModelEnabled() {
+    Response.ChainParameters params = getChainParameters();
+    if (params == null) {
+      return null; // node unreachable / timeout → fail-open
+    }
+    return params.getChainParameterList().stream()
+        .filter(p -> "getAllowNewResourceModel".equals(p.getKey()))
+        .map(p -> p.getValue() == 1)
+        .findFirst()
+        .orElse(null); // key absent → unknown → fail-open
+  }
+
 
   public boolean approveProposal(byte[] ownerAddress, long id, boolean is_add_approval, boolean multi)
       throws CipherException, IOException, CancelException, IllegalException {

--- a/src/main/java/org/tron/walletcli/cli/commands/CommandSupport.java
+++ b/src/main/java/org/tron/walletcli/cli/commands/CommandSupport.java
@@ -1,5 +1,6 @@
 package org.tron.walletcli.cli.commands;
 
+import org.tron.walletcli.WalletApiWrapper;
 import org.tron.walletcli.cli.OutputFormatter;
 
 import java.util.LinkedHashMap;
@@ -84,6 +85,36 @@ final class CommandSupport {
         if (value != 0 && value != 1) {
             out.usageError(name + " must be 0 (BANDWIDTH) or 1 (ENERGY), got: " + value, null);
         }
+    }
+
+    // Network-aware staking resource guard (issue #939). freezeContext=true for
+    // freeze/unfreeze (2=TRON_POWER allowed only when getAllowNewResourceModel is on);
+    // false for delegate/undelegate (TRON_POWER is never delegatable). Fail-open: when the
+    // chain parameter can't be fetched, allow 2 and let the node validate at broadcast.
+    static void requireStakingResource(OutputFormatter out, WalletApiWrapper wrapper,
+                                       String name, int value, boolean freezeContext) {
+        if (value == 0 || value == 1) {
+            return; // common case: no chain-parameter RPC
+        }
+        if (value != 2) {
+            out.usageError(name + " must be 0 (BANDWIDTH), 1 (ENERGY)"
+                    + (freezeContext ? ", or 2 (TRON_POWER)" : "") + ", got: " + value, null);
+            return;
+        }
+        if (!freezeContext) {
+            out.usageError(name + " for delegation must be 0 (BANDWIDTH) or 1 (ENERGY); "
+                    + "TRON_POWER (2) is not delegatable, got: " + value, null);
+            return;
+        }
+        Boolean enabled = wrapper.isNewResourceModelEnabled(); // only reached when value == 2
+        if (Boolean.FALSE.equals(enabled)) {
+            out.usageError(name + " = 2 (TRON_POWER) is not enabled on this network "
+                    + "(getAllowNewResourceModel is off)", null);
+        } else if (enabled == null) {
+            out.info("[WARNING] Could not verify getAllowNewResourceModel (node unreachable); "
+                    + "proceeding with resource=2 (TRON_POWER) — the node validates at broadcast.");
+        }
+        // TRUE or null (fail-open) → allow
     }
 
     static void requireForce(OutputFormatter out, String commandName, boolean force) {

--- a/src/main/java/org/tron/walletcli/cli/commands/StakingCommands.java
+++ b/src/main/java/org/tron/walletcli/cli/commands/StakingCommands.java
@@ -28,7 +28,7 @@ public class StakingCommands {
                 .description("Freeze TRX for bandwidth/energy (v1, deprecated)")
                 .option("amount", "Amount to freeze in SUN", true, OptionDef.Type.LONG)
                 .option("duration", "Freeze duration in days", true, OptionDef.Type.LONG)
-                .option("resource", "Resource type (0=BANDWIDTH, 1=ENERGY)", false, OptionDef.Type.LONG)
+                .option("resource", "Resource type (0=BANDWIDTH, 1=ENERGY, 2=TRON_POWER when getAllowNewResourceModel enabled)", false, OptionDef.Type.LONG)
                 .option("receiver", "Receiver address (for delegated freeze)", false)
                 .option("owner", "Owner address", false)
                 .option("multi", "Multi-signature mode", false, OptionDef.Type.BOOLEAN)
@@ -40,7 +40,7 @@ public class StakingCommands {
                     long duration = opts.getLong("duration");
                     CommandSupport.requirePositive(out, "duration", duration);
                     int resource = opts.has("resource") ? opts.getInt("resource") : 0;
-                    CommandSupport.requireResourceCode(out, "resource", resource);
+                    CommandSupport.requireStakingResource(out, wrapper, "resource", resource, true);
                     byte[] receiver = opts.has("receiver") ? opts.getAccountAddress("receiver") : null;
                     boolean multi = opts.getBoolean("multi");
                     String txid = wrapper.freezeBalanceForCli(owner, amount, duration, resource, receiver, multi);
@@ -58,7 +58,7 @@ public class StakingCommands {
                 .aliases("freezebalancev2")
                 .description("Freeze TRX for bandwidth/energy (Stake 2.0)")
                 .option("amount", "Amount to freeze in SUN", true, OptionDef.Type.LONG)
-                .option("resource", "Resource type (0=BANDWIDTH, 1=ENERGY)", false, OptionDef.Type.LONG)
+                .option("resource", "Resource type (0=BANDWIDTH, 1=ENERGY, 2=TRON_POWER when getAllowNewResourceModel enabled)", false, OptionDef.Type.LONG)
                 .option("owner", "Owner address", false)
                 .option("permission-id", "Permission ID for signing (default: 0)", false, OptionDef.Type.LONG)
                 .option("multi", "Multi-signature mode", false, OptionDef.Type.BOOLEAN)
@@ -68,7 +68,7 @@ public class StakingCommands {
                     long amount = opts.getLong("amount");
                     CommandSupport.requirePositive(out, "amount", amount);
                     int resource = opts.has("resource") ? opts.getInt("resource") : 0;
-                    CommandSupport.requireResourceCode(out, "resource", resource);
+                    CommandSupport.requireStakingResource(out, wrapper, "resource", resource, true);
                     int permissionId = opts.has("permission-id") ? opts.getInt("permission-id") : 0;
                     CommandSupport.requirePermissionId(out, "permission-id", permissionId);
                     boolean multi = opts.getBoolean("multi");
@@ -92,7 +92,7 @@ public class StakingCommands {
                 .name("unfreeze-balance")
                 .aliases("unfreezebalance")
                 .description("Unfreeze TRX (v1, deprecated)")
-                .option("resource", "Resource type (0=BANDWIDTH, 1=ENERGY)", false, OptionDef.Type.LONG)
+                .option("resource", "Resource type (0=BANDWIDTH, 1=ENERGY, 2=TRON_POWER when getAllowNewResourceModel enabled)", false, OptionDef.Type.LONG)
                 .option("receiver", "Receiver address", false)
                 .option("owner", "Owner address", false)
                 .option("multi", "Multi-signature mode", false, OptionDef.Type.BOOLEAN)
@@ -100,7 +100,7 @@ public class StakingCommands {
 
                     byte[] owner = opts.has("owner") ? opts.getAccountAddress("owner") : null;
                     int resource = opts.has("resource") ? opts.getInt("resource") : 0;
-                    CommandSupport.requireResourceCode(out, "resource", resource);
+                    CommandSupport.requireStakingResource(out, wrapper, "resource", resource, true);
                     byte[] receiver = opts.has("receiver") ? opts.getAccountAddress("receiver") : null;
                     boolean multi = opts.getBoolean("multi");
                     String txid = wrapper.unfreezeBalanceForCli(owner, resource, receiver, multi);
@@ -118,7 +118,7 @@ public class StakingCommands {
                 .aliases("unfreezebalancev2")
                 .description("Unfreeze TRX (Stake 2.0)")
                 .option("amount", "Amount to unfreeze in SUN", true, OptionDef.Type.LONG)
-                .option("resource", "Resource type (0=BANDWIDTH, 1=ENERGY)", false, OptionDef.Type.LONG)
+                .option("resource", "Resource type (0=BANDWIDTH, 1=ENERGY, 2=TRON_POWER when getAllowNewResourceModel enabled)", false, OptionDef.Type.LONG)
                 .option("owner", "Owner address", false)
                 .option("permission-id", "Permission ID for signing (default: 0)", false, OptionDef.Type.LONG)
                 .option("multi", "Multi-signature mode", false, OptionDef.Type.BOOLEAN)
@@ -128,7 +128,7 @@ public class StakingCommands {
                     long amount = opts.getLong("amount");
                     CommandSupport.requirePositive(out, "amount", amount);
                     int resource = opts.has("resource") ? opts.getInt("resource") : 0;
-                    CommandSupport.requireResourceCode(out, "resource", resource);
+                    CommandSupport.requireStakingResource(out, wrapper, "resource", resource, true);
                     int permissionId = opts.has("permission-id") ? opts.getInt("permission-id") : 0;
                     CommandSupport.requirePermissionId(out, "permission-id", permissionId);
                     boolean multi = opts.getBoolean("multi");
@@ -185,7 +185,7 @@ public class StakingCommands {
                     long amount = opts.getLong("amount");
                     CommandSupport.requirePositive(out, "amount", amount);
                     int resource = opts.getInt("resource");
-                    CommandSupport.requireResourceCode(out, "resource", resource);
+                    CommandSupport.requireStakingResource(out, wrapper, "resource", resource, false);
                     byte[] receiver = opts.getAccountAddress("receiver");
                     boolean lock = opts.getBoolean("lock");
                     long lockPeriod = opts.has("lock-period") ? opts.getLong("lock-period") : 0;
@@ -217,7 +217,7 @@ public class StakingCommands {
                     long amount = opts.getLong("amount");
                     CommandSupport.requirePositive(out, "amount", amount);
                     int resource = opts.getInt("resource");
-                    CommandSupport.requireResourceCode(out, "resource", resource);
+                    CommandSupport.requireStakingResource(out, wrapper, "resource", resource, false);
                     byte[] receiver = opts.getAccountAddress("receiver");
                     boolean multi = opts.getBoolean("multi");
                     String txid = wrapper.undelegateResourceForCli(owner, amount, resource, receiver, multi);

--- a/src/main/java/org/tron/walletcli/cli/commands/StakingCommands.java
+++ b/src/main/java/org/tron/walletcli/cli/commands/StakingCommands.java
@@ -40,8 +40,9 @@ public class StakingCommands {
                     long duration = opts.getLong("duration");
                     CommandSupport.requirePositive(out, "duration", duration);
                     int resource = opts.has("resource") ? opts.getInt("resource") : 0;
-                    CommandSupport.requireStakingResource(out, wrapper, "resource", resource, true);
                     byte[] receiver = opts.has("receiver") ? opts.getAccountAddress("receiver") : null;
+                    // v1 freeze with a receiver is a delegated freeze; TRON_POWER is not delegatable.
+                    CommandSupport.requireStakingResource(out, wrapper, "resource", resource, receiver == null);
                     boolean multi = opts.getBoolean("multi");
                     String txid = wrapper.freezeBalanceForCli(owner, amount, duration, resource, receiver, multi);
                     CommandSupport.emitSuccess(out,
@@ -100,8 +101,9 @@ public class StakingCommands {
 
                     byte[] owner = opts.has("owner") ? opts.getAccountAddress("owner") : null;
                     int resource = opts.has("resource") ? opts.getInt("resource") : 0;
-                    CommandSupport.requireStakingResource(out, wrapper, "resource", resource, true);
                     byte[] receiver = opts.has("receiver") ? opts.getAccountAddress("receiver") : null;
+                    // v1 unfreeze with a receiver targets a delegated freeze; TRON_POWER is not delegatable.
+                    CommandSupport.requireStakingResource(out, wrapper, "resource", resource, receiver == null);
                     boolean multi = opts.getBoolean("multi");
                     String txid = wrapper.unfreezeBalanceForCli(owner, resource, receiver, multi);
                     CommandSupport.emitSuccess(out,

--- a/src/test/java/org/tron/walletcli/cli/commands/StakingResourceGuardTest.java
+++ b/src/test/java/org/tron/walletcli/cli/commands/StakingResourceGuardTest.java
@@ -1,0 +1,162 @@
+package org.tron.walletcli.cli.commands;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.Assert;
+import org.junit.Test;
+import org.tron.common.enums.NetType;
+import org.tron.walletcli.WalletApiWrapper;
+import org.tron.walletcli.cli.CommandContext;
+import org.tron.walletcli.cli.CommandDefinition;
+import org.tron.walletcli.cli.CommandRegistry;
+import org.tron.walletcli.cli.OutputFormatter;
+import org.tron.walletcli.cli.ParsedOptions;
+import org.tron.walletserver.WalletApi;
+
+/**
+ * Network-aware, fail-open resource-code guard for staking commands (issue #939).
+ *
+ * Covers the tri-state getAllowNewResourceModel behavior (enabled / disabled / unknown fail-open),
+ * unconditional TRON_POWER rejection for delegation, and the receiver-aware v1 semantics: a v1
+ * freeze/unfreeze with a receiver is a delegated freeze, where TRON_POWER is not delegatable.
+ */
+public class StakingResourceGuardTest {
+
+  private static final String RECEIVER = "TNPeeaaFB7K9cmo4uQpcU32zGK8G1NYqeL";
+
+  /** Stub wrapper: fixed getAllowNewResourceModel state; records whether a broadcast was attempted. */
+  private static class GuardStubWrapper extends WalletApiWrapper {
+    private final Boolean modelEnabled;
+    boolean broadcastCalled = false;
+
+    GuardStubWrapper(Boolean modelEnabled) {
+      this.modelEnabled = modelEnabled;
+    }
+
+    @Override
+    public Boolean isNewResourceModelEnabled() {
+      return modelEnabled;
+    }
+
+    @Override
+    public String freezeBalanceForCli(byte[] ownerAddress, long frozenBalance, long frozenDuration,
+        int resourceCode, byte[] receiverAddress, boolean multi) {
+      broadcastCalled = true;
+      return "faketxid";
+    }
+
+    @Override
+    public String unfreezeBalanceForCli(byte[] ownerAddress, int resourceCode, byte[] receiverAddress,
+        boolean multi) {
+      broadcastCalled = true;
+      return "faketxid";
+    }
+
+    @Override
+    public String delegateResourceForCli(byte[] ownerAddress, long balance, int resourceCode,
+        byte[] receiverAddress, boolean lock, long lockPeriod, boolean multi) {
+      broadcastCalled = true;
+      return "faketxid";
+    }
+  }
+
+  private static class Result {
+    final JsonObject json;
+    final boolean broadcastCalled;
+
+    Result(JsonObject json, boolean broadcastCalled) {
+      this.json = json;
+      this.broadcastCalled = broadcastCalled;
+    }
+  }
+
+  private Result run(GuardStubWrapper wrapper, String commandName, String... args) throws Exception {
+    NetType originalNetwork = WalletApi.getCurrentNetwork();
+    PrintStream originalOut = System.out;
+    ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+    WalletApi.setCurrentNetwork(NetType.NILE);
+    System.setOut(new PrintStream(stdout));
+    try {
+      CommandRegistry registry = new CommandRegistry();
+      StakingCommands.register(registry);
+      CommandDefinition command = registry.lookup(commandName);
+      ParsedOptions opts = command.parseArgs(args);
+      OutputFormatter formatter = new OutputFormatter(OutputFormatter.OutputMode.JSON, false);
+      try {
+        command.getHandler().execute(CommandContext.empty(), opts, wrapper, formatter);
+      } catch (RuntimeException ignored) {
+        // usageError()/error() throw CliAbortException after recording the outcome
+      }
+      formatter.flush();
+      String json = stdout.toString(StandardCharsets.UTF_8.name());
+      return new Result(JsonParser.parseString(json).getAsJsonObject(), wrapper.broadcastCalled);
+    } finally {
+      WalletApi.setCurrentNetwork(originalNetwork);
+      System.setOut(originalOut);
+    }
+  }
+
+  private void assertUsageError(Result r, String messageFragment) {
+    Assert.assertFalse("expected failure", r.json.get("success").getAsBoolean());
+    Assert.assertEquals("usage_error", r.json.get("error").getAsString());
+    Assert.assertTrue("message should contain: " + messageFragment,
+        r.json.get("message").getAsString().contains(messageFragment));
+    Assert.assertFalse("must not broadcast when rejected", r.broadcastCalled);
+  }
+
+  private void assertProceeded(Result r) {
+    Assert.assertTrue("expected success", r.json.get("success").getAsBoolean());
+    Assert.assertTrue("should reach broadcast", r.broadcastCalled);
+  }
+
+  // --- tri-state getAllowNewResourceModel for a self-freeze (no receiver) ---
+
+  @Test
+  public void freezeBalanceAllowsTronPowerWhenModelEnabled() throws Exception {
+    Result r = run(new GuardStubWrapper(Boolean.TRUE), "freeze-balance",
+        "--amount", "1000000", "--duration", "3", "--resource", "2");
+    assertProceeded(r);
+  }
+
+  @Test
+  public void freezeBalanceRejectsTronPowerWhenModelDisabled() throws Exception {
+    Result r = run(new GuardStubWrapper(Boolean.FALSE), "freeze-balance",
+        "--amount", "1000000", "--duration", "3", "--resource", "2");
+    assertUsageError(r, "not enabled on this network");
+  }
+
+  @Test
+  public void freezeBalanceAllowsTronPowerFailOpenWhenModelUnknown() throws Exception {
+    Result r = run(new GuardStubWrapper(null), "freeze-balance",
+        "--amount", "1000000", "--duration", "3", "--resource", "2");
+    assertProceeded(r);
+  }
+
+  // --- receiver-aware v1 semantics: freeze/unfreeze with a receiver is a delegation ---
+
+  @Test
+  public void freezeBalanceWithReceiverRejectsTronPowerEvenWhenModelEnabled() throws Exception {
+    Result r = run(new GuardStubWrapper(Boolean.TRUE), "freeze-balance",
+        "--amount", "1000000", "--duration", "3", "--resource", "2", "--receiver", RECEIVER);
+    assertUsageError(r, "not delegatable");
+  }
+
+  @Test
+  public void unfreezeBalanceWithReceiverRejectsTronPowerEvenWhenModelEnabled() throws Exception {
+    Result r = run(new GuardStubWrapper(Boolean.TRUE), "unfreeze-balance",
+        "--resource", "2", "--receiver", RECEIVER);
+    assertUsageError(r, "not delegatable");
+  }
+
+  // --- delegation always rejects TRON_POWER, regardless of the chain parameter ---
+
+  @Test
+  public void delegateResourceRejectsTronPowerEvenWhenModelEnabled() throws Exception {
+    Result r = run(new GuardStubWrapper(Boolean.TRUE), "delegate-resource",
+        "--amount", "1000000", "--resource", "2", "--receiver", RECEIVER);
+    assertUsageError(r, "not delegatable");
+  }
+}


### PR DESCRIPTION
Align resource-code handling across REPL and standard CLI with the node's actuator behavior, per the discussion in https://github.com/tronprotocol/wallet-cli/issues/939:

- freeze/unfreeze accept 2 (TRON_POWER) only when the chain parameter getAllowNewResourceModel is enabled; delegate/undelegate reject 2 unconditionally (BANDWIDTH/ENERGY only).
- Fail-open: when chain params can't be fetched (offline/timeout), skip the client-side pre-check and defer to the node's validate() at broadcast; text mode warns on stderr, JSON/quiet stays silent.
- Only query chain params when resource == 2 (0/1 short-circuit, no RPC).

REPL previously did no validation at all; standard CLI hardcoded 0/1. Reuses the existing getChainParameters() plumbing. Docs updated for consistency.