### PR TITLE
fix(deps): bump jackson-databind 2.16.1 -> 2.18.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ dependencies {
     implementation group: 'com.typesafe', name: 'config', version: '1.3.2'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.14.0'
     implementation group: 'com.alibaba', name: 'fastjson', version: '1.2.83'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.16.1'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.18.8'
 
     compileOnly 'org.projectlombok:lombok:1.18.24'
     annotationProcessor 'org.projectlombok:lombok:1.18.24'


### PR DESCRIPTION
Addresses CVE-2026-54512/54513/54514/54515 (PolymorphicTypeValidator bypass in jackson-databind). Fixed on the 2.x line in 2.18.8.