### PR TITLE
fix(ts): rename npm package to @tron-walletcli/wallet-cli

### DIFF
--- a/ts/README.md
+++ b/ts/README.md
@@ -34,7 +34,7 @@ An agent-first TypeScript CLI wallet for TRON, with deterministic commands, stru
 Node.js 20 or later is required.
 
 ```bash
-npm install -g walletcli
+npm install -g @tron-walletcli/wallet-cli
 ```
 
 Verify the installation:

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "walletcli",
+  "name": "@tron-walletcli/wallet-cli",
   "version": "0.1.0",
   "description": "Agent-first TypeScript CLI wallet for TRON — deterministic commands, JSON output, and discoverable schemas",
   "type": "module",
   "bin": {
-    "wallet-cli": "./dist/index.js"
+    "wallet-cli": "dist/index.js"
   },
   "files": [
     "dist",


### PR DESCRIPTION
Publish under the scoped name @tron-walletcli/wallet-cli and update the README install command to match. Also drop the leading "./" from the bin path, which npm treats as invalid and auto-corrects on publish (matches `npm pkg fix`). The wallet-cli binary name is unchanged.