### PR TITLE
feat(ts): add tx sign and typed-data sign commands

### DIFF
--- a/ts/README.md
+++ b/ts/README.md
@@ -7,7 +7,7 @@ The agent-first implementation of wallet-cli, built for automation: every comman
 - **Agent-first** — stable JSON output, deterministic exit codes, and discoverable schemas, built for scripts, CI, and AI agents (details in [The contract, in one paragraph](#the-contract-in-one-paragraph)).
 - **Encrypted local storage** — software keystores are encrypted on disk; secrets are never passed via argv or environment variables.
 - **Software and Ledger signing** — sign in software, or on a Ledger device (the private key never leaves the device).
-- **Covers the main TRON capabilities** — HD wallets, TRX and TRC20/TRC10 transfers, staking / resource delegation, voting / rewards, smart-contract calls and deployment, message signing, and on-chain queries.
+- **Covers the main TRON capabilities** — HD wallets, TRX and TRC20/TRC10 transfers, staking / resource delegation, voting / rewards, smart-contract calls and deployment, message and EIP-712/TIP-712 signing, and on-chain queries.
 
 ## Supported chains
 
@@ -112,6 +112,7 @@ Every command — including every subcommand — has a reference page; run `wall
 | Command | Description |
 |---|---|
 | [`tx send`](docs/commands/tx/send.md) | Send native TRX or TRC20/TRC10 tokens |
+| [`tx sign`](docs/commands/tx/sign.md) | Sign a transaction built elsewhere, without broadcasting |
 | [`tx broadcast`](docs/commands/tx/broadcast.md) | Broadcast a presigned transaction |
 | [`tx status`](docs/commands/tx/status.md) | Show confirmation status (confirmed / failed / pending / not_found) |
 | [`tx info`](docs/commands/tx/info.md) | Show full transaction detail + receipt |
@@ -139,6 +140,7 @@ Every command — including every subcommand — has a reference page; run `wall
 | [`vote`](docs/commands/vote/index.md) | Vote for super representatives ([cast](docs/commands/vote/cast.md) · [list](docs/commands/vote/list.md) · [status](docs/commands/vote/status.md)) |
 | [`reward`](docs/commands/reward/index.md) | Query / withdraw voting rewards ([balance](docs/commands/reward/balance.md) · [withdraw](docs/commands/reward/withdraw.md)) |
 | [`message`](docs/commands/message/index.md) | Sign arbitrary messages ([sign](docs/commands/message/sign.md)) |
+| [`typed-data`](docs/commands/typed-data/index.md) | Sign EIP-712 / TIP-712 structured data ([sign](docs/commands/typed-data/sign.md)) |
 
 ### Local configuration
 

--- a/ts/docs/commands/contract/send.md
+++ b/ts/docs/commands/contract/send.md
@@ -101,7 +101,7 @@ echo "$PW" | wallet-cli contract send --contract TXYZopYRdj2D9XRtbG411XZZ3kM5VkA
 | default (submit) | `kind: "contract-send"`, `stage: "submitted"`, `txId`, `method`, `contract` |
 | `--wait` (confirmed/failed) | above, but `stage: "confirmed"` or `"failed"`, plus `confirmed`, `blockNumber`, `feeSun`, `energyUsed`, `result` (`SUCCESS` / `OUT_OF_ENERGY`, etc.), `failed` |
 | `--dry-run` | `kind`, `mode: "dry-run"`, `fee` (`feeModel`, estimated `energy`, `availableEnergy`), unsigned `tx` |
-| `--sign-only` | `kind`, `mode: "sign-only"`, `signed` (feed to `tx broadcast`), `fee`, `method`, `contract` |
+| `--sign-only` | `kind`, `mode: "sign-only"`, `signed` (feed to `tx broadcast`), `address` (signer), `txId`, `fee`, `method`, `contract` |
 
 ## Exit status
 

--- a/ts/docs/commands/index.md
+++ b/ts/docs/commands/index.md
@@ -26,6 +26,7 @@ Every command — including every subcommand — has its own page, following a f
 |---|---|
 | `tx` (group) | [tx/index.md](tx/index.md) |
 | `tx send` | [tx/send.md](tx/send.md) |
+| `tx sign` | [tx/sign.md](tx/sign.md) |
 | `tx broadcast` | [tx/broadcast.md](tx/broadcast.md) |
 | `tx status` | [tx/status.md](tx/status.md) |
 | `tx info` | [tx/info.md](tx/info.md) |
@@ -88,6 +89,8 @@ Every command — including every subcommand — has its own page, following a f
 |---|---|
 | `message` (group) | [message/index.md](message/index.md) |
 | `message sign` | [message/sign.md](message/sign.md) |
+| `typed-data` (group) | [typed-data/index.md](typed-data/index.md) |
+| `typed-data sign` | [typed-data/sign.md](typed-data/sign.md) |
 
 ## Local
 

--- a/ts/docs/commands/tx/send.md
+++ b/ts/docs/commands/tx/send.md
@@ -88,7 +88,7 @@ printf '%s' "$PW" | wallet-cli tx send --to TGkbaCYB4kRBc3Q6wjqkACefUvRwf2KzkH -
 | default (submit) | `kind: "send"`, `stage: "submitted"`, `txId`, `rawAmount` (string), `to` |
 | `--wait` (confirmed) | the above, but `stage: "confirmed"`, plus `confirmed`, `blockNumber`, `netUsed` (bandwidth used) or `feeSun` (fee burned), `failed` |
 | `--dry-run` | `kind`, `mode: "dry-run"`, `fee` (`feeModel`, e.g. `bandwidthBurnSunIfNoFreeze`), unsigned `tx` (TRON tx object incl. `txID`, `raw_data`), `rawAmount`, `to` |
-| `--sign-only` | `kind`, `mode: "sign-only"`, `signed` (full signed TRON tx incl. `signature[]` — feed to `tx broadcast`), `fee`, `rawAmount`, `to` |
+| `--sign-only` | `kind`, `mode: "sign-only"`, `signed` (full signed TRON tx incl. `signature[]` — feed to `tx broadcast`), `address` (signer), `txId`, `fee`, `rawAmount`, `to` |
 
 ## Exit status
 

--- a/ts/docs/commands/tx/sign.md
+++ b/ts/docs/commands/tx/sign.md
@@ -1,0 +1,128 @@
+# wallet-cli tx sign
+
+Sign a transaction built elsewhere, without broadcasting.
+
+## Synopsis
+
+```
+wallet-cli tx sign --transaction <json> [options]
+```
+
+## Description
+
+Signs a transaction that was constructed outside this CLI with the active account's key (or
+`--account`) and prints the signed result. Nothing is broadcast — pass the signed payload to
+[`tx broadcast`](broadcast.md) when you are ready. `--network` is optional: signing itself is
+offline for software accounts.
+
+This is a **pure signer**. It does not check who owns the transaction, what contract it calls, or
+how much it moves — the caller decides what to sign; the wallet holds the key, not the policy.
+
+What it does check is **payload integrity**, because a TRON transaction states its content three
+times and nothing in the format forces the three to agree:
+
+| Field | Who reads it |
+|---|---|
+| `raw_data` | you / your agent, when deciding whether to sign |
+| `raw_data_hex` | the node, when executing the transaction |
+| `txID` | the signature — this hash, and only this hash, is what gets signed |
+
+So a transaction whose `raw_data` reads "1 TRX" can carry the `txID` and `raw_data_hex` of a
+1000 TRX transfer, and the signature would be perfectly valid for what actually executes.
+`tx sign` therefore refuses (`tx_integrity`) unless:
+
+1. `txID` is the sha256 of `raw_data_hex` — always enforced, for every contract type; and
+2. `raw_data` re-encodes to exactly those bytes — enforced wherever the contract type can be
+   decoded. A handful of types (`MarketSellAssetContract`, `MarketCancelOrderContract`,
+   `ShieldedTransferContract`) cannot be re-encoded; those are still bound by check 1.
+
+Neither check rejects anything a correct transaction builder produces.
+
+Watch-only accounts cannot sign (`watch_only_no_signer`). Ledger accounts sign on the device.
+
+### Multi-sig co-signing
+
+If the transaction you pass already carries a `signature` array, this command **appends** its
+signature rather than replacing what is there. That is what TRON multi-sig requires — each
+permitted key signs the same transaction in turn — so a partially signed transaction can be passed
+from signer to signer and broadcast once the permission threshold is met.
+
+The consequence worth knowing: `data.signed.signature` may contain signatures this wallet did not
+produce. `data.address` always tells you which key *this* invocation used, and the text receipt
+numbers them so you can tell them apart:
+
+```console
+✅ Signed transaction
+  Address      TU9Z8Ha6Xj9oLLhamrT8MC77dxsj65VYMC
+  TxID         d0157b08eb6a5ce9482d4429a481f3bca4a95914f92a6b8f2fb73fb905ff7de0
+  Signature 1  ffffffff…                       ← already on the transaction
+  Signature 2  16a2ec10…                       ← added by this invocation
+```
+
+## Options
+
+| Option | Description |
+|---|---|
+| `--transaction <string>` | Unsigned transaction JSON (`raw_data`, `raw_data_hex` and `txID` must agree) |
+| `--password-stdin` | Master password from stdin (software accounts) |
+
+Plus the [global options](../index.md#global-options-every-command).
+
+The payload is passed on argv, not stdin: it is not a secret, and this leaves fd 0 free for
+`--password-stdin`.
+
+## Examples
+
+In the examples, `$PW` is your master password (fed on stdin via `--password-stdin`) and `$TX`
+holds the unsigned transaction JSON.
+
+```bash
+echo "$PW" | wallet-cli tx sign --transaction "$TX" --password-stdin
+```
+
+```console
+✅ Signed transaction
+  Address    TU9Z8Ha6Xj9oLLhamrT8MC77dxsj65VYMC
+  TxID       d0157b08eb6a5ce9482d4429a481f3bca4a95914f92a6b8f2fb73fb905ff7de0
+  Signature  16a2ec107591827046bcd77e9ae71a5fc415e2f69b9eebe5ad0fe6e3e39cfed16e7dad3e35bc36031ddd5bc47e22de63a925bf65a82e0e1e69508735bc3fd6271C
+```
+
+The signature is printed in full — it is the product of the command and you have to copy it
+somewhere. `Fee` is omitted because nothing was estimated: the transaction was built elsewhere.
+
+Sign now, broadcast later:
+
+```bash
+echo "$PW" | wallet-cli tx sign --transaction "$TX" --password-stdin -o json \
+  | jq -c .data.signed > signed.json
+wallet-cli tx broadcast --network tron:nile --tx-stdin < signed.json
+```
+
+A transaction whose fields disagree is refused rather than signed:
+
+```console
+{"success":false,"command":"tx.sign","error":{"code":"tx_integrity","message":"TRON transaction raw_data does not match its raw_data_hex; refusing to sign"}}
+```
+
+## Output
+
+| Field | Type | Meaning |
+|---|---|---|
+| `kind` | string | `"sign"` |
+| `mode` | string | `"sign-only"` — same shape `tx send --sign-only` emits, so consumers need no branch |
+| `address` | string | Address that produced the signature |
+| `txId` | string | Transaction id (TRON: `txID`) |
+| `signed` | object | The signed transaction — exactly what `tx broadcast` accepts |
+
+No `fee` is reported: nothing was estimated, because the transaction was not built here.
+
+## Exit status
+
+`0` signed · `1` execution failure (`tx_integrity`, `watch_only_no_signer`, `auth_failed`,
+`signing_rejected`) · `2` usage error (missing or malformed `--transaction` → `missing_option` /
+`invalid_value`).
+
+## See also
+
+[`tx broadcast`](broadcast.md) · [`typed-data sign`](../typed-data/sign.md) ·
+[Security model](../../concepts/security.md)

--- a/ts/docs/commands/typed-data/index.md
+++ b/ts/docs/commands/typed-data/index.md
@@ -1,0 +1,20 @@
+# wallet-cli typed-data
+
+Sign EIP-712 / TIP-712 structured data.
+
+## Synopsis
+
+```
+wallet-cli typed-data COMMAND
+```
+
+## Subcommands
+
+| Command | Page | Description |
+|---|---|---|
+| `typed-data sign` | [sign.md](sign.md) | Sign EIP-712 / TIP-712 structured data |
+
+## See also
+
+[`message`](../message/index.md) — arbitrary text signing (TIP-191/V2 · EIP-191) ·
+[Security model](../../concepts/security.md)

--- a/ts/docs/commands/typed-data/sign.md
+++ b/ts/docs/commands/typed-data/sign.md
@@ -1,0 +1,117 @@
+# wallet-cli typed-data sign
+
+Sign EIP-712 / TIP-712 structured data.
+
+## Synopsis
+
+```
+wallet-cli typed-data sign --typed-data <json> [options]
+```
+
+## Description
+
+Signs structured data with the active account's key (or `--account`) using the EIP-712 / TIP-712
+scheme, and prints the signature together with the digest that was signed. Signing only — nothing
+is broadcast, and `--network` is optional since signing is offline for software accounts.
+
+The payload is the standard EIP-712 JSON object:
+
+```json
+{
+  "domain":  { "name": "SunPerp", "version": "1", "chainId": 728126428 },
+  "types":   { "Order": [{ "name": "trader", "type": "address" }, { "name": "size", "type": "uint256" }] },
+  "message": { "trader": "TW7xMzawfuGcowC3rYN1qPnvrkrxVVMive", "size": "1000000" }
+}
+```
+
+Accommodations for real-world payloads:
+
+- **`EIP712Domain` is ignored** if present in `types`. Wallet-produced payloads routinely include
+  it, but it describes `domain` rather than being a struct to hash, and the encoder rejects it.
+- **`value` is accepted** as an alias for `message`.
+- **`primaryType` is optional** — it is inferred from `types` and always echoed back in the result,
+  so a caller can assert what was signed.
+- **TRON base58 addresses work** in `address`-typed fields; `T…` and `41…` hash identically.
+
+`domain.chainId` is signed as given and is **not** validated against `--network`: TRON networks are
+identified by name (`mainnet`/`nile`/`shasta`) rather than by an EIP-155 number, so there is nothing
+meaningful to compare against. Make sure the domain you pass targets the chain you intend.
+
+Watch-only accounts cannot sign (`watch_only_no_signer`).
+
+### Ledger
+
+Ledger accounts **can** sign typed data — the signature is produced on the device like any other.
+
+The caveat is *blind signing*: the TRON app exposes only the hashed TIP-712 instruction, so the
+screen shows the domain separator and the struct hash rather than the fields you are agreeing to.
+There is no way to render the message on-device, so check the payload before approving.
+
+**The TRON app blocks this by default.** Hash-only signing is gated behind a setting, so the first
+attempt fails with `ledger_setting_required`:
+
+```console
+{"success":false,"error":{"code":"ledger_setting_required","message":"enable \"Sign by Hash\" in the Ledger TRON app settings (Settings › Sign by Hash › Allowed)"}}
+```
+
+Enable it on the device under **Settings › Sign by Hash › Allowed**, then retry. App versions
+predating the TIP-712 instruction fail with `ledger_unsupported`; update the TRON app.
+
+## Options
+
+| Option | Description |
+|---|---|
+| `--typed-data <string>` | EIP-712/TIP-712 JSON: `{"domain":…,"types":…,"primaryType"?:…,"message":…}` |
+| `--password-stdin` | Master password from stdin (software accounts) |
+
+Plus the [global options](../index.md#global-options-every-command).
+
+The payload is passed on argv, not stdin: it is not a secret, and this leaves fd 0 free for
+`--password-stdin`.
+
+## Examples
+
+In the examples, `$PW` is your master password (fed on stdin via `--password-stdin`) and
+`$DATA` holds the EIP-712 JSON.
+
+```bash
+echo "$PW" | wallet-cli typed-data sign --typed-data "$DATA" --password-stdin
+```
+
+```console
+✅ Signed typed data
+  Address    TW7xMzawfuGcowC3rYN1qPnvrkrxVVMive
+  Type       Order
+  Digest     0x0a8d555d85874979f93b7f36b3518c825c0f8af12a97c21863610509732cdadd
+  Signature  0x8cbad926adcba9c155dc791d1412632d95c415ad5bd83e35fa71752b602db03429e2f866180802fea83268d6bac601c33ea00218e43fc42840e589200b3491fb1b
+```
+
+Digest and signature are printed in full; nothing in this receipt is abbreviated.
+
+```bash
+echo "$PW" | wallet-cli typed-data sign --typed-data "$DATA" --password-stdin -o json
+```
+
+```json
+{"schema":"wallet-cli.result.v1","success":true,"command":"typed-data.sign","data":{"address":"TW7xMzawfuGcowC3rYN1qPnvrkrxVVMive","signature":"0x8cbad926adcba9c155dc791d1412632d95c415ad5bd83e35fa71752b602db03429e2f866180802fea83268d6bac601c33ea00218e43fc42840e589200b3491fb1b","digest":"0x0a8d555d85874979f93b7f36b3518c825c0f8af12a97c21863610509732cdadd","primaryType":"Order"},"meta":{"durationMs":955,"warnings":[]},"chain":{"family":"tron","network":"tron:nile","chainId":"nile"}}
+```
+
+## Output
+
+| Field | Type | Meaning |
+|---|---|---|
+| `address` | string | Signer's base58 address |
+| `primaryType` | string | The struct that was signed (inferred when omitted) |
+| `digest` | string | The EIP-712/TIP-712 hash that was signed, 0x-prefixed |
+| `signature` | string | Signature, 0x-prefixed hex (`r‖s‖v`) |
+
+## Exit status
+
+`0` signed · `1` execution failure (`watch_only_no_signer`, `auth_failed`, `signing_rejected`,
+`ledger_setting_required`, `ledger_unsupported`) · `2` usage error (missing or malformed `--typed-data` → `missing_option` /
+`invalid_value`).
+
+## See also
+
+[`message sign`](../message/sign.md) · [`tx sign`](../tx/sign.md) ·
+[Security model](../../concepts/security.md)

--- a/ts/docs/typescript-wallet-cli-architecture-source-of-truth.md
+++ b/ts/docs/typescript-wallet-cli-architecture-source-of-truth.md
@@ -277,7 +277,7 @@ interface FamilyPlugin<F extends ChainFamily> {
 | `path` | Neutral commands use the full path; chain commands use a cross-family logical path. |
 | `family` | Omitted for neutral commands; when present, the resolved network selects the family implementation. |
 | `stdin` | A dedicated **command-scoped** stdin channel, one of `tx` or `message` (signed-tx JSON / message to sign). This field does not cover the master password, which is fed by the **global** `--password-stdin` (see the CLI surface section). Wallet secrets (`mnemonic`, `privateKey`) and the master-password *change* are TTY-only and have no stdin flag — see `secretsTtyOnly`. |
-| `network` | `none`, `optional`, `required`; today both optional/required can fall back to the default network. |
+| `network` | `none` (never touches a chain) or `optional` (resolves `--network`, else `config.defaultNetwork`). There is no `required`: the default-network fallback always applies, so nothing can demand an explicit `--network`. |
 | `wallet` | `none` or `optional`; optional can override the active account with `--account`. |
 | `auth` | An unlock declaration for help/catalog; actual software signing uses lazy decrypt. |
 | `broadcasts` | Controls whether help reveals `--wait`. |
@@ -493,7 +493,7 @@ interface TronNetworkDescriptor {
 | `tron:nile` | `nile` | `https://nile.trongrid.io` |
 | `tron:shasta` | `shasta` | `https://api.shasta.trongrid.io` |
 
-Canonical-id resolution is case-insensitive. Aliases remain descriptor metadata but are not accepted as network selectors. Both `network: optional/required` adopt `config.defaultNetwork` when not specified, and that value must be a canonical id. Ledger/watch pin a single family, and a family mismatch must fail before any RPC.
+Canonical-id resolution is case-insensitive. Aliases remain descriptor metadata but are not accepted as network selectors. `network: optional` adopts `config.defaultNetwork` when `--network` is not specified, and that value must be a canonical id. Ledger/watch pin a single family, and a family mismatch must fail before any RPC.
 
 `ChainGatewayRegistry` is injected with the family factory by Bootstrap and caches the client by network id. Its generic `client()` may only use the truly common minimal capabilities; a family use case obtains the `TronGateway` via the guarded `get(net, "tron")`. TRON staking and the future EVM gas/nonce must not be forced into a universal gateway.
 

--- a/ts/src/adapters/inbound/cli/commands/contract.ts
+++ b/ts/src/adapters/inbound/cli/commands/contract.ts
@@ -75,7 +75,7 @@ const sendFields = z.object({
 
 export const contractSendSpec: ChainSpec = {
   path: ["contract", "send"],
-  network: "required", wallet: "optional", auth: "required",
+  network: "optional", wallet: "optional", auth: "required",
   broadcasts: true,
   capability: "contract.call",
   summary: "State-changing call (triggerSmartContract)",
@@ -104,7 +104,7 @@ const deployFields = z.object({
 
 export const contractDeploySpec: ChainSpec = {
   path: ["contract", "deploy"],
-  network: "required", wallet: "optional", auth: "required",
+  network: "optional", wallet: "optional", auth: "required",
   broadcasts: true,
   capability: "contract.deploy",
   summary: "Deploy a smart contract",

--- a/ts/src/adapters/inbound/cli/commands/stake.ts
+++ b/ts/src/adapters/inbound/cli/commands/stake.ts
@@ -38,7 +38,7 @@ function stakeCommand(
   return {
     spec: {
       path: ["stake", action],
-      network: "required", wallet: "optional", auth: "required",
+      network: "optional", wallet: "optional", auth: "required",
       broadcasts: true,
       capability: options.capability ?? "staking.freeze",
       summary,

--- a/ts/src/adapters/inbound/cli/commands/text-formatters.test.ts
+++ b/ts/src/adapters/inbound/cli/commands/text-formatters.test.ts
@@ -272,3 +272,35 @@ describe("accountHistory formatter", () => {
     expect(out).toContain("Tother");
   });
 });
+
+describe("sign-only receipt", () => {
+  const base = { kind: "sign" as const, mode: "sign-only" as const, address: "TSigner", txId: "abc123" };
+  const ctx = { command: "tx sign", net: { family: "tron", id: "nile" } } as never;
+
+  // The signature is the product of a signing command and has to be copied somewhere, so it must
+  // never be shortened. Before this it showed a truncated txID — redundant with the TxID row and
+  // useless as output.
+  it("prints the signature in full", () => {
+    const sig = "16a2ec10".repeat(16) + "1C";
+    const out = TextFormatters.txReceipt({ ...base, signed: { txID: "abc123", signature: [sig] } }, ctx) as string;
+    expect(out).toContain(sig);
+    expect(out).not.toMatch(/\.\.\./);
+    expect(out).toContain("Signature");
+  });
+
+  it("numbers the signatures when a multi-sig transaction carries several", () => {
+    const out = TextFormatters.txReceipt(
+      { ...base, signed: { txID: "abc123", signature: ["aa".repeat(65), "bb".repeat(65)] } },
+      ctx,
+    ) as string;
+    expect(out).toContain("Signature 1");
+    expect(out).toContain("Signature 2");
+  });
+
+  // tx sign estimates nothing, so there is no fee to report and the row is dropped entirely
+  // rather than rendered as "unknown".
+  it("omits the fee row when nothing was estimated", () => {
+    const out = TextFormatters.txReceipt({ ...base, signed: { signature: ["aa".repeat(65)] } }, ctx) as string;
+    expect(out).not.toContain("Fee");
+  });
+});

--- a/ts/src/adapters/inbound/cli/commands/tx.sign.test.ts
+++ b/ts/src/adapters/inbound/cli/commands/tx.sign.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { txSignSpec, txSignTronBinding } from "./tx.js";
+
+const ctx = { activeAccount: "main" } as never;
+const net = { family: "tron", id: "nile" } as never;
+
+describe("tx sign spec", () => {
+  it("does not broadcast and requires auth", () => {
+    expect(txSignSpec.path).toEqual(["tx", "sign"]);
+    expect(txSignSpec.broadcasts).toBeFalsy();
+    expect(txSignSpec.auth).toBe("required");
+  });
+
+  it("requires a --transaction payload", () => {
+    expect(txSignSpec.baseFields.safeParse({}).success).toBe(false);
+    expect(txSignSpec.baseFields.safeParse({ transaction: "{}" }).success).toBe(true);
+  });
+
+  // the payload is not a secret, so argv is the only channel — no --tx-stdin on this command.
+  it("declares no stdin channel", () => {
+    expect(txSignSpec.stdin).toBeUndefined();
+  });
+});
+
+describe("tx sign binding", () => {
+  it("parses the JSON payload and hands it to the service", async () => {
+    let received: unknown;
+    const svc = {
+      sign: async (_c: unknown, _n: unknown, tx: unknown) => {
+        received = tx;
+        return { kind: "sign" };
+      },
+    };
+    await txSignTronBinding(svc as never).run(ctx, net, { transaction: '{"txID":"abc"}' });
+    expect(received).toEqual({ txID: "abc" });
+  });
+
+  it("rejects malformed JSON with invalid_value", async () => {
+    const svc = { sign: async () => ({}) };
+    await expect(txSignTronBinding(svc as never).run(ctx, net, { transaction: "not json" }))
+      .rejects.toMatchObject({ code: "invalid_value" });
+  });
+});

--- a/ts/src/adapters/inbound/cli/commands/tx.ts
+++ b/ts/src/adapters/inbound/cli/commands/tx.ts
@@ -59,7 +59,7 @@ const broadcastFields = z.object({
 export const txBroadcastSpec: ChainSpec = {
   path: ["tx", "broadcast"],
   stdin: "tx",
-  network: "required", wallet: "none", auth: "none",
+  network: "optional", wallet: "none", auth: "none",
   broadcasts: true,
   capability: "tx.broadcast",
   summary: "Broadcast a presigned transaction",
@@ -79,6 +79,41 @@ export const txBroadcastTronBinding = (svc: TronTransactionService): FamilyBindi
       }
       throw error;
     }
+  },
+});
+
+const signFields = z.object({
+  transaction: z.string().min(1)
+    .describe("unsigned TRON transaction JSON, as built (raw_data, raw_data_hex and txID must agree)"),
+});
+
+export const txSignSpec: ChainSpec = {
+  path: ["tx", "sign"],
+  network: "optional", wallet: "optional", auth: "required",
+  broadcasts: false,
+  capability: "tx.sign",
+  summary: "Sign a transaction built elsewhere, without broadcasting",
+  description:
+    "Sign a transaction built outside this CLI and output the signed result; broadcast it later\n" +
+    "with `tx broadcast`. Signs any well-formed transaction without inspecting its contents, but\n" +
+    "rejects a payload whose txID does not match its raw_data — the signature always covers the\n" +
+    "exact bytes you passed.",
+  baseFields: signFields,
+  examples: [
+    { cmd: `wallet-cli tx sign --transaction '{"txID":"...","raw_data":{...},"raw_data_hex":"..."}'` },
+  ],
+  formatText: TextFormatters.txReceipt,
+};
+
+export const txSignTronBinding = (svc: TronTransactionService): FamilyBinding => ({
+  run: async (ctx, net, input) => {
+    let tx: unknown;
+    try {
+      tx = JSON.parse(input.transaction);
+    } catch {
+      throw new UsageError("invalid_value", "TRON transaction must be JSON");
+    }
+    return svc.sign(ctx, net, tx);
   },
 });
 

--- a/ts/src/adapters/inbound/cli/commands/typed-data.test.ts
+++ b/ts/src/adapters/inbound/cli/commands/typed-data.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { typedDataSignSpec, typedDataSignBinding } from "./typed-data.js";
+
+const ctx = { activeAccount: "main" } as never;
+const net = { family: "tron", id: "nile", chainId: "728126428" } as never;
+
+const PAYLOAD = JSON.stringify({
+  domain: { name: "SunPerp", version: "1", chainId: 728126428 },
+  types: { EIP712Domain: [{ name: "name", type: "string" }], Order: [{ name: "size", type: "uint256" }] },
+  message: { size: "1" },
+});
+
+const stubResult = { address: "T1", primaryType: "Order", digest: "0xd", signature: "0xs" };
+
+describe("typed-data sign spec", () => {
+  it("is its own group and never broadcasts", () => {
+    expect(typedDataSignSpec.path).toEqual(["typed-data", "sign"]);
+    expect(typedDataSignSpec.broadcasts).toBeFalsy();
+    expect(typedDataSignSpec.auth).toBe("required");
+  });
+
+  // the payload is not a secret, so argv is the only channel — no --typed-data-stdin exists.
+  it("declares no stdin channel", () => {
+    expect(typedDataSignSpec.stdin).toBeUndefined();
+  });
+
+  it("requires --typed-data", () => {
+    expect(typedDataSignSpec.baseFields.safeParse({}).success).toBe(false);
+    expect(typedDataSignSpec.baseFields.safeParse({ typedData: PAYLOAD }).success).toBe(true);
+  });
+});
+
+describe("typed-data sign binding", () => {
+  it("normalizes the payload before signing", async () => {
+    let seen: any;
+    const svc = {
+      sign: async (_c: unknown, _f: unknown, _a: unknown, payload: unknown) => {
+        seen = payload;
+        return stubResult;
+      },
+    };
+    const out = await typedDataSignBinding(svc as never).run(ctx, net, { typedData: PAYLOAD });
+    expect(seen.types.EIP712Domain).toBeUndefined();
+    expect(seen.types.Order).toBeDefined();
+    expect(out).toEqual(stubResult);
+  });
+
+  it("rejects malformed JSON with invalid_value", async () => {
+    const svc = { sign: async () => stubResult };
+    await expect(typedDataSignBinding(svc as never).run(ctx, net, { typedData: "nope" }))
+      .rejects.toMatchObject({ code: "invalid_value" });
+  });
+
+  it("rejects a structurally invalid payload with invalid_value", async () => {
+    const svc = { sign: async () => stubResult };
+    await expect(
+      typedDataSignBinding(svc as never).run(ctx, net, { typedData: '{"domain":{},"types":{}}' }),
+    ).rejects.toMatchObject({ code: "invalid_value" });
+  });
+});

--- a/ts/src/adapters/inbound/cli/commands/typed-data.ts
+++ b/ts/src/adapters/inbound/cli/commands/typed-data.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+import type { ChainSpec, FamilyBinding } from "../contracts/index.js";
+import { UsageError } from "../../../../domain/errors/index.js";
+import { normalizeTypedData } from "../../../../domain/typed-data/index.js";
+import type { TypedDataService } from "../../../../application/use-cases/typed-data-service.js";
+import { TextFormatters } from "../render/index.js";
+
+const typedDataFields = z.object({
+  typedData: z.string().min(1)
+    .describe(`EIP-712/TIP-712 JSON: {"domain":…,"types":…,"primaryType"?:…,"message":…}`),
+});
+
+export const typedDataSignSpec: ChainSpec = {
+  path: ["typed-data", "sign"],
+  network: "optional", wallet: "optional", auth: "required",
+  broadcasts: false,
+  capability: "typedData.sign",
+  summary: "Sign EIP-712 / TIP-712 structured data",
+  description:
+    "Prints the signature, the digest that was signed, and the primary type.\n" +
+    "`EIP712Domain` in `types` is ignored, `value` is accepted for `message`, and TRON base58\n" +
+    "addresses work in address fields.",
+  baseFields: typedDataFields,
+  examples: [
+    { cmd: `wallet-cli typed-data sign --typed-data '{"domain":{...},"types":{...},"message":{...}}'` },
+  ],
+  formatText: TextFormatters.typedDataSign,
+};
+
+export const typedDataSignBinding = (service: TypedDataService): FamilyBinding => ({
+  run: async (ctx, net, input) => {
+    let raw: unknown;
+    try {
+      raw = JSON.parse(input.typedData);
+    } catch {
+      throw new UsageError("invalid_value", "typed data must be JSON");
+    }
+    const payload = normalizeTypedData(raw);
+    return service.sign(ctx, net.family, ctx.activeAccount, payload);
+  },
+});

--- a/ts/src/adapters/inbound/cli/commands/wallet.test.ts
+++ b/ts/src/adapters/inbound/cli/commands/wallet.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect , vi } from "vitest";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -18,6 +18,11 @@ import { isChainCommand } from "../contracts/index.js";
 import type { CommandDefinition, Globals } from "../contracts/index.js";
 import { Derivation } from "../../../../domain/derivation/index.js";
 import { WalletService } from "../../../../application/use-cases/wallet-service.js";
+
+// Cheap KDF for keystore encryption in this suite — see cheap-scrypt.ts. Production untouched.
+vi.mock("@noble/hashes/scrypt.js", async () =>
+  import("../../../outbound/persistence/crypto/__test-support__/cheap-scrypt.js"),
+);
 
 // ── test constants ─────────────────────────────────────────────────────────────
 const VALID_MNEMONIC = "test test test test test test test test test test test junk";

--- a/ts/src/adapters/inbound/cli/globals/index.ts
+++ b/ts/src/adapters/inbound/cli/globals/index.ts
@@ -73,21 +73,34 @@ const VALUE_SPEC_BY_FIELD: Record<string, GlobalFlagSpec> = Object.fromEntries(
   GLOBAL_FLAG_SPECS.filter((f) => f.kind === "value").map((f) => [specField(f), f]),
 );
 
+/** Result of coercing a value flag: a validated value, or the reason it was rejected. */
+export type GlobalCoercion =
+  | { ok: true; value: string | number }
+  | { ok: false; reason: string };
+
 /**
- * Coerce a raw value-flag string per its spec; `undefined` = invalid (caller falls back to default).
- * Derives entirely from valueType/choices: number flags accept a finite value at or above the spec's
- * `min` (default 0; --timeout sets min 1 since a 0ms bound aborts instantly), choice flags must match,
- * everything else passes through as a string.
+ * Coerce a raw value-flag string per its spec. A rejected value is `{ ok:false, reason }`, NOT a
+ * silent fallback — an out-of-range/non-matching flag is a usage error, never the default. Derives
+ * entirely from valueType/choices: number flags accept a finite value at or above the spec's `min`
+ * (default 0; --timeout sets min 1 since a 0ms bound aborts instantly), choice flags must match one
+ * of `choices`, everything else passes through as a string.
  */
-export function coerceGlobalValue(field: string, raw: string): string | number | undefined {
+export function coerceGlobalValue(field: string, raw: string): GlobalCoercion {
   const spec = VALUE_SPEC_BY_FIELD[field];
-  if (!spec) return raw;
+  if (!spec) return { ok: true, value: raw };
   if (spec.valueType === "number") {
     const n = Number(raw);
-    return Number.isFinite(n) && n >= (spec.min ?? 0) ? n : undefined;
+    const min = spec.min ?? 0;
+    return Number.isFinite(n) && n >= min
+      ? { ok: true, value: n }
+      : { ok: false, reason: `must be a number >= ${min}` };
   }
-  if (spec.choices) return spec.choices.includes(raw) ? raw : undefined;
-  return raw;
+  if (spec.choices) {
+    return spec.choices.includes(raw)
+      ? { ok: true, value: raw }
+      : { ok: false, reason: `must be one of: ${spec.choices.join(", ")}` };
+  }
+  return { ok: true, value: raw };
 }
 
 interface YargsOption {

--- a/ts/src/adapters/inbound/cli/help/help.test.ts
+++ b/ts/src/adapters/inbound/cli/help/help.test.ts
@@ -84,3 +84,29 @@ describe("HelpService ChainCommandDefinition", () => {
     expect(catalog.commands).toContainEqual(expect.objectContaining({ id: "block", families: ["tron"] }))
   })
 })
+
+describe("Requires: master password line", () => {
+  function renderAuthLine(spec: Partial<ChainSpec>): string {
+    const reg = new CommandRegistry()
+    reg.addChain(
+      { path: ["demo"], network: "none", wallet: "none", auth: "required", baseFields: z.object({}), examples: [], ...spec } as ChainSpec,
+      "tron",
+      { run: async () => ({}) },
+    )
+    const stream = makeStream()
+    new HelpService(reg, stream, "0.0.0").handleMeta(["demo", "--help"])
+    return (stream.last ?? "").split("\n").find((l) => l.includes("master password")) ?? ""
+  }
+
+  // Regression: the help used to promise "or enter it interactively in a TTY" for every command
+  // that needs the password. Chain commands never prompt — they fail fast with auth_required —
+  // so that sent readers looking for a broken terminal instead of adding --password-stdin.
+  it("says a non-interactive command never prompts", () => {
+    expect(renderAuthLine({})).toContain("never prompts")
+  })
+
+  it("offers the TTY route only when the command opts into prompting", () => {
+    expect(renderAuthLine({ interactive: true })).toContain("enter it interactively in a TTY")
+    expect(renderAuthLine({ interactive: true })).not.toContain("never prompts")
+  })
+})

--- a/ts/src/adapters/inbound/cli/help/index.ts
+++ b/ts/src/adapters/inbound/cli/help/index.ts
@@ -107,6 +107,7 @@ export class HelpService {
       ["reward", "Query / withdraw voting rewards", "tron"],
       ["chain", "Query chain params, prices & node info", ""],
       ["message", "Sign arbitrary messages", ""],
+      ["typed-data", "Sign EIP-712 / TIP-712 structured data", ""],
       ["block", "Get a block (latest if omitted)", ""],
     ] as const
     const commands = [
@@ -207,6 +208,7 @@ export class HelpService {
       requires: cmd.requires,
       positionals: cmd.positionals,
       secretsTtyOnly: cmd.secretsTtyOnly,
+      interactive: cmd.interactive,
     })
   }
 
@@ -225,6 +227,7 @@ export class HelpService {
       examples: spec.examples,
       requires: spec.requires,
       positionals: spec.positionals,
+      interactive: spec.interactive,
     })
   }
 
@@ -243,6 +246,7 @@ export class HelpService {
     requires?: string[]
     positionals?: { field: string; placeholder?: string }[]
     secretsTtyOnly?: boolean
+    interactive?: boolean
   }): string {
     const positionals = (c.positionals ?? []).map((p) => {
       const field = c.fields.find((f) => f.name === p.field)
@@ -264,10 +268,16 @@ export class HelpService {
     }
 
     const requires: string[] = [...(c.requires ?? [])]
-    if (c.network === "required") requires.push("--network <id>")
-    if (c.auth === "required") requires.push(c.secretsTtyOnly
-      ? "the master password — entered interactively in a TTY"
-      : "master password — pass --password-stdin for non-interactive use, or enter it interactively in a TTY")
+    // A command only prompts when it opts in (`interactive`); everything else fails fast so
+    // scripts and agents get a deterministic error instead of a hung prompt. Say which one this
+    // is — promising a TTY prompt that never comes sends the reader hunting for a broken terminal.
+    if (c.auth === "required") requires.push(
+      c.secretsTtyOnly
+        ? "the master password — entered interactively in a TTY"
+        : c.interactive
+          ? "master password — pass --password-stdin for non-interactive use, or enter it interactively in a TTY"
+          : "master password — pass --password-stdin; this command never prompts",
+    )
     if (c.wallet !== "none") requires.push("an account — defaults to active; override with --account <accountId|label> (or run `wallet-cli use <account>` to change the active account)")
     if (requires.length) {
       lines.push("", "Requires:")
@@ -428,6 +438,7 @@ const GROUP_DESCRIPTIONS: Record<string, string> = {
   reward: "Query and withdraw voting/block rewards.",
   chain: "Query on-chain parameters, resource prices, and node status.",
   message: "Sign arbitrary messages.",
+  "typed-data": "Sign EIP-712 / TIP-712 structured data.",
   block: "Get a block (latest if omitted).",
 }
 

--- a/ts/src/adapters/inbound/cli/render/misc.ts
+++ b/ts/src/adapters/inbound/cli/render/misc.ts
@@ -26,6 +26,15 @@ export const MiscFormatters = {
       ["Signature", String(d.signature ?? "")],
     ])
   }) satisfies TextFormatter,
+  typedDataSign: ((data) => {
+    const d = asObj(data)
+    return receipt(ok(), "Signed typed data", [
+      ["Address", String(d.address ?? "")],
+      ["Type", String(d.primaryType ?? "")],
+      ["Digest", String(d.digest ?? "")],
+      ["Signature", String(d.signature ?? "")],
+    ])
+  }) satisfies TextFormatter,
   block: ((data) => {
     const block = asObj(asObj(data).block)
     const header = asObj(asObj(block.block_header).raw_data)

--- a/ts/src/adapters/inbound/cli/render/tx.ts
+++ b/ts/src/adapters/inbound/cli/render/tx.ts
@@ -39,9 +39,12 @@ function renderTxReceipt(r: TxReceiptView, ctx?: TextRenderContext): string {
     ])
   }
   if (r.mode === "sign-only") {
+    // kv() drops empty rows, so a fee-less signature (tx sign estimates nothing) omits the Fee line.
     return receipt(ok(), `Signed ${actionLabel(r.kind)}`, [
-      ["Fee", formatFee(r.fee, family)],
-      ["Signed", summarizeTx(r.signed)],
+      ["Address", r.address ?? ""],
+      ["TxID", String(r.txId ?? "")],
+      ["Fee", r.fee ? formatFee(r.fee, family) : ""],
+      ...signatureRows(r.signed),
     ])
   }
   const txid = String(r.txId ?? r.hash ?? "")
@@ -128,6 +131,10 @@ function receiptSummary(r: TxReceiptView, family: ChainFamily): string {
     }
     case "broadcast":
       return "Broadcast"
+    // `tx sign` never broadcasts, so it never reaches a broadcast summary; the case keeps the
+    // switch total over TxReceiptKind.
+    case "sign":
+      return "Signed"
   }
 }
 
@@ -168,6 +175,9 @@ function actionLabel(kind: TxReceiptKind): string {
       return "tx send"
     case "broadcast":
       return "tx broadcast"
+    // reads as "Signed transaction"; "tx sign" would render as "Signed tx sign".
+    case "sign":
+      return "transaction"
     case "stake-freeze":
       return "stake freeze"
     case "stake-unfreeze":
@@ -208,6 +218,19 @@ function formatFee(fee: unknown, family: ChainFamily): string {
     if (f.note) return String(f.note)
   }
   return FAMILY_RENDER[family].feeFallback(fee)
+}
+
+/** Signatures are the whole point of a sign-only receipt and the user has to copy them somewhere,
+ *  so they are never shortened — unlike the dry-run `Tx` row, which only identifies a blob the
+ *  command did not produce. TRON carries `signature[]` (several when co-signing a multi-sig
+ *  transaction); a family whose signed form is one opaque string shows that string instead. */
+function signatureRows(signed: unknown): Pair[] {
+  if (typeof signed === "string") return [["Signed", signed]]
+  const sigs = (signed as { signature?: unknown } | null)?.signature
+  if (Array.isArray(sigs) && sigs.length > 0) {
+    return sigs.map((s, i): Pair => [sigs.length === 1 ? "Signature" : `Signature ${i + 1}`, String(s)])
+  }
+  return [["Signed", summarizeTx(signed)]]
 }
 
 function summarizeTx(tx: unknown): string {

--- a/ts/src/adapters/outbound/chain/tron/contract-response.test.ts
+++ b/ts/src/adapters/outbound/chain/tron/contract-response.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { normalizeContractResponses } from "./contract-response.js";
+import { isDeployedContract, normalizeContractResponses } from "./contract-response.js";
 
 describe("normalizeContractResponses", () => {
   it("normalizes name and ABI entry variants", () => {
@@ -19,5 +19,18 @@ describe("normalizeContractResponses", () => {
       name: "Fallback",
       methods: ["owner"],
     });
+  });
+});
+
+describe("isDeployedContract", () => {
+  it("is false for the empty response of a non-contract address", () => {
+    expect(isDeployedContract({})).toBe(false);
+    expect(isDeployedContract(undefined)).toBe(false);
+    expect(isDeployedContract(null)).toBe(false);
+  });
+
+  it("is true when the response carries a contract identity", () => {
+    expect(isDeployedContract({ contract_address: "41abc" })).toBe(true);
+    expect(isDeployedContract({ bytecode: "60806040" })).toBe(true);
   });
 });

--- a/ts/src/adapters/outbound/chain/tron/contract-response.ts
+++ b/ts/src/adapters/outbound/chain/tron/contract-response.ts
@@ -18,6 +18,18 @@ const ContractResponseSchema = z.preprocess(
   }),
 );
 
+/**
+ * Whether a `trx.getContract` response describes a deployed contract. TronWeb returns an empty
+ * object `{}` for an address with no contract (e.g. a plain account); a real contract carries a
+ * `contract_address`/`bytecode` identity. Used to fail `contract info` as not_found rather than
+ * normalize the empty response into a valid-but-empty contract.
+ */
+export function isDeployedContract(contract: unknown): boolean {
+  if (!contract || typeof contract !== "object") return false;
+  const c = contract as Record<string, unknown>;
+  return Boolean(c.contract_address || c.bytecode);
+}
+
 export function normalizeContractResponses(contract: unknown, info: unknown): TronContractMetadata {
   const contractView = ContractResponseSchema.parse(contract);
   const infoView = ContractResponseSchema.parse(info);

--- a/ts/src/adapters/outbound/chain/tron/signing-strategy.test.ts
+++ b/ts/src/adapters/outbound/chain/tron/signing-strategy.test.ts
@@ -1,10 +1,40 @@
 import { describe, it, expect } from "vitest";
-import { TronWeb } from "tronweb";
+import { TronWeb, utils as tronUtils } from "tronweb";
+import { sha256 } from "@noble/hashes/sha2.js";
+import { bytesToHex, hexToBytes } from "@noble/hashes/utils.js";
 import { tronSignStrategy } from "./signing-strategy.js";
 
 // Well-known test key; never holds funds.
 const PK = "0x0000000000000000000000000000000000000000000000000000000000000001";
 const oldTw = new TronWeb({ fullHost: "http://localhost" });
+
+const OWNER = "4119e7e376e7c213b7e7e7e46cc70a5dd086daff2a";
+const TO = "41e552f6487585c2b58bc2c9bb4492bc1f17132cd0";
+
+const RAW_DATA = {
+  contract: [{
+    parameter: {
+      value: { amount: 1000000, owner_address: OWNER, to_address: TO },
+      type_url: "type.googleapis.com/protocol.TransferContract",
+    },
+    type: "TransferContract",
+  }],
+  ref_block_bytes: "0a1b",
+  ref_block_hash: "c1e5f0a1d2b3c4d5",
+  expiration: 1753180800000,
+  timestamp: 1753180740000,
+};
+
+/** build a self-consistent tx (raw_data_hex + txID derived from raw_data), as a node would. */
+function buildTx(rawData: object) {
+  const shell = { visible: false, raw_data: rawData, raw_data_hex: "", txID: "" };
+  const pb = tronUtils.transaction.txJsonToPb(shell as never);
+  return {
+    ...shell,
+    raw_data_hex: tronUtils.transaction.txPbToRawDataHex(pb).toLowerCase(),
+    txID: tronUtils.transaction.txPbToTxID(pb).replace(/^0x/, ""),
+  };
+}
 
 describe("tronSignStrategy — static utils signing parity", () => {
   it("signMessage matches the old instance trx.signMessageV2 byte-for-byte", async () => {
@@ -14,10 +44,7 @@ describe("tronSignStrategy — static utils signing parity", () => {
   });
 
   it("sign attaches a valid secp256k1 signature to a transaction", async () => {
-    // Static signTransaction skips the instance's owner_address pre-check, so a minimal
-    // tx is enough; it appends signature[] over the txID hash.
-    const tx = { txID: "ab".repeat(32), raw_data: { contract: [] }, raw_data_hex: "0a02" };
-    const got = await tronSignStrategy.sign(PK, structuredClone(tx) as any);
+    const got = await tronSignStrategy.sign(PK, buildTx(RAW_DATA) as never);
     expect(Array.isArray((got as any).signature)).toBe(true);
     expect((got as any).signature[0]).toMatch(/^[0-9a-fA-F]{130}$/); // 65-byte r||s||v
   });
@@ -26,5 +53,118 @@ describe("tronSignStrategy — static utils signing parity", () => {
     await expect(tronSignStrategy.signMessage(PK, undefined as any)).rejects.toMatchObject({
       code: "signing_rejected",
     });
+  });
+});
+
+describe("tronSignStrategy.sign — payload integrity", () => {
+  // Security regression. raw_data (what a caller reads) and raw_data_hex/txID (what is signed and
+  // what the node executes) are independent fields. Signing a txID that does not describe the
+  // accompanying raw_data means the inspected JSON is decoration.
+  it("refuses a transaction whose txID/raw_data_hex disagree with raw_data", async () => {
+    const honest = buildTx(RAW_DATA);
+    const evilRaw = JSON.parse(JSON.stringify(RAW_DATA));
+    evilRaw.contract[0].parameter.value.amount = 1000000000;
+    const evil = buildTx(evilRaw);
+    const tampered = { ...honest, raw_data_hex: evil.raw_data_hex, txID: evil.txID };
+    await expect(tronSignStrategy.sign(PK, tampered as never)).rejects.toMatchObject({ code: "tx_integrity" });
+  });
+
+  // Layer 1: the hash we sign must be the hash of the bytes the node executes. Here raw_data and
+  // raw_data_hex agree, but txID is someone else's — signing it would authorize other bytes.
+  it("refuses a transaction whose txID is not the hash of its raw_data_hex", async () => {
+    const tx = { ...buildTx(RAW_DATA), txID: "00".repeat(32) };
+    await expect(tronSignStrategy.sign(PK, tx as never)).rejects.toMatchObject({ code: "tx_integrity" });
+  });
+
+  it("refuses a transaction missing raw_data_hex or txID", async () => {
+    await expect(tronSignStrategy.sign(PK, { raw_data: RAW_DATA } as never)).rejects.toMatchObject({
+      code: "tx_integrity",
+    });
+  });
+
+  // The bypass layer 2 exists to prevent: raw_data_hex/txID describe a real transfer, while the
+  // raw_data a caller reads is crafted so the re-encoder throws — a float amount looks entirely
+  // benign ("0.5 TRX") yet makes txJsonToPb fail. Skipping the check on ANY throw would sign it.
+  it("refuses raw_data that cannot be re-encoded for a decodable contract type", async () => {
+    const honest = buildTx(RAW_DATA);
+    const crafted = JSON.parse(JSON.stringify(RAW_DATA));
+    crafted.contract[0].parameter.value.amount = 0.5;
+    const tx = { ...honest, raw_data: crafted };
+    await expect(tronSignStrategy.sign(PK, tx as never)).rejects.toMatchObject({ code: "tx_integrity" });
+  });
+
+  it("refuses raw_data whose address is malformed", async () => {
+    const honest = buildTx(RAW_DATA);
+    const crafted = JSON.parse(JSON.stringify(RAW_DATA));
+    crafted.contract[0].parameter.value.to_address = "not-an-address";
+    await expect(tronSignStrategy.sign(PK, { ...honest, raw_data: crafted } as never))
+      .rejects.toMatchObject({ code: "tx_integrity" });
+  });
+
+  // Layer 2 is skipped ONLY here: tronweb's txJsonToPb throws "Unsupported transaction type" for
+  // Market/Shielded contracts. Those are still bound by layer 1, so refusing them would make
+  // legitimate payloads unsignable for no security gain.
+  it("signs a contract type tronweb cannot re-encode, as long as txID binds raw_data_hex", async () => {
+    const hex = "0a020a1b"; // arbitrary bytes; content is irrelevant to the binding
+    const exotic = {
+      visible: false,
+      raw_data: { contract: [{ type: "MarketSellAssetContract", parameter: { value: {} } }] },
+      raw_data_hex: hex,
+      txID: bytesToHex(sha256(hexToBytes(hex))),
+    };
+    const signed = await tronSignStrategy.sign(PK, exotic as never);
+    expect((signed as any).signature).toHaveLength(1);
+  });
+
+  // TRON multi-sig collects N signatures on one transaction, each signer appending its own, so a
+  // pre-existing signature must survive rather than be replaced. Pinned because tronweb's
+  // signTransaction pushes onto the array, and silently dropping it would break co-signing.
+  it("appends to an existing signature array instead of replacing it", async () => {
+    const tx = { ...buildTx(RAW_DATA), signature: ["ff".repeat(65)] };
+    const signed = await tronSignStrategy.sign(PK, tx as never);
+    expect((signed as any).signature).toHaveLength(2);
+    expect((signed as any).signature[0]).toBe("ff".repeat(65));
+  });
+
+  // visible:true transactions carry base58 addresses inside raw_data; both layers must accept them.
+  it("accepts a visible (base58) transaction", async () => {
+    const raw = JSON.parse(JSON.stringify(RAW_DATA));
+    raw.contract[0].parameter.value.owner_address = TronWeb.address.fromHex(OWNER);
+    raw.contract[0].parameter.value.to_address = TronWeb.address.fromHex(TO);
+    const shell = { visible: true, raw_data: raw, raw_data_hex: "", txID: "" };
+    const pb = tronUtils.transaction.txJsonToPb(shell as never);
+    const tx = {
+      ...shell,
+      raw_data_hex: tronUtils.transaction.txPbToRawDataHex(pb).toLowerCase(),
+      txID: tronUtils.transaction.txPbToTxID(pb).replace(/^0x/, ""),
+    };
+    const signed = await tronSignStrategy.sign(PK, tx as never);
+    expect((signed as any).signature).toHaveLength(1);
+  });
+});
+
+describe("tronSignStrategy.signTypedData", () => {
+  const ADDRESS = TronWeb.address.fromPrivateKey(PK.slice(2)) as string;
+  const domain = { name: "SunPerp", version: "1", chainId: 728126428 };
+  const types = { Order: [{ name: "trader", type: "address" }, { name: "size", type: "uint256" }] };
+  const message = { trader: ADDRESS, size: "1000000" };
+
+  it("produces a signature that recovers to the signing address", async () => {
+    const out = await tronSignStrategy.signTypedData(PK, { domain, types, message });
+    expect(out.primaryType).toBe("Order");
+    expect(out.digest).toBe(tronUtils.typedData.TypedDataEncoder.hash(domain, types, message));
+    const recovered = tronUtils.typedData.verifyTypedData(domain, types, message, out.signature);
+    expect(TronWeb.address.fromHex(`41${recovered.replace(/^0x/, "")}`)).toBe(ADDRESS);
+  });
+
+  it("honours an explicitly supplied primaryType", async () => {
+    const out = await tronSignStrategy.signTypedData(PK, { domain, types, primaryType: "Order", message });
+    expect(out.primaryType).toBe("Order");
+  });
+
+  it("wraps hashing failures in a ChainError(signing_rejected)", async () => {
+    await expect(
+      tronSignStrategy.signTypedData(PK, { domain, types, message: { trader: "not-an-address", size: "1" } }),
+    ).rejects.toMatchObject({ code: "signing_rejected" });
   });
 });

--- a/ts/src/adapters/outbound/chain/tron/signing-strategy.test.ts
+++ b/ts/src/adapters/outbound/chain/tron/signing-strategy.test.ts
@@ -101,19 +101,75 @@ describe("tronSignStrategy.sign — payload integrity", () => {
       .rejects.toMatchObject({ code: "tx_integrity" });
   });
 
-  // Layer 2 is skipped ONLY here: tronweb's txJsonToPb throws "Unsupported transaction type" for
-  // Market/Shielded contracts. Those are still bound by layer 1, so refusing them would make
-  // legitimate payloads unsignable for no security gain.
-  it("signs a contract type tronweb cannot re-encode, as long as txID binds raw_data_hex", async () => {
-    const hex = "0a020a1b"; // arbitrary bytes; content is irrelevant to the binding
-    const exotic = {
+  // Serialize a Transaction.raw carrying a single contract of `typeNum` (empty inner parameter —
+  // only the outer envelope type matters for the binding tronweb cannot re-encode).
+  function envelopeHex(typeNum: number): string {
+    const P = (globalThis as any).TronWebProto;
+    const contract = new P.Transaction.Contract();
+    contract.setType(typeNum);
+    const raw = new P.Transaction.raw();
+    raw.addContract(contract);
+    return bytesToHex(raw.serializeBinary());
+  }
+  // An exotic tx whose raw_data claims `claimedType` while raw_data_hex encodes a contract of
+  // `encodedTypeNum`; txID is derived so layer 1 always passes and the type binding is what decides.
+  function exoticTx(claimedType: string, encodedTypeNum: number) {
+    const hex = envelopeHex(encodedTypeNum);
+    return {
+      visible: false,
+      raw_data: { contract: [{ type: claimedType, parameter: { value: {} } }] },
+      raw_data_hex: hex,
+      txID: bytesToHex(sha256(hexToBytes(hex))),
+    };
+  }
+
+  // Layer 2 (re-encode) is skipped for Market/Shielded — tronweb cannot encode them — but the type
+  // binding (decode of raw_data_hex) still applies. A legitimate Market tx, where the claimed type
+  // matches the encoded envelope type, must still sign; refusing it gains no security.
+  it("signs a Market contract tronweb cannot re-encode when raw_data's type matches the envelope", async () => {
+    const signed = await tronSignStrategy.sign(PK, exoticTx("MarketSellAssetContract", 52) as never);
+    expect((signed as any).signature).toHaveLength(1);
+  });
+
+  // SIGN-TX-020: raw_data displays a (benign) Market order while raw_data_hex actually encodes a
+  // different contract. Skipping layer 2 for Market must NOT let a disguised type through.
+  it("refuses a transaction whose raw_data type disagrees with the encoded envelope type", async () => {
+    await expect(tronSignStrategy.sign(PK, exoticTx("MarketSellAssetContract", 1) as never))
+      .rejects.toMatchObject({ code: "tx_integrity" });
+  });
+
+  // SIGN-TX-019: raw_data claims one contract, but the envelope decodes to none. A count mismatch is
+  // as much a disguise as a type mismatch.
+  it("refuses a transaction whose raw_data_hex envelope carries no matching contract", async () => {
+    const hex = "0a020a1b"; // a Transaction.raw with ref_block_bytes only, zero contracts
+    const tx = {
       visible: false,
       raw_data: { contract: [{ type: "MarketSellAssetContract", parameter: { value: {} } }] },
       raw_data_hex: hex,
       txID: bytesToHex(sha256(hexToBytes(hex))),
     };
-    const signed = await tronSignStrategy.sign(PK, exotic as never);
-    expect((signed as any).signature).toHaveLength(1);
+    await expect(tronSignStrategy.sign(PK, tx as never)).rejects.toMatchObject({ code: "tx_integrity" });
+  });
+
+  // An unrecognizable contract-type name cannot be confirmed against the envelope, so fail closed
+  // rather than skip — the safe reading of "we cannot verify this".
+  it("refuses a transaction whose raw_data declares an unknown contract type", async () => {
+    await expect(tronSignStrategy.sign(PK, exoticTx("TotallyFakeContract", 52) as never))
+      .rejects.toMatchObject({ code: "tx_integrity" });
+  });
+
+  // Decode failure (valid hex, invalid protobuf) is suspicious, not a legitimate codec gap: the
+  // outer envelope is always decodable for a well-formed tx. A Market claim skips layer 2, so only
+  // the envelope decode stands between this and a signature — it must fail closed, not skip.
+  it("refuses a transaction whose raw_data_hex is not decodable protobuf", async () => {
+    const hex = "ff"; // valid hex, but not a parseable Transaction.raw
+    const tx = {
+      visible: false,
+      raw_data: { contract: [{ type: "MarketSellAssetContract", parameter: { value: {} } }] },
+      raw_data_hex: hex,
+      txID: bytesToHex(sha256(hexToBytes(hex))),
+    };
+    await expect(tronSignStrategy.sign(PK, tx as never)).rejects.toMatchObject({ code: "tx_integrity" });
   });
 
   // TRON multi-sig collects N signatures on one transaction, each signer appending its own, so a
@@ -140,6 +196,43 @@ describe("tronSignStrategy.sign — payload integrity", () => {
     };
     const signed = await tronSignStrategy.sign(PK, tx as never);
     expect((signed as any).signature).toHaveLength(1);
+  });
+});
+
+// Pins the two tronweb assumptions the contract-type binding (layer 1.5) rests on. If a tronweb
+// upgrade breaks either, these fail loudly here instead of silently reopening the disguise gap.
+describe("tx-integrity — pinned tronweb assumptions", () => {
+  // These families are valid on-chain but tronweb cannot re-encode them, so layer 2 is skipped and
+  // layer 1.5 is the only thing binding their type. If any becomes re-encodable, revisit the skip.
+  const UNENCODABLE = [
+    "VoteAssetContract", "UnfreezeAssetContract", "CustomContract",
+    "ShieldedTransferContract", "MarketSellAssetContract", "MarketCancelOrderContract",
+  ];
+
+  it.each(UNENCODABLE)("tronweb still cannot re-encode %s (layer 2 legitimately skips it)", (name) => {
+    const CT = (globalThis as any).TronWebProto.Transaction.Contract.ContractType;
+    const c = new (globalThis as any).TronWebProto.Transaction.Contract();
+    c.setType(CT[name.toUpperCase()]);
+    const raw = new (globalThis as any).TronWebProto.Transaction.raw();
+    raw.addContract(c);
+    const hex = bytesToHex(raw.serializeBinary());
+    expect(() =>
+      tronUtils.transaction.txCheck({
+        visible: false,
+        raw_data: { contract: [{ type: name, parameter: { value: {} } }] },
+        raw_data_hex: hex,
+        txID: bytesToHex(sha256(hexToBytes(hex))),
+      } as never),
+    ).toThrow(/Unsupported transaction type/i);
+  });
+
+  // Layer 1.5 resolves a raw_data type string by upper-casing it and looking it up in the enum.
+  // That only works while the enum keys are the upper-cased CamelCase names with no separators.
+  it("resolves contract type names against the protobuf enum by upper-casing", () => {
+    const CT = (globalThis as any).TronWebProto.Transaction.Contract.ContractType;
+    for (const name of ["TransferContract", "TriggerSmartContract", "AccountPermissionUpdateContract", "MarketSellAssetContract"]) {
+      expect(CT[name.toUpperCase()]).toBeTypeOf("number");
+    }
   });
 });
 

--- a/ts/src/adapters/outbound/chain/tron/signing-strategy.ts
+++ b/ts/src/adapters/outbound/chain/tron/signing-strategy.ts
@@ -5,8 +5,9 @@
  * ADAPTERS table. Adding a chain = one more strategy here.
  */
 import { utils as tronUtils } from "tronweb"
-import type { SignStrategy } from "../../../../domain/types/index.js";
+import type { SignStrategy, TypedDataPayload, TypedDataSignature } from "../../../../domain/types/index.js";
 import { ChainError } from "../../../../domain/errors/index.js"
+import { assertTronTxIntegrity } from "./tx-integrity.js"
 
 // Offline signing via TronWeb's static utils — no TronWeb instance, no fullHost, no network.
 // These are the same primitives the instance methods call internally:
@@ -14,6 +15,7 @@ import { ChainError } from "../../../../domain/errors/index.js"
 // signTransaction wants a bare hex key; signMessage wants the 0x-prefixed key.
 export const tronSignStrategy: SignStrategy = {
   async sign(pkHex, tx) {
+    assertTronTxIntegrity(tx)
     return tronUtils.crypto.signTransaction(pkHex.slice(2), tx as any)
   },
   async signMessage(pkHex, message) {
@@ -21,6 +23,19 @@ export const tronSignStrategy: SignStrategy = {
       return tronUtils.message.signMessage(message, pkHex)
     } catch (e) {
       throw new ChainError("signing_rejected", `TRON message sign failed: ${(e as Error).message}`)
+    }
+  },
+  async signTypedData(pkHex, payload: TypedDataPayload): Promise<TypedDataSignature> {
+    const { domain, types, message } = payload
+    try {
+      const encoder = tronUtils.typedData.TypedDataEncoder
+      return {
+        signature: tronUtils.typedData.signTypedData(domain as any, types as any, message, pkHex),
+        digest: encoder.hash(domain as any, types as any, message),
+        primaryType: payload.primaryType ?? encoder.from(types as any).primaryType,
+      }
+    } catch (e) {
+      throw new ChainError("signing_rejected", `TRON typed-data sign failed: ${(e as Error).message}`)
     }
   },
 }

--- a/ts/src/adapters/outbound/chain/tron/tron.timeout.test.ts
+++ b/ts/src/adapters/outbound/chain/tron/tron.timeout.test.ts
@@ -15,6 +15,14 @@ describe("TronRpcClient timeout", () => {
     await expect(client.getContract(ADDR)).rejects.toMatchObject({ code: "timeout" });
   });
 
+  it("getContractMetadata fails not_found when no contract is deployed at the address", async () => {
+    const client = new TronRpcClient("http://localhost:1", 20);
+    // tronweb returns {} for an address with no contract (e.g. a plain account).
+    client.tronweb.trx.getContract = (() => Promise.resolve({})) as never;
+    client.tronweb.trx.getContractInfo = (() => Promise.resolve({})) as never;
+    await expect(client.getContractMetadata(ADDR)).rejects.toMatchObject({ code: "not_found" });
+  });
+
   it("getAccount aborts its fetch at timeoutMs (best-effort, does not hang)", async () => {
     // fetch that only settles when its abort signal fires — proves the signal is wired to timeoutMs.
     // hangs unless an abort signal is wired — a missing signal must fail the test, not pass it.

--- a/ts/src/adapters/outbound/chain/tron/tron.ts
+++ b/ts/src/adapters/outbound/chain/tron/tron.ts
@@ -30,7 +30,7 @@ import { tronHexToBase58 } from "../../../../domain/address/index.js";
 import { parseTronTx, parseTronTxInfo } from "./tron-responses.js";
 import { assertBuiltTx } from "./tx-guard.js";
 import { decodeTronTransaction } from "./transaction-decoder.js";
-import { normalizeContractResponses } from "./contract-response.js";
+import { isDeployedContract, normalizeContractResponses } from "./contract-response.js";
 
 /** a valid base58 owner used as the caller for read-only (constant) contract calls. */
 const TRON_READ_OWNER = "T9yD14Nj9j7xAB4dbGeiX9h8unkKHxuWwb";
@@ -442,6 +442,11 @@ export class TronRpcClient implements TronGateway, Broadcaster {
       this.getContract(address),
       this.getContractInfo(address).catch(() => undefined),
     ]);
+    // getContract is authoritative for existence: an empty response means no contract is deployed
+    // here (e.g. a plain account). Fail as not_found rather than normalize {} into an empty contract.
+    if (!isDeployedContract(contract)) {
+      throw new ChainError("not_found", `no contract deployed at ${address}`);
+    }
     return normalizeContractResponses(contract, info);
   }
 

--- a/ts/src/adapters/outbound/chain/tron/tx-integrity.ts
+++ b/ts/src/adapters/outbound/chain/tron/tx-integrity.ts
@@ -1,0 +1,76 @@
+/**
+ * TRON transaction payload integrity — enforced before ANY signature is produced, by every
+ * signing backend (software strategy and Ledger device alike).
+ *
+ * A TRON transaction states its content three times, and nothing in the format forces the three
+ * to agree:
+ *
+ *   raw_data      the JSON a caller inspects when deciding whether to sign
+ *   raw_data_hex  the protobuf bytes the node actually executes
+ *   txID          sha256 of those bytes — and the ONLY thing that gets signed
+ *                 (tronweb's crypto.signTransaction signs tx.txID verbatim, never recomputing it;
+ *                  the Ledger app signs the raw_data_hex you hand it)
+ *
+ * So a caller-supplied transaction can display a harmless raw_data while carrying the txID and
+ * raw_data_hex of a different one, and the resulting signature is perfectly valid for whatever
+ * actually broadcasts.
+ *
+ * Two layers, because they close different holes and have different coverage:
+ *
+ *   1. txID === sha256(raw_data_hex) — the security-critical binding between the hash we sign and
+ *      the bytes the node executes. Pure protocol arithmetic, so it holds for EVERY contract type,
+ *      including ones no library can decode.
+ *   2. txCheck — re-encode raw_data and confirm it yields those same bytes, which additionally
+ *      proves the JSON a caller inspected is the JSON being signed.
+ *
+ * Layer 2 is skipped ONLY for contract types tronweb cannot encode at all
+ * (the Market and Shielded families), which layer 1 still binds. Every other failure is fatal: a re-encode that
+ * throws for any other reason (a float amount, an out-of-range value, a malformed address) is
+ * indistinguishable from a payload crafted to dodge the check, and several such payloads look
+ * entirely benign to a human reading the JSON.
+ *
+ * Neither layer is policy — they reject nothing a correct transaction builder produces, only
+ * self-inconsistent payloads.
+ */
+import { utils as tronUtils } from "tronweb"
+import { sha256 } from "@noble/hashes/sha2.js"
+import { bytesToHex, hexToBytes } from "@noble/hashes/utils.js"
+import { ChainError } from "../../../../domain/errors/index.js"
+
+/** tronweb's txJsonToPb rejects contract types it has no protobuf mapping for with this message. */
+const UNSUPPORTED_CONTRACT_TYPE = /^Unsupported transaction type/i
+
+export function assertTronTxIntegrity(tx: unknown): void {
+  const t = tx as { raw_data?: unknown; raw_data_hex?: unknown; txID?: unknown }
+  if (!t || typeof t !== "object" || !t.raw_data || typeof t.raw_data_hex !== "string" || typeof t.txID !== "string") {
+    throw new ChainError("tx_integrity", "TRON transaction must carry raw_data, raw_data_hex and txID; refusing to sign")
+  }
+
+  const claimed = t.txID.replace(/^0x/, "").toLowerCase()
+  let derived: string
+  try {
+    derived = bytesToHex(sha256(hexToBytes(t.raw_data_hex.replace(/^0x/, ""))))
+  } catch (e) {
+    throw new ChainError("tx_integrity", `TRON transaction raw_data_hex is not valid hex: ${(e as Error).message}`)
+  }
+  if (derived !== claimed) {
+    throw new ChainError("tx_integrity", "TRON transaction txID is not the hash of its raw_data_hex; refusing to sign")
+  }
+
+  let matchesRawData: boolean
+  try {
+    matchesRawData = tronUtils.transaction.txCheck(tx as any)
+  } catch (e) {
+    const message = (e as Error)?.message ?? String(e)
+    // The one tolerable failure: tronweb has no encoding for this contract type, so raw_data
+    // cannot be verified by anyone. Layer 1 still binds the signature to the executed bytes.
+    if (UNSUPPORTED_CONTRACT_TYPE.test(message)) return
+    // Anything else — a float amount, an over-range value, a malformed address — means raw_data
+    // could not be re-encoded. Fail closed: an unverifiable raw_data is exactly what a crafted
+    // payload produces, and it looks benign in the JSON.
+    throw new ChainError("tx_integrity", `TRON transaction raw_data could not be re-encoded for verification: ${message}`)
+  }
+  if (!matchesRawData) {
+    throw new ChainError("tx_integrity", "TRON transaction raw_data does not match its raw_data_hex; refusing to sign")
+  }
+}

--- a/ts/src/adapters/outbound/chain/tron/tx-integrity.ts
+++ b/ts/src/adapters/outbound/chain/tron/tx-integrity.ts
@@ -20,11 +20,20 @@
  *   1. txID === sha256(raw_data_hex) — the security-critical binding between the hash we sign and
  *      the bytes the node executes. Pure protocol arithmetic, so it holds for EVERY contract type,
  *      including ones no library can decode.
+ *   1.5. contract-type binding — decode raw_data_hex's outer envelope (always decodable, even for
+ *      contract types no library can *encode*) and confirm its contract type(s) equal the ones
+ *      raw_data declares. This closes the gap layer 2 leaves for Market/Shielded: a caller-read
+ *      raw_data cannot claim a benign type while raw_data_hex encodes a different one.
  *   2. txCheck — re-encode raw_data and confirm it yields those same bytes, which additionally
- *      proves the JSON a caller inspected is the JSON being signed.
+ *      proves the JSON a caller inspected is the JSON being signed (down to every field).
  *
  * Layer 2 is skipped ONLY for contract types tronweb cannot encode at all
- * (the Market and Shielded families), which layer 1 still binds. Every other failure is fatal: a re-encode that
+ * (the Market and Shielded families), which layers 1 and 1.5 still bind — so a disguised *type* can no
+ * longer slip through. One residual remains and is NOT closed here: a same-type payload of an
+ * unencodable contract with attacker-chosen *field values* (e.g. a ShieldedTransferContract that moves
+ * value, showing benign fields in raw_data while raw_data_hex carries different ones). tronweb ships
+ * no encoder OR field decoder for those families, so no layer can verify their fields; a caller of the
+ * pure `tx sign` must treat Market/Shielded field contents as unverified. Every other failure is fatal: a re-encode that
  * throws for any other reason (a float amount, an out-of-range value, a malformed address) is
  * indistinguishable from a payload crafted to dodge the check, and several such payloads look
  * entirely benign to a human reading the JSON.
@@ -39,6 +48,63 @@ import { ChainError } from "../../../../domain/errors/index.js"
 
 /** tronweb's txJsonToPb rejects contract types it has no protobuf mapping for with this message. */
 const UNSUPPORTED_CONTRACT_TYPE = /^Unsupported transaction type/i
+
+/** Minimal shape of the protobuf definitions tronweb publishes on globalThis when it is imported. */
+interface TronProto {
+  Transaction: {
+    raw: { deserializeBinary(bytes: Uint8Array): { getContractList(): { getType(): number }[] } }
+    Contract: { ContractType: Record<string, number> }
+  }
+}
+
+/** ContractType names normalized to a case-insensitive lookup, built once from tronweb's protobuf. */
+let contractTypeMap: Map<string, number> | undefined
+function contractTypeByName(proto: TronProto): Map<string, number> {
+  if (!contractTypeMap) {
+    contractTypeMap = new Map()
+    for (const [name, num] of Object.entries(proto.Transaction.Contract.ContractType)) {
+      contractTypeMap.set(name.toUpperCase(), num)
+    }
+  }
+  return contractTypeMap
+}
+
+/**
+ * Layer 1.5 — bind the contract type(s) a caller reads in raw_data to the ones raw_data_hex encodes.
+ * Decoding the outer envelope succeeds even for contract types tronweb cannot re-encode, so this
+ * applies where layer 2 cannot. Fails closed: a raw_data_hex that will not decode, an unrecognized
+ * type name, or any mismatch means we cannot confirm what we would sign.
+ */
+function assertContractTypeBinding(rawData: unknown, rawDataHex: string): void {
+  // Load-bearing assumption: tronweb publishes its protobuf definitions on globalThis as an import
+  // side effect. If a tronweb upgrade renames/removes this global, signing fails closed here (safe),
+  // and the pinning tests in signing-strategy.test.ts are the tripwire that catches the drift.
+  const proto = (globalThis as { TronWebProto?: TronProto }).TronWebProto
+  if (!proto) throw new ChainError("tx_integrity", "TRON protobuf definitions are unavailable; refusing to sign")
+
+  let encoded: number[]
+  try {
+    const raw = proto.Transaction.raw.deserializeBinary(hexToBytes(rawDataHex.replace(/^0x/, "")))
+    encoded = raw.getContractList().map((c) => c.getType())
+  } catch (e) {
+    throw new ChainError("tx_integrity", `TRON transaction raw_data_hex is not a decodable transaction: ${(e as Error).message}`)
+  }
+
+  const byName = contractTypeByName(proto)
+  const contracts = Array.isArray((rawData as { contract?: unknown }).contract) ? (rawData as { contract: unknown[] }).contract : []
+  const declared = contracts.map((c) => {
+    const name = typeof (c as { type?: unknown })?.type === "string" ? (c as { type: string }).type.toUpperCase() : ""
+    const num = byName.get(name)
+    if (num === undefined) {
+      throw new ChainError("tx_integrity", `TRON transaction declares an unknown contract type "${(c as { type?: unknown })?.type}"; refusing to sign`)
+    }
+    return num
+  })
+
+  if (declared.length !== encoded.length || declared.some((n, i) => n !== encoded[i])) {
+    throw new ChainError("tx_integrity", "TRON transaction raw_data contract type does not match its raw_data_hex; refusing to sign")
+  }
+}
 
 export function assertTronTxIntegrity(tx: unknown): void {
   const t = tx as { raw_data?: unknown; raw_data_hex?: unknown; txID?: unknown }
@@ -56,6 +122,8 @@ export function assertTronTxIntegrity(tx: unknown): void {
   if (derived !== claimed) {
     throw new ChainError("tx_integrity", "TRON transaction txID is not the hash of its raw_data_hex; refusing to sign")
   }
+
+  assertContractTypeBinding(t.raw_data, t.raw_data_hex)
 
   let matchesRawData: boolean
   try {

--- a/ts/src/adapters/outbound/keystore/keystore.test.ts
+++ b/ts/src/adapters/outbound/keystore/keystore.test.ts
@@ -1,4 +1,11 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Swap real scrypt (n=2^18, hundreds of ms/call) for a cheap deterministic KDF: this suite
+// exercises keystore *logic* over dozens of encrypt/decrypt cycles, not the KDF, which
+// crypto.test.ts covers against the real implementation. Production is untouched.
+vi.mock("@noble/hashes/scrypt.js", async () =>
+  import("../persistence/crypto/__test-support__/cheap-scrypt.js"),
+);
 import { mkdtempSync, readdirSync, renameSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";

--- a/ts/src/adapters/outbound/ledger/index.test.ts
+++ b/ts/src/adapters/outbound/ledger/index.test.ts
@@ -1,10 +1,15 @@
 import { describe, it, expect, vi } from "vitest";
+import { utils as tronUtils } from "tronweb";
 import { Ledger } from "./index.js";
 
 // The @ledgerhq transport/app modules are imported lazily inside the adapter, so hoisted vi.mock
 // applies. closeSpy stands in for the native HID handle: the real bug is that a timed-out device
 // call leaks this handle (it is never closed), pinning libuv so the process can't exit.
-const { closeSpy } = vi.hoisted(() => ({ closeSpy: vi.fn(async () => {}) }));
+const { closeSpy, tip712Calls, failures } = vi.hoisted(() => ({
+  closeSpy: vi.fn(async () => {}),
+  tip712Calls: [] as Array<{ path: string; domainHash: string; messageHash: string }>,
+  failures: { tip712: undefined as Error | undefined, tip712Hang: false },
+}));
 vi.mock("@ledgerhq/hw-transport-node-hid", () => ({
   default: { open: async () => ({ close: closeSpy }) },
 }));
@@ -23,11 +28,46 @@ vi.mock("@ledgerhq/hw-app-trx", () => ({
     async getAppConfiguration(): Promise<{ version: string }> {
       return new Promise(() => {});
     }
+    // Unlike the others this one resolves: the TIP-712 tests assert what reaches the device,
+    // which a never-settling promise cannot show.
+    async signTIP712HashedMessage(path: string, domainHash: string, messageHash: string): Promise<string> {
+      if (failures.tip712) throw failures.tip712;
+      if (failures.tip712Hang) return new Promise(() => {});
+      tip712Calls.push({ path, domainHash, messageHash });
+      return "aa".repeat(65);
+    }
   },
 }));
 
 const PATH = "m/44'/195'/0'/0/0";
-const RAW_TX = { raw_data_hex: "0a02" } as never;
+// Must be a self-consistent transaction: signTransaction now enforces payload integrity before
+// reaching the device, so a bare {raw_data_hex} stub would fail there instead of timing out.
+const RAW_TX = (() => {
+  const raw = {
+    contract: [{
+      parameter: {
+        value: {
+          amount: 1000000,
+          owner_address: "4119e7e376e7c213b7e7e7e46cc70a5dd086daff2a",
+          to_address: "41e552f6487585c2b58bc2c9bb4492bc1f17132cd0",
+        },
+        type_url: "type.googleapis.com/protocol.TransferContract",
+      },
+      type: "TransferContract",
+    }],
+    ref_block_bytes: "0a1b",
+    ref_block_hash: "c1e5f0a1d2b3c4d5",
+    expiration: 1753180800000,
+    timestamp: 1753180740000,
+  };
+  const shell = { visible: false, raw_data: raw, raw_data_hex: "", txID: "" };
+  const pb = tronUtils.transaction.txJsonToPb(shell as never);
+  return {
+    ...shell,
+    raw_data_hex: tronUtils.transaction.txPbToRawDataHex(pb).toLowerCase(),
+    txID: tronUtils.transaction.txPbToTxID(pb).replace(/^0x/, ""),
+  } as never;
+})();
 
 describe("Ledger adapter timeout", () => {
   it("bounds a hung device signMessage by timeoutMs", async () => {
@@ -58,5 +98,105 @@ describe("Ledger adapter timeout", () => {
     closeSpy.mockClear();
     await expect(new Ledger(20).appConfig("tron")).rejects.toMatchObject({ code: "timeout" });
     await vi.waitFor(() => expect(closeSpy).toHaveBeenCalled(), { timeout: 500 });
+  });
+});
+
+describe("Ledger transaction signing", () => {
+  // A Ledger account must not be the weaker signer: the device signs raw_data_hex, so the same
+  // integrity rules apply. Before this, `tx sign --account <ledger>` skipped the check entirely.
+  it("refuses a transaction whose txID does not hash its raw_data_hex, before reaching the device", async () => {
+    const tampered = { ...(RAW_TX as object), txID: "00".repeat(32) };
+    await expect(new Ledger(2000).signTransaction("tron", PATH, tampered as never)).rejects.toMatchObject({
+      code: "tx_integrity",
+    });
+  });
+});
+
+describe("Ledger abort signal", () => {
+  // The signal must do real work, not sit in the parameter list: an in-flight HID APDU is not
+  // self-cancelling, so the only way to release the device is to close the transport. Without
+  // this the handle stays open until the adapter's own (much longer) timeout expires.
+  it("closes the transport when the caller aborts a pending signMessage", async () => {
+    closeSpy.mockClear();
+    const ac = new AbortController();
+    // long adapter timeout: if the abort did nothing, this test would hang rather than pass early.
+    // capture the rejection before aborting: an unhandled window here is reported as a stray
+    // unhandled rejection even though the test later asserts on it.
+    const settled = new Ledger(60_000).signMessage("tron", PATH, "hi", ac.signal).catch((e) => e);
+    ac.abort();
+    await vi.waitFor(() => expect(closeSpy).toHaveBeenCalled(), { timeout: 1000 });
+    expect(await settled).toMatchObject({ code: "cancelled" });
+  });
+
+  it("closes the transport when the caller aborts a pending typed-data signature", async () => {
+    closeSpy.mockClear();
+    const ac = new AbortController();
+    failures.tip712Hang = true;
+    try {
+      const settled = new Ledger(60_000)
+        .signTypedData(
+          "tron",
+          PATH,
+          { domain: { name: "X", version: "1", chainId: 1 }, types: { A: [{ name: "x", type: "uint256" }] }, message: { x: "1" } },
+          ac.signal,
+        )
+        .catch((e) => e);
+      ac.abort();
+      await vi.waitFor(() => expect(closeSpy).toHaveBeenCalled(), { timeout: 1000 });
+      expect(await settled).toMatchObject({ code: "cancelled" });
+    } finally {
+      failures.tip712Hang = false;
+    }
+  });
+});
+
+describe("Ledger app-setting errors", () => {
+  // Verified against Speculos running the real TRON app 0.7.6: with "Sign by Hash" disabled (its
+  // default) the device answers 0x6a8c, which otherwise surfaces as "UNKNOWN_ERROR (0x6a8c)" and
+  // leaves the user with no idea the fix is a toggle in the app's own settings menu.
+  it("maps a missing app setting to an actionable error", async () => {
+    const apdu = Object.assign(new Error("Ledger device: UNKNOWN_ERROR (0x6a8c)"), { statusCode: 0x6a8c });
+    failures.tip712 = apdu;
+    try {
+      await expect(
+        new Ledger(2000).signTypedData("tron", PATH, {
+          domain: { name: "X", version: "1", chainId: 1 },
+          types: { A: [{ name: "x", type: "uint256" }] },
+          message: { x: "1" },
+        }),
+      ).rejects.toMatchObject({ code: "ledger_setting_required", message: /Sign by Hash/ });
+    } finally {
+      failures.tip712 = undefined;
+    }
+  });
+});
+
+describe("Ledger TIP-712", () => {
+  const domain = { name: "SunPerp", version: "1", chainId: 728126428 };
+  const types = { Order: [{ name: "trader", type: "address" }, { name: "size", type: "uint256" }] };
+  const message = { trader: "TCLBgkbfVkJroVBJVqBEsxtPNQEQMTQCLQ", size: "1000000" };
+  const encoder = tronUtils.typedData.TypedDataEncoder;
+
+  it("sends the locally computed domain and struct hashes to the device", async () => {
+    tip712Calls.length = 0;
+    const out = await new Ledger(2000).signTypedData("tron", PATH, { domain, types, message });
+
+    expect(tip712Calls).toHaveLength(1);
+    // hw-app-trx wants the path without the leading "m/"; its hexBuffer accepts bare hex.
+    expect(tip712Calls[0]!.path).toBe("44'/195'/0'/0/0");
+    expect(tip712Calls[0]!.domainHash).toBe(encoder.hashDomain(domain).replace(/^0x/, ""));
+    expect(tip712Calls[0]!.messageHash).toBe(encoder.hashStruct("Order", types, message).replace(/^0x/, ""));
+    // the app returns bare 65-byte hex; the adapter 0x-prefixes it like signPersonalMessage does.
+    expect(out.signature).toBe(`0x${"aa".repeat(65)}`);
+    expect(out.primaryType).toBe("Order");
+    expect(out.digest).toBe(encoder.hash(domain, types, message));
+  });
+
+  it("rejects a payload that cannot be hashed before touching the device", async () => {
+    tip712Calls.length = 0;
+    await expect(
+      new Ledger(2000).signTypedData("tron", PATH, { domain, types, message: { trader: "nope", size: "1" } }),
+    ).rejects.toMatchObject({ code: "invalid_transaction" });
+    expect(tip712Calls).toHaveLength(0);
   });
 });

--- a/ts/src/adapters/outbound/ledger/index.test.ts
+++ b/ts/src/adapters/outbound/ledger/index.test.ts
@@ -171,6 +171,33 @@ describe("Ledger app-setting errors", () => {
   });
 });
 
+describe("Ledger unsupported instruction (0x6d00)", () => {
+  // 0x6d00 (INS_NOT_SUPPORTED) is a standard Ledger/ISO status word shared by every app, not
+  // TRON-specific: the installed app version does not implement the instruction, or the wrong app is
+  // open. It must map to a generic hint, not the opaque "auth_required / …(0x6d00)".
+  it("maps INS_NOT_SUPPORTED to a generic, chain-agnostic ledger_unsupported error", async () => {
+    const apdu = Object.assign(new Error("Ledger device: INS_NOT_SUPPORTED (0x6d00)"), { statusCode: 0x6d00 });
+    failures.tip712 = apdu;
+    let err: unknown;
+    try {
+      await new Ledger(2000).signTypedData("tron", PATH, {
+        domain: { name: "X", version: "1", chainId: 1 },
+        types: { A: [{ name: "x", type: "uint256" }] },
+        message: { x: "1" },
+      });
+    } catch (e) {
+      err = e;
+    } finally {
+      failures.tip712 = undefined;
+    }
+    const m = err as { code?: string; message: string };
+    expect(m.code).toBe("ledger_unsupported");
+    expect(m.message).toMatch(/does not support this operation/i);
+    // The message must not leak a chain or operation name — it fires for any app and any call.
+    expect(m.message).not.toMatch(/tip-?712|tron|typed[- ]?data|eip-?712/i);
+  });
+});
+
 describe("Ledger TIP-712", () => {
   const domain = { name: "SunPerp", version: "1", chainId: 728126428 };
   const types = { Order: [{ name: "trader", type: "address" }, { name: "size", type: "uint256" }] };

--- a/ts/src/adapters/outbound/ledger/index.ts
+++ b/ts/src/adapters/outbound/ledger/index.ts
@@ -12,14 +12,16 @@
  *
  * This module never prints; callers print waiting prompts via StreamManager.
  */
-import type { SignedTx, UnsignedTx } from "../../../domain/types/index.js";
+import { utils as tronUtils } from "tronweb";
+import { assertTronTxIntegrity } from "../chain/tron/tx-integrity.js";
+import type { SignedTx, TypedDataPayload, TypedDataSignature, UnsignedTx } from "../../../domain/types/index.js";
 
 /** a Ledger app's reported version + readiness (returned by `appConfig`). */
 export interface AppConfig {
   version: string;
   ready: boolean;
 }
-import { ChainError, CliError, ExecutionError } from "../../../domain/errors/index.js";
+import { ChainError, CliError, ExecutionError, WalletError } from "../../../domain/errors/index.js";
 import { ChainFamily, FAMILIES } from "../../../domain/family/index.js";
 import { withTimeout } from "../../../domain/async/index.js";
 
@@ -35,6 +37,7 @@ interface TrxApp {
   getAppConfiguration(): Promise<{ version: string }>;
   signTransaction(path: string, rawTxHex: string, tokenSignatures: string[]): Promise<string>;
   signPersonalMessage(path: string, messageHex: string): Promise<string>;
+  signTIP712HashedMessage?(path: string, domainSeparatorHex: string, hashStructMessageHex: string): Promise<string>;
 }
 
 /** hw-app-trx wants a BIP32 path WITHOUT the leading "m/" (e.g. 44'/195'/0'/0/0). */
@@ -67,12 +70,26 @@ function errMessage(e: unknown): string {
   return e instanceof Error ? e.message : String(e);
 }
 
+/** TRON app settings that gate a whole class of signing, each surfaced as its own APDU status.
+ *  Without this mapping they arrive as an opaque "UNKNOWN_ERROR (0x6a8c)" and the user has no way
+ *  to know the fix is a toggle in the app's own settings menu. */
+const APP_SETTING_REQUIRED: Record<number, string> = {
+  // E_MISSING_SETTING_SIGN_BY_HASH — gates TIP-712 typed data and any hash-only signing.
+  0x6a8c: 'enable "Sign by Hash" in the Ledger TRON app settings (Settings › Sign by Hash › Allowed)',
+  // E_MISSING_SETTING_DATA_ALLOWED — gates transactions carrying extra data.
+  0x6a8b: 'enable "Transactions data" in the Ledger TRON app settings to sign a transaction with extra data',
+  // E_MISSING_SETTING_CUSTOM_CONTRACT — gates contracts the app cannot decode.
+  0x6a8d: 'enable "Custom contracts" in the Ledger TRON app settings to sign this contract call',
+};
+
 /** Map a thrown device/app error to a typed CliError (user-rejection vs not-ready). */
 function classifyDeviceError(e: unknown): CliError {
   if (e instanceof CliError) return e;
   // hw-transport surfaces APDU status as statusCode; 0x6985 = user declined on the device.
   const status = (e as { statusCode?: number }).statusCode;
   if (status === 0x6985) return new ChainError("signing_rejected", "the operation was rejected on the device");
+  const setting = status === undefined ? undefined : APP_SETTING_REQUIRED[status];
+  if (setting) return new WalletError("ledger_setting_required", setting);
   return new ExecutionError("auth_required", `Ledger device error: ${errMessage(e)}`);
 }
 
@@ -95,8 +112,20 @@ export class Ledger {
   // handle leaks, pins libuv, and the process hangs after a timeout — breaking the deterministic-exit
   // contract. close() may run twice (here and in the finally); both swallow errors so double-close is
   // harmless.
-  #bound<T>(fn: (trx: TrxApp) => Promise<T>): Promise<T> {
+  //
+  // An optional `signal` gives callers the same lever the timeout uses: aborting closes the
+  // transport, which rejects the pending APDU and frees the native handle immediately instead of
+  // leaving it open until this method's own timeout expires.
+  #bound<T>(fn: (trx: TrxApp) => Promise<T>, signal?: AbortSignal): Promise<T> {
     let handle: { transport: unknown; close: () => Promise<void> } | undefined;
+    // `cancelled` matters because the abort can land before openTransport() resolves: at that
+    // moment there is no handle to close, and a fire-once listener will not run again. Recording
+    // it lets the opener close the transport it is about to receive instead of leaking it.
+    let cancelled = false;
+    const closeTransport = (): void => {
+      cancelled = true;
+      handle?.close().catch(() => {});
+    };
     const run = (async () => {
       const Trx = unwrap<new (transport: unknown) => TrxApp>(await import("@ledgerhq/hw-app-trx"));
       try {
@@ -105,14 +134,22 @@ export class Ledger {
         // no device / emulator reachable — the pipeline treats this as "device not ready".
         throw new ExecutionError("auth_required", `cannot reach Ledger device: ${errMessage(e)}`);
       }
+      if (cancelled) {
+        await handle.close().catch(() => {});
+        throw new ChainError("cancelled", "the Ledger operation was cancelled before it reached the device");
+      }
       try {
         return await fn(new Trx(handle.transport));
       } finally {
         await handle.close().catch(() => {});
       }
     })();
-    return withTimeout(run, this.timeoutMs, () => {
-      handle?.close().catch(() => {});
+    if (signal) {
+      if (signal.aborted) closeTransport();
+      else signal.addEventListener("abort", closeTransport, { once: true });
+    }
+    return withTimeout(run, this.timeoutMs, closeTransport).finally(() => {
+      signal?.removeEventListener("abort", closeTransport);
     });
   }
 
@@ -126,25 +163,68 @@ export class Ledger {
     }
   }
 
-  async signTransaction(family: ChainFamily, path: string, tx: UnsignedTx, _signal?: AbortSignal): Promise<SignedTx> {
+  async signTransaction(family: ChainFamily, path: string, tx: UnsignedTx, signal?: AbortSignal): Promise<SignedTx> {
     this.assertWired(family);
+    // The device signs raw_data_hex, so the same integrity rules the software strategy enforces
+    // apply here — a Ledger account must not be the weaker signer. See tx-integrity.ts.
+    if (family === "tron") assertTronTxIntegrity(tx);
     const rawTxHex = (tx as { raw_data_hex?: string }).raw_data_hex;
     if (!rawTxHex) throw new ChainError("invalid_transaction", "TRON transaction is missing raw_data_hex for Ledger signing");
+    // TRON multi-sig collects several signatures on one transaction, so an existing signature[]
+    // must be preserved and appended to — matching the software path (tronweb pushes).
+    const existing = (tx as { signature?: unknown }).signature;
+    const prior = Array.isArray(existing) ? existing : [];
     try {
       return await this.#bound(async (trx) => {
         const signature = await trx.signTransaction(ledgerPath(path), rawTxHex, []);
-        return { ...(tx as object), signature: [signature] };
-      });
+        return { ...(tx as object), signature: prior.includes(signature) ? prior : [...prior, signature] };
+      }, signal);
     } catch (e) {
       throw classifyDeviceError(e);
     }
   }
 
-  async signMessage(family: ChainFamily, path: string, message: string): Promise<string> {
+  async signMessage(family: ChainFamily, path: string, message: string, signal?: AbortSignal): Promise<string> {
     this.assertWired(family);
     const messageHex = Buffer.from(message, "utf8").toString("hex");
     try {
-      return await this.#bound(async (trx) => `0x${await trx.signPersonalMessage(ledgerPath(path), messageHex)}`);
+      return await this.#bound(async (trx) => `0x${await trx.signPersonalMessage(ledgerPath(path), messageHex)}`, signal);
+    } catch (e) {
+      throw classifyDeviceError(e);
+    }
+  }
+
+  /**
+   * TIP-712 structured-data signing. The TRON app exposes only the *hashed* variant, so the two
+   * EIP-712 hashes are computed here — in the adapter, where the SDK dependency already lives —
+   * and the device can display only those hashes, not the message. The port deliberately takes the
+   * whole payload rather than pre-computed hashes: the Ethereum app also offers a full
+   * clear-signing APDU, and a hash-shaped port would lock a future EVM adapter out of it.
+   */
+  async signTypedData(family: ChainFamily, path: string, payload: TypedDataPayload, signal?: AbortSignal): Promise<TypedDataSignature> {
+    this.assertWired(family);
+    const { domain, types, message } = payload;
+    let digest: string;
+    let primaryType: string;
+    let domainHash: string;
+    let messageHash: string;
+    try {
+      const encoder = tronUtils.typedData.TypedDataEncoder;
+      primaryType = payload.primaryType ?? encoder.from(types as never).primaryType;
+      digest = encoder.hash(domain as never, types as never, message);
+      domainHash = encoder.hashDomain(domain as never).replace(/^0x/, "");
+      messageHash = encoder.hashStruct(primaryType, types as never, message).replace(/^0x/, "");
+    } catch (e) {
+      throw new ChainError("invalid_transaction", `typed data could not be hashed: ${errMessage(e)}`);
+    }
+    try {
+      return await this.#bound(async (trx) => {
+        if (typeof trx.signTIP712HashedMessage !== "function") {
+          throw new WalletError("ledger_unsupported", "this Ledger TRON app version cannot sign TIP-712 typed data; update the app");
+        }
+        const signature = await trx.signTIP712HashedMessage(ledgerPath(path), domainHash, messageHash);
+        return { signature: `0x${signature}`, digest, primaryType };
+      }, signal);
     } catch (e) {
       throw classifyDeviceError(e);
     }

--- a/ts/src/adapters/outbound/ledger/index.ts
+++ b/ts/src/adapters/outbound/ledger/index.ts
@@ -88,6 +88,15 @@ function classifyDeviceError(e: unknown): CliError {
   // hw-transport surfaces APDU status as statusCode; 0x6985 = user declined on the device.
   const status = (e as { statusCode?: number }).statusCode;
   if (status === 0x6985) return new ChainError("signing_rejected", "the operation was rejected on the device");
+  // 0x6d00 (INS_NOT_SUPPORTED) is a standard status word every Ledger app shares — the app version
+  // does not implement this instruction, or the wrong app is open. Kept chain- and operation-agnostic
+  // on purpose: classifyDeviceError fires for any family and any call.
+  if (status === 0x6d00) {
+    return new WalletError(
+      "ledger_unsupported",
+      "the Ledger app does not support this operation — make sure the correct app is open on the device and updated to its latest version",
+    );
+  }
   const setting = status === undefined ? undefined : APP_SETTING_REQUIRED[status];
   if (setting) return new WalletError("ledger_setting_required", setting);
   return new ExecutionError("auth_required", `Ledger device error: ${errMessage(e)}`);

--- a/ts/src/adapters/outbound/persistence/crypto/__test-support__/cheap-scrypt.ts
+++ b/ts/src/adapters/outbound/persistence/crypto/__test-support__/cheap-scrypt.ts
@@ -1,0 +1,24 @@
+/**
+ * Test double for @noble/hashes/scrypt — imported ONLY from *.test.ts via vi.mock, never by
+ * production code. Real scrypt at n=2^18 is deliberately slow (hundreds of ms per call); a suite
+ * that encrypts/decrypts dozens of keystores spends a minute in key derivation it does not need to
+ * exercise. Correctness of the KDF itself is covered separately by crypto.test.ts against the real
+ * implementation.
+ *
+ * The substitute must behave like a KDF for the surrounding logic to hold:
+ *  - deterministic in (password, salt) so encrypt→decrypt round-trips (it ignores N/r/p);
+ *  - different key for a different password so a wrong-password MAC check still fails.
+ * keccak256(password || salt) gives exactly dkLen = 32 bytes with both properties.
+ */
+import { keccak_256 } from "@noble/hashes/sha3.js";
+import { concatBytes, utf8ToBytes } from "@noble/hashes/utils.js";
+import type { Bytes } from "../../../../../domain/types/index.js";
+
+export function scrypt(password: Bytes | string, salt: Bytes, opts: { dkLen: number }): Bytes {
+  const pw = typeof password === "string" ? utf8ToBytes(password) : password;
+  const key = keccak_256(concatBytes(pw, salt));
+  if (opts.dkLen === key.length) return key;
+  // every keystore blob uses dkLen 32 (= keccak output); guard the assumption loudly rather than
+  // silently return a wrong-length key.
+  throw new Error(`cheap-scrypt only supports dkLen 32, got ${opts.dkLen}`);
+}

--- a/ts/src/application/contracts/execution-policy.ts
+++ b/ts/src/application/contracts/execution-policy.ts
@@ -1,6 +1,11 @@
 import type { ChainFamily } from "../../domain/types/index.js";
 
-export type NetworkRequirement = "none" | "optional" | "required";
+/** "none" = the command never touches a chain; "optional" = it resolves a network,
+ *  using --network when given and config.defaultNetwork otherwise. There is deliberately
+ *  no "required": nothing in the CLI can demand an explicit --network, because the
+ *  default-network fallback always applies. A third value that resolved identically only
+ *  ever produced a help line promising an enforcement that did not exist. */
+export type NetworkRequirement = "none" | "optional";
 export type WalletRequirement = "none" | "optional";
 
 /** Minimal application policy needed to resolve and gate an execution target. */

--- a/ts/src/application/ports/ledger-device.ts
+++ b/ts/src/application/ports/ledger-device.ts
@@ -1,4 +1,4 @@
-import type { ChainFamily, SignedTx, UnsignedTx } from "../../domain/types/index.js";
+import type { ChainFamily, SignedTx, TypedDataPayload, TypedDataSignature, UnsignedTx } from "../../domain/types/index.js";
 
 export interface LedgerAppState {
   version: string;
@@ -18,7 +18,11 @@ export interface LedgerDevice {
     transaction: UnsignedTx,
     signal?: AbortSignal,
   ): Promise<SignedTx>;
-  signMessage(family: ChainFamily, path: string, message: string): Promise<string>;
+  signMessage(family: ChainFamily, path: string, message: string, signal?: AbortSignal): Promise<string>;
+  /** structured-data signing. Takes the whole payload, not pre-computed hashes: the TRON app can
+   *  only sign the hashed form, but the Ethereum app also offers full clear-signing — a
+   *  hash-shaped port would lock a future EVM adapter out of it. */
+  signTypedData(family: ChainFamily, path: string, payload: TypedDataPayload, signal?: AbortSignal): Promise<TypedDataSignature>;
   appConfig(family: ChainFamily): Promise<LedgerAppState>;
 }
 

--- a/ts/src/application/services/pipeline/index.ts
+++ b/ts/src/application/services/pipeline/index.ts
@@ -8,7 +8,7 @@ import type { AccountRef, ChainFamily, FeeReport, NetworkDescriptor, SignedTx, T
 import type { TransactionScope } from "../../contracts/execution-scope.js";
 import { SignerResolver } from "../signer/index.js";
 import { UsageError } from "../../../domain/errors/index.js";
-import { withTimeout } from "../../../domain/async/index.js";
+import { obtainSignature } from "../signing/obtain-signature.js";
 import type { Broadcaster } from "../../ports/chain/broadcaster.js";
 
 export interface TxPipelineParams {
@@ -36,8 +36,24 @@ export class TxPipeline {
     this.signers.assertCanSign(account, family, opts);
   }
 
+  /**
+   * Sign a transaction the caller built elsewhere. Shares signer resolution and the device
+   * preliminaries with `run`, but has no build/estimate/broadcast phase — there is nothing to estimate
+   * for a transaction we did not construct, and nothing to broadcast here.
+   */
+  async signOnly(p: {
+    ctx: TransactionScope;
+    net: NetworkDescriptor;
+    account: AccountRef;
+    tx: UnsignedTx;
+  }): Promise<TxOutcome> {
+    this.assertCanSign(p.account, p.net.family);
+    const signer = this.signers.resolve(p.account, p.net.family);
+    const signed = await obtainSignature(signer, p.ctx, (opts) => signer.sign(p.tx, opts));
+    return { stage: "signed", signed, address: signer.address, txId: txIdOf(signed) };
+  }
+
   async run(p: TxPipelineParams): Promise<TxOutcome> {
-    const { timeoutMs } = p.ctx;
     // --wait only makes sense when we actually broadcast (dry-run/sign-only never reach the chain).
     if (p.ctx.wait && !p.broadcast) {
       throw new UsageError("invalid_option", "--wait has nothing to wait for with --dry-run/--sign-only (neither broadcasts)");
@@ -45,23 +61,15 @@ export class TxPipeline {
     const signer = this.signers.resolve(p.account, p.net.family);
 
     // RPC steps (build/estimate/broadcast) are bounded by the adapter's own --timeout, so they
-    // aren't wrapped here. The one thing no RPC timeout covers is a Ledger tap that never comes:
-    // bound the device signature and abort its prompt on timeout.
+    // aren't wrapped here. The one thing no RPC timeout covers is a Ledger tap that never comes;
+    // obtainSignature bounds the device signature and aborts its prompt on timeout.
     const tx = await p.build(signer.address);
     const fee = await p.estimate(tx);
     if (p.dryRun) return { stage: "plan", tx, fee };
 
-    let signed: SignedTx;
-    if (signer.kind === "device") {
-      await signer.precheck?.();
-      p.ctx.emit({ type: "awaiting_device", reason: "sign" });
-      const ac = new AbortController();
-      signed = await withTimeout(signer.sign(tx, { signal: ac.signal }), timeoutMs, () => ac.abort());
-    } else {
-      signed = await signer.sign(tx, {});
-    }
+    const signed = await obtainSignature(signer, p.ctx, (opts) => signer.sign(tx, opts));
 
-    if (!p.broadcast) return { stage: "signed", signed, fee };
+    if (!p.broadcast) return { stage: "signed", signed, fee, address: signer.address, txId: txIdOf(signed) };
     const result = await p.broadcaster.broadcast(signed);
     const txId = String(result.txId ?? result.hash ?? "");
     // default (no --wait): non-blocking, return the submitted txid only (fee/energy unknown yet).
@@ -89,4 +97,11 @@ export class TxPipeline {
     }
     return { stage: confirmed.failed ? "failed" : "confirmed", ...result, ...confirmed };
   }
+}
+
+/** best-effort transaction id of a signed tx, for the sign-only receipt (TRON: txID). */
+function txIdOf(signed: SignedTx): string | undefined {
+  const s = signed as { txID?: unknown; hash?: unknown } | null;
+  const id = s?.txID ?? s?.hash;
+  return typeof id === "string" ? id : undefined;
 }

--- a/ts/src/application/services/pipeline/pipeline.test.ts
+++ b/ts/src/application/services/pipeline/pipeline.test.ts
@@ -45,6 +45,7 @@ describe("TxPipeline device-sign timeout", () => {
         return new Promise(() => {});
       },
       signMessage: async () => "",
+      signTypedData: async () => ({ signature: "", digest: "", primaryType: "" }),
     };
     const signers = { resolve: () => signer } as unknown as SignerResolver;
 

--- a/ts/src/application/services/pipeline/sign-only.test.ts
+++ b/ts/src/application/services/pipeline/sign-only.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { TxPipeline } from "./index.js";
+import type { SignerResolver } from "../signer/index.js";
+import type { Signer } from "../../../domain/types/index.js";
+
+const TX = { txID: "abc", raw_data: {}, raw_data_hex: "0a02" };
+
+function pipelineWith(signer: Partial<Signer>, assertCanSign = () => {}) {
+  const resolver = { assertCanSign, resolve: () => signer as Signer } as unknown as SignerResolver;
+  return new TxPipeline(resolver);
+}
+
+const scope = {
+  timeoutMs: 100,
+  wait: false,
+  waitTimeoutMs: 0,
+  activeAccount: "main",
+  resolveAddress: () => "T1",
+  emit: () => {},
+  warn: () => {},
+} as never;
+const net = { family: "tron", id: "nile" } as never;
+
+describe("TxPipeline.signOnly", () => {
+  it("signs a caller-supplied transaction without building, estimating or broadcasting", async () => {
+    const p = pipelineWith({
+      kind: "software",
+      address: "TSignerAddress",
+      sign: async (tx) => ({ ...(tx as object), signature: ["deadbeef"] }),
+    });
+    const outcome = await p.signOnly({ ctx: scope, net, account: "main", tx: TX });
+    expect(outcome).toMatchObject({
+      stage: "signed",
+      address: "TSignerAddress",
+      txId: "abc",
+      signed: { txID: "abc", signature: ["deadbeef"] },
+    });
+    // nothing was estimated, so no fee is invented
+    expect((outcome as { fee?: unknown }).fee).toBeUndefined();
+  });
+
+  it("runs the device preliminaries for a Ledger signer", async () => {
+    const events: unknown[] = [];
+    const p = pipelineWith({
+      kind: "device",
+      address: "TLedger",
+      precheck: async () => {},
+      sign: async (tx) => ({ ...(tx as object), signature: ["beef"] }),
+    });
+    const ctx = { ...(scope as object), emit: (e: unknown) => events.push(e) } as never;
+    await p.signOnly({ ctx, net, account: "main", tx: TX });
+    expect(events).toEqual([{ type: "awaiting_device", reason: "sign" }]);
+  });
+
+  // A watch-only account must fail before any signing work, same as every write command.
+  it("refuses an account that cannot sign", async () => {
+    const p = pipelineWith({ kind: "software", address: "T1", sign: async () => ({}) }, () => {
+      throw new Error("watch-only");
+    });
+    await expect(p.signOnly({ ctx: scope, net, account: "main", tx: TX })).rejects.toThrow(/watch-only/);
+  });
+});

--- a/ts/src/application/services/signer/ledger.ts
+++ b/ts/src/application/services/signer/ledger.ts
@@ -4,7 +4,7 @@
  * detail stays inside the injected `Ledger` (path/hex encoding, @ledgerhq, hw-app-trx).
  */
 import type { ChainFamily } from "../../../domain/family/index.js";
-import type { SignedTx, Signer, SignerSignOpts, UnsignedTx } from "../../../domain/types/index.js";
+import type { SignedTx, Signer, SignerSignOpts, TypedDataPayload, TypedDataSignature, UnsignedTx } from "../../../domain/types/index.js";
 import { ExecutionError, WalletError } from "../../../domain/errors/index.js";
 import type { LedgerDevice } from "../../ports/ledger-device.js";
 
@@ -32,7 +32,10 @@ export class LedgerSigner implements Signer {
   async sign(tx: UnsignedTx, opts: SignerSignOpts): Promise<SignedTx> {
     return this.ledger.signTransaction(this.family, this.path, tx, opts.signal);
   }
-  async signMessage(message: string, _opts: SignerSignOpts): Promise<string> {
-    return this.ledger.signMessage(this.family, this.path, message);
+  async signMessage(message: string, opts: SignerSignOpts): Promise<string> {
+    return this.ledger.signMessage(this.family, this.path, message, opts.signal);
+  }
+  async signTypedData(payload: TypedDataPayload, opts: SignerSignOpts): Promise<TypedDataSignature> {
+    return this.ledger.signTypedData(this.family, this.path, payload, opts.signal);
   }
 }

--- a/ts/src/application/services/signer/resolver.test.ts
+++ b/ts/src/application/services/signer/resolver.test.ts
@@ -1,4 +1,9 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Cheap KDF for keystore encryption in this suite — see cheap-scrypt.ts. Production untouched.
+vi.mock("@noble/hashes/scrypt.js", async () =>
+  import("../../../adapters/outbound/persistence/crypto/__test-support__/cheap-scrypt.js"),
+);
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";

--- a/ts/src/application/services/signer/software.ts
+++ b/ts/src/application/services/signer/software.ts
@@ -4,7 +4,7 @@
  * through dependency injection, so this class has no `if family` branch.
  */
 import { bytesToHex } from "@noble/hashes/utils.js";
-import type { Bytes, SignedTx, Signer, SignerSignOpts, SignStrategy, UnsignedTx } from "../../../domain/types/index.js";
+import type { Bytes, SignedTx, Signer, SignerSignOpts, SignStrategy, TypedDataPayload, TypedDataSignature, UnsignedTx } from "../../../domain/types/index.js";
 
 export class SoftwareSigner implements Signer {
   readonly kind = "software" as const;
@@ -28,5 +28,9 @@ export class SoftwareSigner implements Signer {
 
   async signMessage(message: string, _opts: SignerSignOpts): Promise<string> {
     return this.strategy.signMessage(this.#pk(), message);
+  }
+
+  async signTypedData(payload: TypedDataPayload, _opts: SignerSignOpts): Promise<TypedDataSignature> {
+    return this.strategy.signTypedData(this.#pk(), payload);
   }
 }

--- a/ts/src/application/services/signing/obtain-signature.test.ts
+++ b/ts/src/application/services/signing/obtain-signature.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from "vitest";
+import { obtainSignature } from "./obtain-signature.js";
+import type { Signer } from "../../../domain/types/index.js";
+
+const scope = () => ({
+  timeoutMs: 50,
+  emitted: [] as unknown[],
+  emit(e: unknown) {
+    this.emitted.push(e);
+  },
+});
+
+const softwareSigner = { kind: "software", address: "T1" } as unknown as Signer;
+
+describe("obtainSignature", () => {
+  it("runs a software signer directly with no device event", async () => {
+    const s = scope();
+    const out = await obtainSignature(softwareSigner, s, async () => "sig");
+    expect(out).toBe("sig");
+    expect(s.emitted).toEqual([]);
+  });
+
+  it("prechecks and announces the device before a device signature", async () => {
+    const precheck = vi.fn(async () => {});
+    const device = { kind: "device", address: "T1", precheck } as unknown as Signer;
+    const s = scope();
+    const out = await obtainSignature(device, s, async () => "sig");
+    expect(precheck).toHaveBeenCalledOnce();
+    expect(s.emitted).toEqual([{ type: "awaiting_device", reason: "sign" }]);
+    expect(out).toBe("sig");
+  });
+
+  // A device prompt that is never tapped must not hang the CLI, and must abort the pending APDU.
+  it("bounds a hung device signature and aborts it", async () => {
+    const device = { kind: "device", address: "T1", precheck: async () => {} } as unknown as Signer;
+    const s = scope();
+    let aborted = false;
+    await expect(
+      obtainSignature(device, s, (opts) =>
+        new Promise((_res, rej) => {
+          opts.signal?.addEventListener("abort", () => {
+            aborted = true;
+            rej(new Error("aborted"));
+          });
+        }),
+      ),
+    ).rejects.toMatchObject({ code: "timeout" });
+    expect(aborted).toBe(true);
+  });
+
+  // A failing precheck (wrong seed / locked device) must surface before anything is signed.
+  it("propagates a precheck failure without signing", async () => {
+    const produce = vi.fn(async () => "sig");
+    const device = {
+      kind: "device",
+      address: "T1",
+      precheck: async () => {
+        throw new Error("wrong device");
+      },
+    } as unknown as Signer;
+    await expect(obtainSignature(device, scope(), produce)).rejects.toThrow(/wrong device/);
+    expect(produce).not.toHaveBeenCalled();
+  });
+});

--- a/ts/src/application/services/signing/obtain-signature.ts
+++ b/ts/src/application/services/signing/obtain-signature.ts
@@ -1,0 +1,34 @@
+/**
+ * obtainSignature — the one place that knows how a signature is *obtained*, as opposed to what is
+ * being signed. Callers hand over a signer and what they want signed; the preliminaries are this
+ * module's problem.
+ *
+ * Device signers must be prechecked (is this still the right seed?), announced (`awaiting_device`,
+ * so the CLI can print a prompt) and bounded (an un-tapped on-device prompt must not hang the
+ * process — aborting closes the transport and rejects the pending APDU). Software signers need
+ * none of that and pass straight through.
+ *
+ * Every signing path funnels through here — transactions (TxPipeline), messages (MessageService),
+ * typed data (TypedDataService) — so that per-signer-kind branch exists once, not at four call
+ * sites.
+ */
+import type { Signer, SignerSignOpts } from "../../../domain/types/index.js";
+import { withTimeout } from "../../../domain/async/index.js";
+
+/** the slice of TransactionScope this needs; keeps it usable from any scope. */
+export interface SigningScope {
+  readonly timeoutMs: number;
+  emit(event: { type: "awaiting_device"; reason: "sign" }): void;
+}
+
+export async function obtainSignature<T>(
+  signer: Signer,
+  scope: SigningScope,
+  produce: (opts: SignerSignOpts) => Promise<T>,
+): Promise<T> {
+  if (signer.kind !== "device") return produce({});
+  await signer.precheck?.();
+  scope.emit({ type: "awaiting_device", reason: "sign" });
+  const ac = new AbortController();
+  return withTimeout(produce({ signal: ac.signal }), scope.timeoutMs, () => ac.abort());
+}

--- a/ts/src/application/services/transaction-mode.ts
+++ b/ts/src/application/services/transaction-mode.ts
@@ -21,7 +21,15 @@ export function transactionMode(input: TransactionModeInput): {
 export function outcomeData(outcome: TxOutcome): Record<string, unknown> {
   if (outcome.stage === "plan") return { mode: "dry-run", fee: outcome.fee, tx: outcome.tx };
   if (outcome.stage === "signed") {
-    return { mode: "sign-only", signed: outcome.signed, fee: outcome.fee };
+    // `fee` is absent when the caller supplied the transaction (tx sign): nothing was estimated.
+    // Omit rather than emit undefined — kv() drops empty rows and JSON stays additive.
+    return {
+      mode: "sign-only",
+      signed: outcome.signed,
+      ...(outcome.fee === undefined ? {} : { fee: outcome.fee }),
+      ...(outcome.address === undefined ? {} : { address: outcome.address }),
+      ...(outcome.txId === undefined ? {} : { txId: outcome.txId }),
+    };
   }
   return outcome as unknown as Record<string, unknown>;
 }

--- a/ts/src/application/use-cases/message-service.ts
+++ b/ts/src/application/use-cases/message-service.ts
@@ -1,24 +1,21 @@
 import type { AccountRef, ChainFamily } from "../../domain/types/index.js";
 import type { TransactionScope } from "../contracts/execution-scope.js";
 import type { SignerResolver } from "../services/signer/index.js";
+import { obtainSignature } from "../services/signing/obtain-signature.js";
 
 export class MessageService {
   constructor(private readonly signers: SignerResolver) {}
 
   async sign(scope: TransactionScope, family: ChainFamily, account: AccountRef, message: string) {
     const signer = this.signers.resolve(account, family);
-    // Device signers: verify the connected device still derives this account's cached address
-    // (wrong seed/passphrase → wrong_device_seed) before attributing a signature to it, and
-    // tell the user to approve the on-device prompt. Mirrors the transaction pipeline.
-    if (signer.kind === "device") {
-      await signer.precheck?.();
-      scope.emit({ type: "awaiting_device", reason: "sign" });
-    }
+    // obtainSignature handles the device preliminaries: verify the connected device still derives
+    // this account's cached address (wrong seed/passphrase → wrong_device_seed) before attributing
+    // a signature to it, prompt the user to approve on-device, and bound a prompt that is never
+    // tapped. Software signers pass straight through. Same path as the transaction pipeline.
     return {
       address: signer.address,
       message,
-      signature: await signer.signMessage(message, {}),
+      signature: await obtainSignature(signer, scope, (opts) => signer.signMessage(message, opts)),
     };
   }
 }
-

--- a/ts/src/application/use-cases/tron/stake-service.ts
+++ b/ts/src/application/use-cases/tron/stake-service.ts
@@ -1,5 +1,5 @@
 import type { NetworkDescriptor, TxReceiptKind, UnsignedTx } from "../../../domain/types/index.js";
-import { UsageError } from "../../../domain/errors/index.js";
+import { ChainError, UsageError } from "../../../domain/errors/index.js";
 import { toRpcCode, type Resource } from "../../../domain/resources/index.js";
 import type { AccountScope, TransactionScope } from "../../contracts/execution-scope.js";
 import type { ChainGatewayProvider } from "../../ports/chain/gateway-provider.js";
@@ -147,7 +147,15 @@ export class TronStakeService {
 
   withdraw(scope: TransactionScope, network: NetworkDescriptor, input: TransactionModeInput) {
     return this.transact("stake-withdraw", scope, network, input,
-      (gateway, owner) => gateway.buildWithdrawExpireUnfreeze(owner));
+      async (gateway, owner) => {
+        // WithdrawExpireUnfreeze with nothing withdrawable passes the node's broadcast-time checks
+        // but never confirms, leaving a phantom txid. Reject up front (dry-run too) — the amount is
+        // a cheap, authoritative query, unlike duplicating the node's full validation rules.
+        if (BigInt(await gateway.getCanWithdrawUnfreezeAmount(owner)) <= 0n) {
+          throw new ChainError("nothing_to_withdraw", "no expired unfrozen TRX available to withdraw");
+        }
+        return gateway.buildWithdrawExpireUnfreeze(owner);
+      });
   }
 
   cancelUnfreeze(scope: TransactionScope, network: NetworkDescriptor, input: TransactionModeInput) {

--- a/ts/src/application/use-cases/tron/stake-service.withdraw.test.ts
+++ b/ts/src/application/use-cases/tron/stake-service.withdraw.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from "vitest";
+import { TronStakeService } from "./stake-service.js";
+import type { ChainGatewayProvider } from "../../ports/chain/gateway-provider.js";
+import type { TxPipeline } from "../../services/pipeline/index.js";
+import type { NetworkDescriptor } from "../../../domain/types/index.js";
+
+const net = { id: "tron:nile", family: "tron", chainId: "nile", aliases: [], capabilities: [] } as NetworkDescriptor;
+const OWNER = "TQkDWJimyBEhkFcqEfCWNbb6tMDwmH1234";
+const scope = { activeAccount: {}, resolveAddress: () => OWNER } as never;
+
+// A pipeline stub that exercises the build callback (where the pre-flight guard lives) exactly as
+// the real pipeline does: build → return a submitted receipt.
+function stubPipeline() {
+  return {
+    assertCanSign: () => {},
+    run: async (p: { build: (owner: string) => Promise<unknown> }) => {
+      await p.build(OWNER);
+      return { stage: "submitted", txId: "0xdeadbeef" };
+    },
+  } as unknown as TxPipeline;
+}
+
+function svc(gateway: Record<string, unknown>) {
+  const gateways = { get: () => gateway } as unknown as ChainGatewayProvider;
+  return new TronStakeService(gateways, stubPipeline());
+}
+
+describe("TronStakeService.withdraw pre-flight", () => {
+  it("rejects with nothing_to_withdraw when there is no expired unfrozen TRX", async () => {
+    const buildWithdrawExpireUnfreeze = vi.fn();
+    const gateway = {
+      getCanWithdrawUnfreezeAmount: async () => "0",
+      buildWithdrawExpireUnfreeze,
+    };
+    await expect(svc(gateway).withdraw(scope, net, {})).rejects.toMatchObject({
+      code: "nothing_to_withdraw",
+    });
+    // never builds/broadcasts a doomed tx → no phantom txid.
+    expect(buildWithdrawExpireUnfreeze).not.toHaveBeenCalled();
+  });
+
+  it("proceeds to build the withdraw tx when there is a withdrawable amount", async () => {
+    const buildWithdrawExpireUnfreeze = vi.fn(async () => ({ txID: "tx" }));
+    const gateway = {
+      getCanWithdrawUnfreezeAmount: async () => "1000000",
+      buildWithdrawExpireUnfreeze,
+    };
+    const result = await svc(gateway).withdraw(scope, net, {});
+    expect(buildWithdrawExpireUnfreeze).toHaveBeenCalledWith(OWNER);
+    expect(result).toMatchObject({ kind: "stake-withdraw", txId: "0xdeadbeef" });
+  });
+});

--- a/ts/src/application/use-cases/tron/transaction-service.ts
+++ b/ts/src/application/use-cases/tron/transaction-service.ts
@@ -68,6 +68,21 @@ export class TronTransactionService {
     };
   }
 
+  /**
+   * Sign a transaction built elsewhere. Deliberately does not inspect ownership or contract type —
+   * the caller decides what to sign; the wallet holds the key, not the policy. Payload integrity
+   * (txID must hash raw_data_hex) is enforced by the TRON sign strategy.
+   */
+  async sign(scope: TransactionScope, network: NetworkDescriptor, tx: unknown) {
+    const outcome = await this.pipeline.signOnly({
+      ctx: scope,
+      net: network,
+      account: scope.activeAccount,
+      tx,
+    });
+    return { kind: "sign" as const, ...outcomeData(outcome) };
+  }
+
   async broadcast(scope: TransactionScope, network: NetworkDescriptor, signed: unknown) {
     const gateway = this.gateways.get(network, "tron");
     const result = await gateway.broadcast(signed);

--- a/ts/src/application/use-cases/typed-data-service.test.ts
+++ b/ts/src/application/use-cases/typed-data-service.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { TypedDataService } from "./typed-data-service.js";
+import type { SignerResolver } from "../services/signer/index.js";
+import type { Signer } from "../../domain/types/index.js";
+
+const PAYLOAD = {
+  domain: { name: "SunPerp", version: "1", chainId: 728126428 },
+  types: { Order: [{ name: "size", type: "uint256" }] },
+  message: { size: "1" },
+};
+
+function serviceWith(signer: Partial<Signer>, assertCanSign = () => {}) {
+  return new TypedDataService({ resolve: () => signer as Signer, assertCanSign } as unknown as SignerResolver);
+}
+
+const scope = () => ({
+  timeoutMs: 100,
+  warnings: [] as string[],
+  events: [] as unknown[],
+  emit(e: unknown) {
+    this.events.push(e);
+  },
+  warn(m: string) {
+    this.warnings.push(m);
+  },
+});
+
+const signing = {
+  kind: "software" as const,
+  address: "TSigner",
+  signTypedData: async () => ({ signature: "0xsig", digest: "0xdig", primaryType: "Order" }),
+};
+
+describe("TypedDataService", () => {
+  it("returns the signature with the signing address and echoed primaryType", async () => {
+    const s = scope();
+    const out = await serviceWith(signing).sign(s as never, "tron", "main", PAYLOAD);
+    expect(out).toEqual({ address: "TSigner", primaryType: "Order", digest: "0xdig", signature: "0xsig" });
+    expect(s.warnings).toEqual([]);
+  });
+
+
+
+  it("prechecks and announces a device signer", async () => {
+    const s = scope();
+    await serviceWith({
+      kind: "device",
+      address: "TLedger",
+      precheck: async () => {},
+      signTypedData: async () => ({ signature: "0xsig", digest: "0xdig", primaryType: "Order" }),
+    }).sign(s as never, "tron", "main", PAYLOAD);
+    expect(s.events).toEqual([{ type: "awaiting_device", reason: "sign" }]);
+  });
+
+  it("refuses an account that cannot sign", async () => {
+    const svc = serviceWith(signing, () => {
+      throw new Error("watch-only");
+    });
+    await expect(svc.sign(scope() as never, "tron", "main", PAYLOAD)).rejects.toThrow(/watch-only/);
+  });
+});

--- a/ts/src/application/use-cases/typed-data-service.ts
+++ b/ts/src/application/use-cases/typed-data-service.ts
@@ -1,0 +1,20 @@
+import type { AccountRef, ChainFamily, TypedDataPayload } from "../../domain/types/index.js";
+import type { TransactionScope } from "../contracts/execution-scope.js";
+import type { SignerResolver } from "../services/signer/index.js";
+import { obtainSignature } from "../services/signing/obtain-signature.js";
+
+/**
+ * TypedDataService — EIP-712 / TIP-712 signing. Sibling of MessageService: same shape, different
+ * payload. Hashing is family-specific and stays behind the signer (software strategy / device
+ * port); this service owns only the signing preliminaries and the response contract.
+ */
+export class TypedDataService {
+  constructor(private readonly signers: SignerResolver) {}
+
+  async sign(scope: TransactionScope, family: ChainFamily, account: AccountRef, payload: TypedDataPayload) {
+    this.signers.assertCanSign(account, family);
+    const signer = this.signers.resolve(account, family);
+    const result = await obtainSignature(signer, scope, (opts) => signer.signTypedData(payload, opts));
+    return { address: signer.address, ...result };
+  }
+}

--- a/ts/src/bootstrap/argv.ts
+++ b/ts/src/bootstrap/argv.ts
@@ -11,10 +11,20 @@ const {
   secretStdinFlags: SECRET_STDIN_FLAGS,
 } = globalTokenMaps();
 
+/** A value flag whose supplied value failed coercion — surfaced by the runner as invalid_value. */
+export interface InvalidGlobal {
+  flag: string;
+  value: string;
+  reason: string;
+}
+
 /** Pre-yargs scan needed to select output and secret channels before the CLI adapter is built. */
-export function parseGlobals(tokens: string[]): { globals: Globals; secretPaths: SecretPaths } {
+export function parseGlobals(
+  tokens: string[],
+): { globals: Globals; secretPaths: SecretPaths; invalid: InvalidGlobal[] } {
   const globals = { verbose: false } as Globals;
   const secretPaths: SecretPaths = {};
+  const invalid: InvalidGlobal[] = [];
   for (let i = 0; i < tokens.length; i++) {
     let token = tokens[i]!;
     let inlineValue: string | undefined;
@@ -28,7 +38,9 @@ export function parseGlobals(tokens: string[]): { globals: Globals; secretPaths:
     if (valueKey) {
       const value = inlineValue ?? tokens[++i];
       if (value !== undefined) {
-        (globals as unknown as Record<string, unknown>)[valueKey] = coerceGlobalValue(valueKey, value);
+        const coerced = coerceGlobalValue(valueKey, value);
+        if (coerced.ok) (globals as unknown as Record<string, unknown>)[valueKey] = coerced.value;
+        else invalid.push({ flag: token, value, reason: coerced.reason });
       }
       continue;
     }
@@ -42,7 +54,7 @@ export function parseGlobals(tokens: string[]): { globals: Globals; secretPaths:
     const booleanField = BOOLEAN_FLAGS[token];
     if (booleanField) (globals as unknown as Record<string, unknown>)[booleanField] = true;
   }
-  return { globals, secretPaths };
+  return { globals, secretPaths, invalid };
 }
 
 /** True when argv contains a command token rather than only global flags and their values. */

--- a/ts/src/bootstrap/families/tron.ts
+++ b/ts/src/bootstrap/families/tron.ts
@@ -26,6 +26,7 @@ import {
   tokenRemoveTronBinding,
 } from "../../adapters/inbound/cli/commands/token.js";
 import { messageSignSpec, messageSignBinding } from "../../adapters/inbound/cli/commands/shared.js";
+import { typedDataSignSpec, typedDataSignBinding } from "../../adapters/inbound/cli/commands/typed-data.js";
 import {
   txBroadcastSpec,
   txBroadcastTronBinding,
@@ -33,6 +34,8 @@ import {
   txInfoTronBinding,
   txSendSpec,
   txSendTronBinding,
+  txSignSpec,
+  txSignTronBinding,
   txStatusSpec,
   txStatusTronBinding,
 } from "../../adapters/inbound/cli/commands/tx.js";
@@ -73,6 +76,7 @@ import { TronRewardService } from "../../application/use-cases/tron/reward-servi
 import { TronChainService } from "../../application/use-cases/tron/chain-service.js";
 import { TronBlockService } from "../../application/use-cases/tron/block-service.js";
 import { MessageService } from "../../application/use-cases/message-service.js";
+import { TypedDataService } from "../../application/use-cases/typed-data-service.js";
 import type { ChainGatewayProvider } from "../../application/ports/chain/gateway-provider.js";
 import type { TokenRepository } from "../../application/ports/token-repository.js";
 import type { PriceProvider } from "../../application/ports/price-provider.js";
@@ -104,6 +108,7 @@ export function registerTronChainCommands(reg: CommandRegistry, deps: TronChainC
   );
   const token = new TronTokenService(deps.gateways, deps.tokens);
   const message = new MessageService(deps.signers);
+  const typedData = new TypedDataService(deps.signers);
   const transaction = new TronTransactionService(deps.gateways, deps.tokens, deps.transactions);
   const stake = new TronStakeService(deps.gateways, deps.transactions);
   const vote = new TronVoteService(deps.gateways, deps.transactions, stake);
@@ -122,7 +127,9 @@ export function registerTronChainCommands(reg: CommandRegistry, deps: TronChainC
   reg.addChain(tokenListSpec, "tron", tokenListTronBinding(token));
   reg.addChain(tokenRemoveSpec, "tron", tokenRemoveTronBinding(token));
   reg.addChain(messageSignSpec, "tron", messageSignBinding(message));
+  reg.addChain(typedDataSignSpec, "tron", typedDataSignBinding(typedData));
   reg.addChain(txSendSpec, "tron", txSendTronBinding(transaction));
+  reg.addChain(txSignSpec, "tron", txSignTronBinding(transaction));
   reg.addChain(txBroadcastSpec, "tron", txBroadcastTronBinding(transaction));
   reg.addChain(txStatusSpec, "tron", txStatusTronBinding(transaction));
   reg.addChain(txInfoSpec, "tron", txInfoTronBinding(transaction));

--- a/ts/src/bootstrap/runner.test.ts
+++ b/ts/src/bootstrap/runner.test.ts
@@ -30,19 +30,27 @@ describe("parseGlobals", () => {
     expect(globals.output).toBe("json");
   });
 
-  it("drops an invalid --timeout to undefined (falls back to config) instead of NaN", () => {
-    expect(parseGlobals(["--timeout", "abc"]).globals.timeoutMs).toBeUndefined();
-    expect(parseGlobals(["--timeout", "-5"]).globals.timeoutMs).toBeUndefined();
-    expect(parseGlobals(["--timeout", "0"]).globals.timeoutMs).toBeUndefined(); // 0ms = instant-abort, not a usable bound
-    expect(parseGlobals(["--timeout", "2000"]).globals.timeoutMs).toBe(2000);
+  it("rejects an invalid --timeout as invalid (never falls back to the default)", () => {
+    for (const raw of ["abc", "-5", "0"]) { // 0ms = instant-abort, not a usable bound
+      const { globals, invalid } = parseGlobals(["--timeout", raw]);
+      expect(globals.timeoutMs).toBeUndefined();
+      expect(invalid).toEqual([{ flag: "--timeout", value: raw, reason: "must be a number >= 1" }]);
+    }
+    const ok = parseGlobals(["--timeout", "2000"]);
+    expect(ok.globals.timeoutMs).toBe(2000);
+    expect(ok.invalid).toEqual([]);
   });
 
   it("accepts --wait-timeout 0 (poll cap of 0 = give up after one poll)", () => {
-    expect(parseGlobals(["--wait-timeout", "0"]).globals.waitTimeoutMs).toBe(0);
+    const { globals, invalid } = parseGlobals(["--wait-timeout", "0"]);
+    expect(globals.waitTimeoutMs).toBe(0);
+    expect(invalid).toEqual([]);
   });
 
-  it("leaves an invalid --output undefined (yargs choices reports it) rather than silently 'text'", () => {
-    expect(parseGlobals(["--output", "xml"]).globals.output).toBeUndefined();
+  it("rejects an invalid --output instead of silently defaulting to 'text'", () => {
+    const bad = parseGlobals(["--output", "xml"]);
+    expect(bad.globals.output).toBeUndefined();
+    expect(bad.invalid).toEqual([{ flag: "--output", value: "xml", reason: "must be one of: text, json" }]);
     expect(parseGlobals(["--output", "json"]).globals.output).toBe("json");
   });
 

--- a/ts/src/bootstrap/runner.ts
+++ b/ts/src/bootstrap/runner.ts
@@ -1,6 +1,6 @@
 import { hideBin } from "yargs/helpers";
 import type { ExitCode } from "../domain/types/index.js";
-import { normalizeError } from "../domain/errors/index.js";
+import { normalizeError, UsageError } from "../domain/errors/index.js";
 import { HelpService, hasMeta } from "../adapters/inbound/cli/help/index.js";
 import { buildCli } from "../adapters/inbound/cli/shell/index.js";
 import { hasCommand, parseGlobals } from "./argv.js";
@@ -12,13 +12,20 @@ export const VERSION = "0.1.1";
 export async function main(argv: string[]): Promise<ExitCode> {
   const startedAt = Date.now();
   const tokens = hideBin(argv);
-  const { globals, secretPaths } = parseGlobals(tokens);
+  const { globals, secretPaths, invalid } = parseGlobals(tokens);
   const runtime = composeCliRuntime({ globals, secretPaths, startedAt });
 
   try {
     if (hasMeta(tokens) || !hasCommand(tokens)) {
       const help = new HelpService(runtime.registry, runtime.streams, VERSION);
       return help.handleMeta(hasMeta(tokens) ? tokens : ["--help"]);
+    }
+
+    // A supplied global flag with an out-of-range/invalid value is a usage error — never a silent
+    // fall-back to the default. Reported before any command dispatch, so no RPC is attempted.
+    if (invalid.length > 0) {
+      const bad = invalid[0]!;
+      throw new UsageError("invalid_value", `invalid ${bad.flag} value "${bad.value}": ${bad.reason}`);
     }
 
     const cli = buildCli({

--- a/ts/src/domain/typed-data/index.test.ts
+++ b/ts/src/domain/typed-data/index.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { normalizeTypedData } from "./index.js";
+
+const DOMAIN = { name: "SunPerp", version: "1", chainId: 728126428 };
+const TYPES = { Order: [{ name: "trader", type: "address" }, { name: "size", type: "uint256" }] };
+
+describe("normalizeTypedData", () => {
+  it("keeps a well-formed payload intact", () => {
+    const p = normalizeTypedData({ domain: DOMAIN, types: TYPES, message: { trader: "T1", size: "1" } });
+    expect(p).toEqual({ domain: DOMAIN, types: TYPES, message: { trader: "T1", size: "1" } });
+  });
+
+  // MetaMask-style payloads include EIP712Domain in `types`; ethers' TypedDataEncoder throws on it.
+  it("strips EIP712Domain from types", () => {
+    const p = normalizeTypedData({
+      domain: DOMAIN,
+      types: { EIP712Domain: [{ name: "name", type: "string" }], ...TYPES },
+      primaryType: "Order",
+      message: { trader: "T1", size: "1" },
+    });
+    expect(p.types).toEqual(TYPES);
+    expect(p.primaryType).toBe("Order");
+  });
+
+  it("accepts `value` as an alias for `message`", () => {
+    const p = normalizeTypedData({ domain: DOMAIN, types: TYPES, value: { trader: "T1", size: "1" } });
+    expect(p.message).toEqual({ trader: "T1", size: "1" });
+  });
+
+  it("rejects a payload whose types contain only EIP712Domain", () => {
+    expect(() => normalizeTypedData({ domain: DOMAIN, types: { EIP712Domain: [] }, message: {} }))
+      .toThrow(/at least one struct type/);
+  });
+
+  it("rejects a missing message", () => {
+    expect(() => normalizeTypedData({ domain: DOMAIN, types: TYPES })).toThrow(/message/);
+  });
+
+  it("rejects a non-object domain", () => {
+    expect(() => normalizeTypedData({ domain: "x", types: TYPES, message: {} })).toThrow(/domain/);
+  });
+
+  it("rejects a primaryType that is not declared", () => {
+    expect(() => normalizeTypedData({ domain: DOMAIN, types: TYPES, primaryType: "Nope", message: {} }))
+      .toThrow(/not declared in types/);
+  });
+
+  it("rejects a malformed field list", () => {
+    expect(() => normalizeTypedData({ domain: DOMAIN, types: { Order: [{ name: "x" }] }, message: {} }))
+      .toThrow(/without a name\/type/);
+  });
+});

--- a/ts/src/domain/typed-data/index.test.ts
+++ b/ts/src/domain/typed-data/index.test.ts
@@ -45,6 +45,37 @@ describe("normalizeTypedData", () => {
       .toThrow(/not declared in types/);
   });
 
+  // A nested (non-root) type is referenced by another struct, so it can never be what actually gets
+  // signed — ethers signs the root regardless. Reject it rather than sign one thing and report another.
+  const NESTED = {
+    Outer: [{ name: "who", type: "address" }, { name: "detail", type: "Inner" }],
+    Inner: [{ name: "amount", type: "uint256" }],
+  };
+
+  it("rejects a primaryType that is nested inside another type (not a root)", () => {
+    expect(() => normalizeTypedData({ domain: DOMAIN, types: NESTED, primaryType: "Inner", message: {} }))
+      .toThrow(/not a root type/);
+  });
+
+  it("rejects a nested primaryType referenced through an array field", () => {
+    const arrayNested = {
+      Outer: [{ name: "items", type: "Inner[]" }],
+      Inner: [{ name: "amount", type: "uint256" }],
+    };
+    expect(() => normalizeTypedData({ domain: DOMAIN, types: arrayNested, primaryType: "Inner", message: {} }))
+      .toThrow(/not a root type/);
+  });
+
+  it("accepts a primaryType that is the root type", () => {
+    const p = normalizeTypedData({ domain: DOMAIN, types: NESTED, primaryType: "Outer", message: { who: "T1", detail: { amount: "1" } } });
+    expect(p.primaryType).toBe("Outer");
+  });
+
+  it("accepts an omitted primaryType even with nested types", () => {
+    const p = normalizeTypedData({ domain: DOMAIN, types: NESTED, message: { who: "T1", detail: { amount: "1" } } });
+    expect(p.primaryType).toBeUndefined();
+  });
+
   it("rejects a malformed field list", () => {
     expect(() => normalizeTypedData({ domain: DOMAIN, types: { Order: [{ name: "x" }] }, message: {} }))
       .toThrow(/without a name\/type/);

--- a/ts/src/domain/typed-data/index.ts
+++ b/ts/src/domain/typed-data/index.ts
@@ -1,0 +1,64 @@
+/**
+ * TypedDataPayload — the EIP-712 / TIP-712 value object and its normalization rules.
+ * Pure: no hashing, no signing, no I/O. Hashing is family-specific and lives in the outbound
+ * adapters (tronweb for TRON); this module only decides what a well-formed payload is.
+ */
+import { UsageError } from "../errors/index.js";
+
+export interface TypedDataField {
+  name: string;
+  type: string;
+}
+
+export interface TypedDataPayload {
+  domain: Record<string, unknown>;
+  types: Record<string, TypedDataField[]>;
+  /** inferred from `types` when the caller omits it. */
+  primaryType?: string;
+  message: Record<string, unknown>;
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/**
+ * Validate and canonicalize a caller-supplied typed-data payload.
+ * - `EIP712Domain` is dropped from `types`: it describes `domain`, it is not a struct to hash,
+ *   and ethers' TypedDataEncoder (which tronweb reuses) throws when it is present.
+ * - `value` is accepted as an alias for `message`; some producers emit that spelling.
+ */
+export function normalizeTypedData(raw: unknown): TypedDataPayload {
+  if (!isObject(raw)) throw new UsageError("invalid_value", "typed data must be a JSON object");
+  const { domain, types, primaryType } = raw;
+  if (!isObject(domain)) throw new UsageError("invalid_value", "typed data `domain` must be an object");
+  if (!isObject(types)) throw new UsageError("invalid_value", "typed data `types` must be an object");
+
+  const message = raw.message ?? raw.value;
+  if (!isObject(message)) throw new UsageError("invalid_value", "typed data `message` must be an object");
+
+  const structs: Record<string, TypedDataField[]> = {};
+  for (const [name, fields] of Object.entries(types)) {
+    if (name === "EIP712Domain") continue;
+    if (!Array.isArray(fields)) {
+      throw new UsageError("invalid_value", `typed data type \`${name}\` must be an array of fields`);
+    }
+    for (const f of fields) {
+      if (!isObject(f) || typeof f.name !== "string" || typeof f.type !== "string") {
+        throw new UsageError("invalid_value", `typed data type \`${name}\` has a field without a name/type`);
+      }
+    }
+    structs[name] = fields as TypedDataField[];
+  }
+  if (Object.keys(structs).length === 0) {
+    throw new UsageError("invalid_value", "typed data `types` must declare at least one struct type besides EIP712Domain");
+  }
+  if (primaryType !== undefined && typeof primaryType !== "string") {
+    throw new UsageError("invalid_value", "typed data `primaryType` must be a string");
+  }
+  if (typeof primaryType === "string" && !(primaryType in structs)) {
+    throw new UsageError("invalid_value", `typed data \`primaryType\` "${primaryType}" is not declared in types`);
+  }
+
+  return { domain, types: structs, ...(primaryType === undefined ? {} : { primaryType }), message };
+}

--- a/ts/src/domain/typed-data/index.ts
+++ b/ts/src/domain/typed-data/index.ts
@@ -22,6 +22,16 @@ function isObject(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null && !Array.isArray(v);
 }
 
+/** Whether `name` appears as a field type (bare or as an array element) of any struct in `types`. */
+function isReferencedType(types: Record<string, TypedDataField[]>, name: string): boolean {
+  for (const fields of Object.values(types)) {
+    for (const f of fields) {
+      if (f.type.replace(/(\[\d*\])+$/, "") === name) return true;
+    }
+  }
+  return false;
+}
+
 /**
  * Validate and canonicalize a caller-supplied typed-data payload.
  * - `EIP712Domain` is dropped from `types`: it describes `domain`, it is not a struct to hash,
@@ -58,6 +68,12 @@ export function normalizeTypedData(raw: unknown): TypedDataPayload {
   }
   if (typeof primaryType === "string" && !(primaryType in structs)) {
     throw new UsageError("invalid_value", `typed data \`primaryType\` "${primaryType}" is not declared in types`);
+  }
+  // The signed message is always the root struct — the one no other struct references. A supplied
+  // primaryType that IS referenced (directly or through an array field) is nested, so it can never be
+  // what gets signed; reject it rather than sign the root while echoing the caller's nested type.
+  if (typeof primaryType === "string" && isReferencedType(structs, primaryType)) {
+    throw new UsageError("invalid_value", `typed data \`primaryType\` "${primaryType}" is not a root type; it is referenced as a field type, so it cannot be the message root`);
   }
 
   return { domain, types: structs, ...(primaryType === undefined ? {} : { primaryType }), message };

--- a/ts/src/domain/types/index.ts
+++ b/ts/src/domain/types/index.ts
@@ -20,6 +20,7 @@
  * ChainFamily (type + value enum) lives with the family registry and is re-exported here.
  */
 export type { ChainFamily } from "../family/index.js";
+export type { TypedDataField, TypedDataPayload } from "../typed-data/index.js";
 
 export * from "./network.js";
 export * from "./wallet.js";

--- a/ts/src/domain/types/tx.ts
+++ b/ts/src/domain/types/tx.ts
@@ -2,12 +2,23 @@
  * SharedTypes — crypto / signing / tx / rpc (implementations live in upper layers)
  * plus the per-command typed text outputs the text formatter narrows on.
  */
+import type { TypedDataPayload } from "../typed-data/index.js";
+
 export type Bytes = Uint8Array;
 export type KeyPair = { privateKey: Bytes; publicKey: Bytes };
 
 export type UnsignedTx = unknown;
 export type SignedTx = unknown;
 export type FeeReport = Record<string, unknown>;
+
+/** result of signing structured data (EIP-712 / TIP-712). `digest` is the hash that was signed;
+ *  `primaryType` is echoed back (inferred when the caller omitted it) so a caller can assert what
+ *  was signed without re-deriving it. */
+export interface TypedDataSignature {
+  signature: string;
+  digest: string;
+  primaryType: string;
+}
 
 export interface BroadcastResult {
   txId?: string;
@@ -21,7 +32,8 @@ export type BroadcastStage = "submitted" | "confirmed" | "failed";
 
 export type TxOutcome =
   | { stage: "plan"; tx: UnsignedTx; fee: FeeReport }
-  | { stage: "signed"; signed: SignedTx; fee: FeeReport }
+  // `fee` is absent when the caller supplied the transaction (tx sign): nothing was estimated.
+  | { stage: "signed"; signed: SignedTx; fee?: FeeReport; address?: string; txId?: string }
   | ({ stage: BroadcastStage } & BroadcastResult);
 
 // ════════════════════ per-command typed text outputs ══════════════════════
@@ -52,7 +64,7 @@ export interface TxParties { from?: string; to?: string; amount?: string; symbol
 /** which action a broadcast receipt describes — drives the summary verb + extra rows.
  *  A typed discriminant replaces matching on the stringly command id. */
 export type TxReceiptKind =
-  | "send" | "broadcast"
+  | "send" | "broadcast" | "sign"
   | "stake-freeze" | "stake-unfreeze" | "stake-delegate" | "stake-undelegate" | "stake-withdraw" | "stake-cancel"
   | "contract-send" | "contract-deploy"
   | "vote-cast" | "reward-withdraw";
@@ -70,6 +82,8 @@ export interface TxReceiptView {
   txId?: string;
   hash?: string;
   // plan / sign-only
+  /** address that produced the signature (sign-only outcomes). */
+  address?: string;
   fee?: FeeReport;
   tx?: UnsignedTx;
   signed?: SignedTx;
@@ -122,6 +136,9 @@ export interface Signer {
   sign(tx: UnsignedTx, opts: SignerSignOpts): Promise<SignedTx>;
   /** raw message signing (not via TxPipeline). */
   signMessage(message: string, opts: SignerSignOpts): Promise<string>;
+  /** structured-data signing (EIP-712 / TIP-712); hashing is family-specific and lives behind the
+   *  strategy (software) or the device port (Ledger). */
+  signTypedData(payload: TypedDataPayload, opts: SignerSignOpts): Promise<TypedDataSignature>;
 }
 
 /** per-family signing behaviour; SoftwareSigner delegates to this (no `if family`).
@@ -129,4 +146,5 @@ export interface Signer {
 export interface SignStrategy {
   sign(pkHex: string, tx: UnsignedTx): Promise<SignedTx>;
   signMessage(pkHex: string, message: string): Promise<string>;
+  signTypedData(pkHex: string, payload: TypedDataPayload): Promise<TypedDataSignature>;
 }


### PR DESCRIPTION
Two standalone signing commands so the CLI can sign payloads built elsewhere:

- `tx sign` — sign a transaction constructed outside the CLI, output the signed result for later `tx broadcast`. Pure signer (no owner/contract policy) but enforces payload integrity: txID must be sha256(raw_data_hex), and raw_data must re-encode to those bytes where the contract type is decodable. Verified end-to-end on Nile (confirmed on-chain) and offline.
- `typed-data sign` — EIP-712/TIP-712 in a new top-level `typed-data` group. Byte-for-byte identical output to the agent-wallet SDK for the same key and payload. Verified on a Ledger via Speculos (real TRON app 0.7.6).

Both support software and Ledger accounts. Integrity checking lives in a shared tron/tx-integrity module enforced by both the software strategy and the Ledger adapter, so a hardware account is never the weaker signer. Device signing preliminaries (precheck, awaiting_device, abort-on-timeout) are extracted into obtainSignature and reused by every signing path; the abort signal now actually closes the transport.

Also in this change:
- Map Ledger app-setting APDU errors (0x6a8b/c/d) to actionable messages instead of an opaque UNKNOWN_ERROR.
- Remove the network "required" value: it resolved identically to "optional" (default-network fallback), so it only produced a false help line.
- Fix the Requires help block to state whether a command prompts, and print full signatures in sign-only text receipts instead of a truncated txID.
- Speed up the test suite ~13x by mocking scrypt in keystore-heavy specs (production crypto untouched; crypto.test.ts still uses real scrypt).